### PR TITLE
Fix stale homelab-argocd.git references in Application manifests

### DIFF
--- a/clusters/flink-demo/bootstrap.yaml
+++ b/clusters/flink-demo/bootstrap.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://github.com/osowski/homelab-argocd.git
+    repoURL: https://github.com/osowski/confluent-platform-gitops.git
     targetRevision: HEAD
     path: bootstrap
     helm:

--- a/clusters/flink-demo/infrastructure/argocd-config.yaml
+++ b/clusters/flink-demo/infrastructure/argocd-config.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   project: infrastructure
   source:
-    repoURL: https://github.com/osowski/homelab-argocd.git
+    repoURL: https://github.com/osowski/confluent-platform-gitops.git
     targetRevision: HEAD
     path: infrastructure/argocd-config/overlays/flink-demo
   destination:

--- a/clusters/flink-demo/infrastructure/argocd-ingress.yaml
+++ b/clusters/flink-demo/infrastructure/argocd-ingress.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   project: infrastructure
   source:
-    repoURL: https://github.com/osowski/homelab-argocd.git
+    repoURL: https://github.com/osowski/confluent-platform-gitops.git
     targetRevision: HEAD
     path: infrastructure/argocd-ingress/overlays/flink-demo
   destination:

--- a/clusters/flink-demo/infrastructure/cert-manager-resources.yaml
+++ b/clusters/flink-demo/infrastructure/cert-manager-resources.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   project: infrastructure
   source:
-    repoURL: https://github.com/osowski/homelab-argocd.git
+    repoURL: https://github.com/osowski/confluent-platform-gitops.git
     targetRevision: HEAD
     path: infrastructure/cert-manager-resources/overlays/flink-demo
   destination:

--- a/clusters/flink-demo/infrastructure/cert-manager.yaml
+++ b/clusters/flink-demo/infrastructure/cert-manager.yaml
@@ -19,7 +19,7 @@ spec:
       valueFiles:
         - $values/infrastructure/cert-manager/base/values.yaml
         - $values/infrastructure/cert-manager/overlays/flink-demo/values.yaml
-  - repoURL: https://github.com/osowski/homelab-argocd
+  - repoURL: https://github.com/osowski/confluent-platform-gitops
     targetRevision: HEAD
     ref: values
   destination:

--- a/clusters/flink-demo/infrastructure/kube-prometheus-stack-crds.yaml
+++ b/clusters/flink-demo/infrastructure/kube-prometheus-stack-crds.yaml
@@ -17,7 +17,7 @@ spec:
     helm:
       valueFiles:
         - $values/infrastructure/kube-prometheus-stack-crds/base/values.yaml
-  - repoURL: https://github.com/osowski/homelab-argocd
+  - repoURL: https://github.com/osowski/confluent-platform-gitops
     targetRevision: HEAD
     ref: values
   destination:

--- a/clusters/flink-demo/infrastructure/kube-prometheus-stack.yaml
+++ b/clusters/flink-demo/infrastructure/kube-prometheus-stack.yaml
@@ -18,7 +18,7 @@ spec:
       valueFiles:
         - $values/infrastructure/kube-prometheus-stack/base/values.yaml
         - $values/infrastructure/kube-prometheus-stack/overlays/flink-demo/values.yaml
-  - repoURL: https://github.com/osowski/homelab-argocd
+  - repoURL: https://github.com/osowski/confluent-platform-gitops
     targetRevision: HEAD
     ref: values
   destination:

--- a/clusters/flink-demo/infrastructure/traefik.yaml
+++ b/clusters/flink-demo/infrastructure/traefik.yaml
@@ -19,7 +19,7 @@ spec:
       valueFiles:
         - $values/infrastructure/traefik/base/values.yaml
         - $values/infrastructure/traefik/overlays/flink-demo/values.yaml
-  - repoURL: https://github.com/osowski/homelab-argocd
+  - repoURL: https://github.com/osowski/confluent-platform-gitops
     targetRevision: HEAD
     ref: values
   destination:

--- a/clusters/flink-demo/workloads/cmf-operator.yaml
+++ b/clusters/flink-demo/workloads/cmf-operator.yaml
@@ -17,7 +17,7 @@ spec:
         valueFiles:
           - $values/workloads/cmf-operator/base/values.yaml
           - $values/workloads/cmf-operator/overlays/flink-demo/values.yaml
-    - repoURL: https://github.com/osowski/homelab-argocd.git
+    - repoURL: https://github.com/osowski/confluent-platform-gitops.git
       targetRevision: HEAD
       ref: values
   destination:

--- a/clusters/flink-demo/workloads/confluent-resources.yaml
+++ b/clusters/flink-demo/workloads/confluent-resources.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   project: workloads
   source:
-    repoURL: https://github.com/osowski/homelab-argocd.git
+    repoURL: https://github.com/osowski/confluent-platform-gitops.git
     targetRevision: HEAD
     path: workloads/confluent-resources/overlays/flink-demo
   destination:

--- a/clusters/flink-demo/workloads/controlcenter-ingress.yaml
+++ b/clusters/flink-demo/workloads/controlcenter-ingress.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   project: workloads
   source:
-    repoURL: https://github.com/osowski/homelab-argocd.git
+    repoURL: https://github.com/osowski/confluent-platform-gitops.git
     targetRevision: HEAD
     path: workloads/controlcenter-ingress/overlays/flink-demo
   destination:

--- a/clusters/flink-demo/workloads/flink-kubernetes-operator.yaml
+++ b/clusters/flink-demo/workloads/flink-kubernetes-operator.yaml
@@ -17,7 +17,7 @@ spec:
         valueFiles:
           - $values/workloads/flink-kubernetes-operator/base/values.yaml
           - $values/workloads/flink-kubernetes-operator/overlays/flink-demo/values.yaml
-    - repoURL: https://github.com/osowski/homelab-argocd.git
+    - repoURL: https://github.com/osowski/confluent-platform-gitops.git
       targetRevision: HEAD
       ref: values
   destination:

--- a/clusters/flink-demo/workloads/flink-resources.yaml
+++ b/clusters/flink-demo/workloads/flink-resources.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   project: workloads
   source:
-    repoURL: https://github.com/osowski/homelab-argocd.git
+    repoURL: https://github.com/osowski/confluent-platform-gitops.git
     targetRevision: HEAD
     path: workloads/flink-resources/overlays/flink-demo
   destination:

--- a/clusters/flink-demo/workloads/namespaces.yaml
+++ b/clusters/flink-demo/workloads/namespaces.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   project: workloads
   source:
-    repoURL: https://github.com/osowski/homelab-argocd.git
+    repoURL: https://github.com/osowski/confluent-platform-gitops.git
     targetRevision: HEAD
     path: workloads/namespaces/base
   destination:


### PR DESCRIPTION
## Summary
- Update all 14 ArgoCD Application manifests in `clusters/flink-demo/` to reference `confluent-platform-gitops` instead of the old `homelab-argocd` repository
- Covers both URL variants: `homelab-argocd.git` (with suffix) and `homelab-argocd` (without suffix)
- These were missed during the original repository migration

Closes [#8](https://github.com/osowski/confluent-platform-gitops/issues/8)

## Files changed

**Infrastructure (8 files):**
- `bootstrap.yaml`, `argocd-config.yaml`, `argocd-ingress.yaml`, `cert-manager.yaml`, `cert-manager-resources.yaml`, `kube-prometheus-stack.yaml`, `kube-prometheus-stack-crds.yaml`, `traefik.yaml`

**Workloads (6 files):**
- `cfk-operator.yaml` (already correct — not changed), `cmf-operator.yaml`, `confluent-resources.yaml`, `controlcenter-ingress.yaml`, `flink-kubernetes-operator.yaml`, `flink-resources.yaml`, `namespaces.yaml`

## Test plan
- [x] `grep -r "homelab-argocd" clusters/` returns zero results
- [ ] Deploy to cluster and verify ArgoCD resolves all Application sources from the correct repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)