### PR TITLE
Inline shared checklist items from homelab-docs

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Inlined shared checklist from homelab-docs** ([#18](https://github.com/osowski/confluent-platform-gitops/issues/18))
+  - Copied all shared checklist items from homelab-docs code review checklist into this repo's `docs/code_review_checklist.md`
+  - Added sections: Secrets and Credentials, Input Validation, Authentication and Authorization, Network Security, Defensive Programming, Dependencies, Code Organization, Git and GitHub (Branch Naming, PR Description, Commits), Validation
+  - Merged overlapping items in Idempotency, Documentation, Testing, and Common Pitfalls sections
+  - Removed all external references to homelab-docs checklist — document is now fully self-contained
+
 ### Added
 - **trust-manager for CA certificate distribution** ([#16](https://github.com/osowski/confluent-platform-gitops/issues/16))
   - Added cert-manager's trust-manager as infrastructure application (sync-wave 30)

--- a/docs/code_review_checklist.md
+++ b/docs/code_review_checklist.md
@@ -1,42 +1,79 @@
 # Code Review Checklist
 
-This checklist contains ArgoCD/GitOps-specific checks for the confluent-platform-gitops repository. Review these items **before** creating a pull request.
-
-> **For shared security practices, code quality guidelines, Git workflow, and common development practices, see the [homelab-docs code review checklist](https://github.com/osowski/homelab-docs/blob/main/docs/guides/code-review-checklist.md).**
+This checklist contains all checks for the confluent-platform-gitops repository — including shared development practices and ArgoCD/GitOps-specific items. Review these items **before** creating a pull request.
 
 ## Security
 
+### Secrets and Credentials
+
+- [ ] No secrets, API keys, or tokens are hardcoded in any files
+- [ ] All secrets are managed via environment variables or external secret management
+- [ ] No `.env`, `.env.local`, or credential files are committed to version control
+- [ ] Temporary files containing secrets are securely deleted after use
+- [ ] File permissions on scripts containing secrets are restrictive (e.g., `chmod 600`)
+
 ### Repository Access
+
 - [ ] ArgoCD repository credentials are configured securely
 - [ ] No sensitive values are exposed in Helm values files or Kustomize overlays
 
+### Input Validation
+
+- [ ] All user input is validated and sanitized
+- [ ] Boundary conditions and edge cases are handled
+- [ ] Error messages do not expose sensitive information (stack traces, file paths, credentials)
+
+### Authentication and Authorization
+
+- [ ] Authentication mechanisms are secure (no hardcoded passwords, tokens managed externally)
+- [ ] Authorization checks are in place where needed
+- [ ] API keys and service account tokens are rotatable
+
+### Network Security
+
+- [ ] HTTPS/TLS is used for external communications
+- [ ] Certificate validation is not disabled
+- [ ] Firewall rules and network policies are reviewed
+
 ## Code Quality
 
+### Defensive Programming
+
+- [ ] Error handling is comprehensive and graceful
+- [ ] Edge cases are considered and handled (empty lists, null values, missing files)
+- [ ] Assumptions are validated (file exists, variable is set, service is running)
+- [ ] Timeouts are set for network operations and long-running tasks
+
 ### Manifest Validation
+
 - [ ] YAML syntax is valid for all modified manifests
 - [ ] Kustomize overlays build successfully: `kubectl kustomize overlays/<cluster>/`
 - [ ] Helm templates render correctly: `helm template <release> <chart> -f values.yaml`
 - [ ] ArgoCD Application manifests reference correct `repoURL`, `path`, and `targetRevision`
 
 ### Sync Wave Ordering
+
 - [ ] Sync wave annotations are set correctly for deployment ordering
 - [ ] Dependencies deploy before dependents (e.g., CRDs before resources, operator before CRs)
 - [ ] No circular dependencies between sync waves
 - [ ] Wave numbers follow established conventions (see [Architecture - Sync Waves](architecture.md#sync-waves))
 
 ### Kustomize
+
 - [ ] `kustomization.yaml` lists all resources
 - [ ] Patches target the correct resources (group, version, kind, name)
 - [ ] Base manifests are cluster-agnostic; cluster-specific values are in overlays
 - [ ] Labels and annotations are applied consistently
 
 ### Helm
+
 - [ ] Multi-source pattern is used correctly (`$values` reference resolves)
 - [ ] Base values and cluster overlay values are properly separated
 - [ ] Chart version is pinned in Application manifest (`targetRevision`)
 - [ ] Namespace is specified and `CreateNamespace=true` is set if needed
 
 ### ArgoCD Applications
+
 - [ ] Application belongs to the correct ArgoCD Project (`infrastructure` or `workloads`)
 - [ ] `destination.namespace` is set correctly
 - [ ] Sync policy includes `automated`, `prune`, and `selfHeal` where appropriate
@@ -44,40 +81,91 @@ This checklist contains ArgoCD/GitOps-specific checks for the confluent-platform
 - [ ] Application is added to the cluster's `kustomization.yaml`
 
 ### Idempotency
+
 - [ ] Manifests can be applied multiple times without errors
 - [ ] Resources use declarative configuration (no imperative operations)
 - [ ] Kustomize patches are idempotent
+- [ ] State is checked before making changes (e.g., "create if not exists" pattern)
+- [ ] Cleanup operations handle already-cleaned resources gracefully
+
+### Dependencies
+
+- [ ] External dependencies are minimized where practical
+- [ ] New dependencies are discussed and approved before adding
+- [ ] Dependencies are pinned to specific versions or version ranges
+- [ ] Dependency updates are tested before merging
+
+### Code Organization
+
+- [ ] Code follows established project patterns and conventions
+- [ ] Complex logic is broken into smaller, focused functions/modules
+- [ ] Magic numbers and strings are replaced with named constants
+- [ ] Code is self-documenting; comments explain "why" not "what"
 
 ## Documentation
 
 ### Required Documentation Updates
-When implementing features, update these files in `/docs`:
+
+When implementing features, update relevant documentation:
 
 - [ ] **`docs/architecture.md`** - If changing system design, adding components, or modifying sync waves
 - [ ] **`docs/changelog.md`** - Always update with new features, fixes, and changes
 - [ ] **`README.md`** - If adding new prerequisites, clusters, or applications
+- [ ] **Configuration examples** - If adding new configuration options
 
 ### Architecture Decision Records
+
 - [ ] Create ADR in `/adrs/` for architectural decisions that impact future development
-- [ ] ADRs follow the format from [homelab-docs ADR template](https://github.com/osowski/homelab-docs/blob/main/adrs/0000-template.md)
+- [ ] ADRs follow the standard ADR format (see [adr.github.io](https://adr.github.io/))
 - [ ] ADRs are referenced in relevant documentation files
 
-> **For Git workflow, branch naming, PR descriptions, and commit guidelines, see the [homelab-docs code review checklist](https://github.com/osowski/homelab-docs/blob/main/docs/guides/code-review-checklist.md#git-and-github).**
+## Git and GitHub
+
+### Branch Naming
+
+- [ ] Branch follows format: `feature-<issue-id>/<description>` or `fix-<issue-id>/<description>`
+- [ ] Branch is associated with a GitHub Issue
+- [ ] Branch is NOT directly on `main`
+
+### Pull Request Description
+
+- [ ] Description accurately reflects implementation (not just a plan)
+- [ ] Description explains **what** changed and **why**
+- [ ] Includes explicit markdown link to GitHub Issue in the format: `[#123](https://github.com/owner/repo/issues/123)`
+- [ ] Not just "Closes #123" or "Resolves #123" — use proper markdown link with issue number visible
+
+### Commits
+
+- [ ] Commit messages clearly state intent and outcome
+- [ ] Commits are focused on single logical changes
+- [ ] No bleeding of multiple unrelated changes into one commit
 
 ## Testing and Verification
 
 ### Before Creating PR
+
+- [ ] Changes have been tested locally or in a dev environment
 - [ ] Validate Kustomize builds for all affected clusters: `kubectl kustomize <path>/overlays/<cluster>/`
 - [ ] Validate Helm templates render without errors: `helm template <release> <chart> -f <values>`
 - [ ] Check YAML syntax for all modified files
 - [ ] Verify ArgoCD Application manifests are valid
 - [ ] Review sync wave ordering for new or modified applications
+- [ ] Regression testing performed (existing functionality still works)
 
 ### Edge Cases
+
 - [ ] Test with minimal and maximal configurations
 - [ ] Verify namespace creation for new applications
 - [ ] Ensure resource limits and requests are specified
 - [ ] Check that ingress hostnames follow naming conventions: `<service>.<cluster>.<domain>`
+- [ ] Edge cases and error conditions have been tested
+
+### Validation
+
+- [ ] Configuration files are syntactically valid
+- [ ] Scripts execute without errors in the target environment
+- [ ] Dependencies are available and versions are compatible
+- [ ] Documentation examples are tested and work as written
 
 ## Common Pitfalls (from Past Reviews)
 
@@ -93,3 +181,9 @@ These specific issues have been caught in previous code reviews:
 8. **Missing `ServerSideApply=true`** - Required for applications that manage CRDs to avoid field ownership conflicts
 9. **Hardcoded cluster values in base** - Base manifests should use placeholders or be cluster-agnostic; cluster-specific values belong in overlays
 10. **MicroK8s ingress controller is Traefik, not NGINX** - Since MicroK8s v1.28+, the default ingress controller is Traefik (service: `traefik` in namespace `ingress`), not NGINX
+11. **Hardcoded secrets** - API keys, tokens, passwords committed to Git (use environment variables or external secret management)
+12. **Missing GitHub Issue link** - PR doesn't include explicit markdown link to issue: `[#123](https://github.com/owner/repo/issues/123)`
+13. **No ADR for architectural decisions** - Significant design choices made without documenting rationale
+14. **Assumptions not validated** - Code assumes files exist, services are running, or variables are set without checking
+15. **No idempotency** - Re-running operations causes errors or duplicate resources
+16. **External dependencies added without discussion** - New libraries or tools added without considering long-term maintenance burden


### PR DESCRIPTION
## Summary

- Copied all shared checklist items from the homelab-docs code review checklist into this repo's `docs/code_review_checklist.md`, making it fully self-contained
- The homelab-docs repository is not planned to be made public, so external consumers of this repository could not access the referenced items
- Merged overlapping items (Idempotency, Documentation, Testing, Common Pitfalls) to avoid duplication

**New sections added:**
- Security: Secrets and Credentials, Input Validation, Authentication and Authorization, Network Security
- Code Quality: Defensive Programming, Dependencies, Code Organization
- Git and GitHub: Branch Naming, Pull Request Description, Commits
- Testing: Validation subsection

**Removed:**
- All external references/links to homelab-docs code review checklist
- Replaced homelab-docs ADR template link with [adr.github.io](https://adr.github.io/)

Closes [#18](https://github.com/osowski/confluent-platform-gitops/issues/18)

## Test plan

- [ ] Verify all items from homelab-docs checklist are present in the merged document
- [ ] Confirm no duplicate checklist items exist
- [ ] Confirm no remaining links to homelab-docs checklist in the file
- [ ] Review document reads cohesively as a single self-contained checklist

🤖 Generated with [Claude Code](https://claude.com/claude-code)