### PR TITLE
Add cert-manager trust-manager to infrastructure layer

### DIFF
--- a/clusters/flink-demo/infrastructure/kustomization.yaml
+++ b/clusters/flink-demo/infrastructure/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
 - argocd-ingress.yaml
 - cert-manager.yaml
 - cert-manager-resources.yaml
+- trust-manager.yaml
 - kube-prometheus-stack-crds.yaml
 - kube-prometheus-stack.yaml
 - traefik.yaml

--- a/clusters/flink-demo/infrastructure/trust-manager.yaml
+++ b/clusters/flink-demo/infrastructure/trust-manager.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: trust-manager
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "30"  # Deploy after cert-manager (wave 20)
+spec:
+  project: infrastructure
+  sources:
+  - repoURL: oci://quay.io/jetstack/charts/trust-manager
+    targetRevision: v0.20.3  # Pin to specific version
+    chart: trust-manager
+    helm:
+      ignoreMissingValueFiles: true
+      valueFiles:
+        - $values/infrastructure/trust-manager/base/values.yaml
+        - $values/infrastructure/trust-manager/overlays/flink-demo/values.yaml
+  - repoURL: https://github.com/osowski/confluent-platform-gitops
+    targetRevision: HEAD
+    ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: cert-manager
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=false  # cert-manager namespace already created by cert-manager app
+      - ServerSideApply=true  # Required for CRDs
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,6 +55,7 @@ Platform infrastructure components deployed before workloads.
 - **traefik** (wave 10) - Ingress controller for external access
 - **kube-prometheus-stack** (wave 20) - Monitoring stack with Prometheus, Grafana, Alertmanager
 - **cert-manager** (wave 20) - TLS certificate management
+- **trust-manager** (wave 30) - Automatic distribution of CA certificate trust bundles across namespaces
 - **cert-manager-resources** (wave 75) - Self-signed ClusterIssuer and certificate resources
 - **argocd-ingress** (wave 80) - Traefik IngressRoute for ArgoCD UI access
 - **argocd-config** (wave 85) - ArgoCD ConfigMap patches for custom health checks and configuration

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **trust-manager for CA certificate distribution** ([#16](https://github.com/osowski/confluent-platform-gitops/issues/16))
+  - Added cert-manager's trust-manager as infrastructure application (sync-wave 30)
+  - Enables automatic distribution of trust bundles (CA certificates) across cluster namespaces
+  - Deployed to cert-manager namespace alongside cert-manager
+  - Version v0.20.3 via OCI Helm chart from Jetstack (quay.io/jetstack/charts/trust-manager)
+  - Deployed after cert-manager (wave 20) to ensure CRDs are available
 - **CFK component sync-wave ordering for optimal startup time** ([#3](https://github.com/osowski/confluent-platform-gitops/issues/3))
   - Added ArgoCD sync-wave annotations to CFK resource manifests in `workloads/confluent-resources/base/`
   - Dependency chain: KRaftController (wave 0) → Kafka (wave 10) → SchemaRegistry/Connect (wave 20) → ControlCenter/KafkaTopic (wave 30)

--- a/infrastructure/trust-manager/base/values.yaml
+++ b/infrastructure/trust-manager/base/values.yaml
@@ -1,0 +1,3 @@
+# Base configuration for trust-manager
+crds:
+  enabled: true

--- a/infrastructure/trust-manager/overlays/flink-demo/values.yaml
+++ b/infrastructure/trust-manager/overlays/flink-demo/values.yaml
@@ -1,0 +1,2 @@
+# Overlay configuration for trust-manager on flink-demo cluster
+# No specific overrides needed for this cluster


### PR DESCRIPTION
## Summary
Adds cert-manager's trust-manager as a standalone infrastructure application to enable automatic distribution of CA certificate trust bundles across cluster namespaces.

## Changes
- Created infrastructure/trust-manager/ with base and flink-demo overlay
- Added ArgoCD Application manifest for trust-manager (sync-wave 30)
- Included trust-manager in flink-demo infrastructure kustomization
- Updated architecture.md and changelog.md

## Test Plan
- [x] Validated kustomization builds successfully
- [ ] Deploy to flink-demo cluster and verify trust-manager pod starts
- [ ] Verify sync wave ordering (deploys after cert-manager)

Resolves #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)