### PR TITLE
Add sync-wave ordering and health checks for CFK components

### DIFF
--- a/adrs/0002-cfk-component-sync-wave-ordering.md
+++ b/adrs/0002-cfk-component-sync-wave-ordering.md
@@ -1,0 +1,97 @@
+# 2. CFK Component Sync-Wave Ordering
+
+Date: 2026-02-14
+
+## Status
+
+Accepted
+
+## Context
+
+The Confluent Platform deployment via the `confluent-resources` ArgoCD Application (sync-wave 110) deploys all CFK component manifests simultaneously. ArgoCD submits all resources at once, meaning components with unsatisfied dependencies (e.g., Kafka before KRaftController is ready) are created and must wait/retry until their dependencies become available.
+
+The CFK component dependency chain is:
+
+```
+KRaftController → Kafka → SchemaRegistry → ControlCenter
+                       ↘ Connect       ↗
+```
+
+This causes two problems:
+
+1. **Unnecessary retry loops**: Components that cannot start yet still get created and repeatedly fail/retry, wasting resources and producing noisy logs.
+2. **Non-deterministic startup**: Without explicit ordering, startup timing depends on Kubernetes scheduling, which can vary between deployments.
+
+### Alternatives Considered
+
+1. **Separate ArgoCD Applications per component**: Split `confluent-resources` into individual Applications (e.g., `kraft-controller`, `kafka-broker`, etc.) with inter-application sync-wave ordering.
+   - Pros: Full isolation, independent sync policies per component
+   - Cons: Significant increase in Application count and management overhead; the components are logically a single deployment unit
+
+2. **CFK operator dependency handling only**: Rely solely on CFK's built-in dependency management (the operator waits for dependencies before starting components).
+   - Pros: No ArgoCD configuration needed
+   - Cons: Resources are still created simultaneously; the operator must handle all retry logic; ArgoCD cannot report accurate health status for individual resources
+
+3. **ArgoCD sync-wave annotations within the single Application**: Add `argocd.argoproj.io/sync-wave` annotations to individual resource manifests within the existing `confluent-resources` Application.
+   - Pros: Minimal configuration change; ArgoCD handles ordering natively; resources are only created when dependencies are healthy; no increase in Application count
+   - Cons: Requires custom health checks for ArgoCD to evaluate CFK resource health
+
+## Decision
+
+We will use **ArgoCD sync-wave annotations within the existing `confluent-resources` Application** (Alternative 3) combined with **custom Lua health checks** in the ArgoCD ConfigMap.
+
+### Sync-Wave Assignment
+
+| Wave | Resource | CFK Kind | Rationale |
+|------|----------|----------|-----------|
+| `"0"` | kraft-controller.yaml | KRaftController | No dependencies, must start first |
+| `"10"` | kafka-broker.yaml | Kafka | Depends on KRaftController |
+| `"10"` | kafkarestclass.yaml | KafkaRestClass | Configuration resource, deploy with Kafka |
+| `"20"` | schema-registry.yaml | SchemaRegistry | Depends on Kafka |
+| `"20"` | connect.yaml | Connect | Depends on Kafka |
+| `"30"` | control-center.yaml | ControlCenter | Depends on Kafka, SchemaRegistry, Connect |
+| `"30"` | kafkatopic.yaml | KafkaTopic | Depends on Kafka + KafkaRestClass |
+
+### Custom Health Checks
+
+ArgoCD defaults to `Progressing` status for unknown CRDs, which would prevent sync waves from advancing. Custom Lua health check scripts are added to the `argocd-cm` ConfigMap for 5 CFK resource types:
+
+- `platform.confluent.io_KRaftController`
+- `platform.confluent.io_Kafka`
+- `platform.confluent.io_SchemaRegistry`
+- `platform.confluent.io_Connect`
+- `platform.confluent.io_ControlCenter`
+
+Each health check evaluates `obj.status.state`:
+- `nil` → `Progressing` (resource just created)
+- `"RUNNING"` → `Healthy`
+- Any other value → `Progressing` (still starting up)
+
+## Consequences
+
+### Positive
+
+- **Ordered startup**: Components deploy in dependency order, eliminating unnecessary retry loops
+- **Accurate health reporting**: ArgoCD UI shows meaningful health status for each CFK resource
+- **Minimal change**: Reuses the existing single-Application pattern; only adds annotations and health checks
+- **Faster overall deployment**: Components don't waste time creating resources that will fail to start
+
+### Negative
+
+- **Health check maintenance**: Custom Lua scripts must be maintained if CFK changes its `status.state` semantics
+- **ArgoCD dependency**: The ordering relies on ArgoCD sync-wave behavior; deploying manifests outside ArgoCD would not enforce ordering
+
+### Risks
+
+- **CFK status field changes**: If future CFK versions change the `status.state` field name or values, health checks will need updating
+  - Mitigation: Pin CFK operator version; update health checks as part of CFK upgrade process
+- **Sync timeout**: If a component fails to reach `RUNNING` state, ArgoCD will wait at that wave indefinitely
+  - Mitigation: ArgoCD's default sync timeout and retry policies handle this; operators can check ArgoCD UI for blocked waves
+
+## References
+
+- [ArgoCD Sync Waves Documentation](https://argo-cd.readthedocs.io/en/stable/user-guide/sync-waves/)
+- [ArgoCD Custom Health Checks](https://argo-cd.readthedocs.io/en/stable/operator-manual/health/)
+- [Confluent for Kubernetes Documentation](https://docs.confluent.io/operator/current/overview.html)
+- [GitHub Issue #3](https://github.com/osowski/confluent-platform-gitops/issues/3)
+- [Architecture Documentation](../docs/architecture.md)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **CFK component sync-wave ordering for optimal startup time** ([#3](https://github.com/osowski/confluent-platform-gitops/issues/3))
+  - Added ArgoCD sync-wave annotations to CFK resource manifests in `workloads/confluent-resources/base/`
+  - Dependency chain: KRaftController (wave 0) → Kafka (wave 10) → SchemaRegistry/Connect (wave 20) → ControlCenter/KafkaTopic (wave 30)
+  - Added custom Lua health checks for 5 CFK resource types (KRaftController, Kafka, SchemaRegistry, Connect, ControlCenter) to `argocd-cm` ConfigMap
+  - Health checks evaluate `status.state == "RUNNING"` to gate sync-wave progression
+  - Eliminates unnecessary retry loops by ensuring components start in correct dependency order
+  - ADR-0002 documents the architectural decision
+
 ## [0.2.0] - 2026-02-14
 
 ### Added

--- a/docs/confluent-platform.md
+++ b/docs/confluent-platform.md
@@ -6,6 +6,19 @@ This homelab deployment uses Confluent Platform managed by the Confluent for Kub
 
 ## Architecture
 
+### Component Startup Ordering
+
+CFK components are deployed within the `confluent-resources` application using ArgoCD sync-wave annotations to enforce the correct dependency chain:
+
+```
+KRaftController (wave 0) → Kafka (wave 10) → SchemaRegistry (wave 20) → ControlCenter (wave 30)
+                                            → Connect (wave 20)       ↗
+```
+
+ArgoCD deploys each wave sequentially and waits for resources to report `status.state == "RUNNING"` (via custom Lua health checks in `argocd-cm`) before advancing to the next wave. This eliminates unnecessary retry loops and ensures components start in optimal order.
+
+For the full sync-wave table and architectural decision, see [Architecture - Intra-Application Sync Waves](./architecture.md#intra-application-sync-waves-confluent-resources).
+
 ### Components
 
 1. **cfk-operator** (wave 105)

--- a/infrastructure/argocd-config/base/argocd-cm-patch.yaml
+++ b/infrastructure/argocd-config/base/argocd-cm-patch.yaml
@@ -11,3 +11,78 @@ data:
     hs = {}
     hs.status = "Healthy"
     return hs
+  resource.customizations.health.platform.confluent.io_KRaftController: |
+    hs = {}
+    if obj.status ~= nil and obj.status.state ~= nil then
+      if obj.status.state == "RUNNING" then
+        hs.status = "Healthy"
+        hs.message = "KRaftController is running"
+      else
+        hs.status = "Progressing"
+        hs.message = "KRaftController state: " .. obj.status.state
+      end
+    else
+      hs.status = "Progressing"
+      hs.message = "Waiting for KRaftController status"
+    end
+    return hs
+  resource.customizations.health.platform.confluent.io_Kafka: |
+    hs = {}
+    if obj.status ~= nil and obj.status.state ~= nil then
+      if obj.status.state == "RUNNING" then
+        hs.status = "Healthy"
+        hs.message = "Kafka is running"
+      else
+        hs.status = "Progressing"
+        hs.message = "Kafka state: " .. obj.status.state
+      end
+    else
+      hs.status = "Progressing"
+      hs.message = "Waiting for Kafka status"
+    end
+    return hs
+  resource.customizations.health.platform.confluent.io_SchemaRegistry: |
+    hs = {}
+    if obj.status ~= nil and obj.status.state ~= nil then
+      if obj.status.state == "RUNNING" then
+        hs.status = "Healthy"
+        hs.message = "SchemaRegistry is running"
+      else
+        hs.status = "Progressing"
+        hs.message = "SchemaRegistry state: " .. obj.status.state
+      end
+    else
+      hs.status = "Progressing"
+      hs.message = "Waiting for SchemaRegistry status"
+    end
+    return hs
+  resource.customizations.health.platform.confluent.io_Connect: |
+    hs = {}
+    if obj.status ~= nil and obj.status.state ~= nil then
+      if obj.status.state == "RUNNING" then
+        hs.status = "Healthy"
+        hs.message = "Connect is running"
+      else
+        hs.status = "Progressing"
+        hs.message = "Connect state: " .. obj.status.state
+      end
+    else
+      hs.status = "Progressing"
+      hs.message = "Waiting for Connect status"
+    end
+    return hs
+  resource.customizations.health.platform.confluent.io_ControlCenter: |
+    hs = {}
+    if obj.status ~= nil and obj.status.state ~= nil then
+      if obj.status.state == "RUNNING" then
+        hs.status = "Healthy"
+        hs.message = "ControlCenter is running"
+      else
+        hs.status = "Progressing"
+        hs.message = "ControlCenter state: " .. obj.status.state
+      end
+    else
+      hs.status = "Progressing"
+      hs.message = "Waiting for ControlCenter status"
+    end
+    return hs

--- a/workloads/confluent-resources/base/connect.yaml
+++ b/workloads/confluent-resources/base/connect.yaml
@@ -3,6 +3,8 @@ kind: Connect
 metadata:
   name: connect
   namespace: kafka
+  annotations:
+    argocd.argoproj.io/sync-wave: "20"
 spec:
   replicas: 1
   image:

--- a/workloads/confluent-resources/base/control-center.yaml
+++ b/workloads/confluent-resources/base/control-center.yaml
@@ -3,6 +3,8 @@ kind: ControlCenter
 metadata:
   name: controlcenter
   namespace: kafka
+  annotations:
+    argocd.argoproj.io/sync-wave: "30"
 spec:
   replicas: 1
   image:

--- a/workloads/confluent-resources/base/kafka-broker.yaml
+++ b/workloads/confluent-resources/base/kafka-broker.yaml
@@ -3,6 +3,8 @@ kind: Kafka
 metadata:
   name: kafka
   namespace: kafka
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
 spec:
   replicas: 3
   image:

--- a/workloads/confluent-resources/base/kafkarestclass.yaml
+++ b/workloads/confluent-resources/base/kafkarestclass.yaml
@@ -3,5 +3,7 @@ kind: KafkaRestClass
 metadata:
   name: default
   namespace: kafka
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
 spec:
   kafkaRest: {}

--- a/workloads/confluent-resources/base/kafkatopic.yaml
+++ b/workloads/confluent-resources/base/kafkatopic.yaml
@@ -3,6 +3,8 @@ kind: KafkaTopic
 metadata:
   name: autoscale-demo
   namespace: kafka
+  annotations:
+    argocd.argoproj.io/sync-wave: "30"
 spec:
   replicas: 3
   partitionCount: 9

--- a/workloads/confluent-resources/base/kraft-controller.yaml
+++ b/workloads/confluent-resources/base/kraft-controller.yaml
@@ -3,6 +3,8 @@ kind: KRaftController
 metadata:
   name: kraftcontroller
   namespace: kafka
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   replicas: 3
   image:

--- a/workloads/confluent-resources/base/kustomization.yaml
+++ b/workloads/confluent-resources/base/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - connect.yaml
   - control-center.yaml
   - kafka-broker.yaml
+  - kafkarestclass.yaml
   - kraft-controller.yaml
   # - ksqldb.yaml ## DISABLE ksqldb UNTIL IT IS NECESSARY
   - schema-registry.yaml

--- a/workloads/confluent-resources/base/schema-registry.yaml
+++ b/workloads/confluent-resources/base/schema-registry.yaml
@@ -3,6 +3,8 @@ kind: SchemaRegistry
 metadata:
   name: schemaregistry
   namespace: kafka
+  annotations:
+    argocd.argoproj.io/sync-wave: "20"
 spec:
   replicas: 1
   image:


### PR DESCRIPTION
## Summary
- Add ArgoCD sync-wave annotations to CFK resource manifests to enforce correct startup dependency chain: KRaftController (wave 0) → Kafka (wave 10) → SchemaRegistry/Connect (wave 20) → ControlCenter/KafkaTopic (wave 30)
- Add custom Lua health checks for 5 CFK resource types (KRaftController, Kafka, SchemaRegistry, Connect, ControlCenter) to `argocd-cm` ConfigMap, evaluating `status.state == "RUNNING"` to gate sync-wave progression
- Add `kafkarestclass.yaml` to the confluent-resources kustomization resources
- Create ADR-0002 documenting the architectural decision

Closes [#3](https://github.com/osowski/confluent-platform-gitops/issues/3)

## Test plan
- [x] `kubectl kustomize workloads/confluent-resources/overlays/flink-demo/` — all sync-wave annotations present in rendered output
- [x] `kubectl kustomize infrastructure/argocd-config/overlays/flink-demo/` — all 5 health check Lua scripts rendered in ConfigMap
- [ ] Deploy to cluster and verify ArgoCD reports correct health status for CFK resources
- [ ] Verify resources deploy in wave order (KRaftController → Kafka → SR/Connect → C3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)