### PR TITLE
Fix traefik service type to NodePort in flink-demo overlay

### DIFF
--- a/infrastructure/traefik/overlays/flink-demo/values.yaml
+++ b/infrastructure/traefik/overlays/flink-demo/values.yaml
@@ -1,7 +1,7 @@
 deployment:
   kind: DaemonSet
 service:
-  type: LoadBalancer
+  type: NodePort
 nodeSelector: ~
 tolerations:
   - key: node-role.kubernetes.io/control-plane


### PR DESCRIPTION
## Summary
Fixes the traefik Application stuck in Progressing state by changing the service type from LoadBalancer to NodePort in the flink-demo overlay.

## Problem
The traefik Application showed a misleading "Progressing" health status even though Traefik was fully functional. This was caused by the flink-demo overlay overriding the service type to LoadBalancer, which doesn't work in KIND clusters without a load balancer provider like MetalLB.

## Changes
- Changed `service.type` from `LoadBalancer` to `NodePort` in `infrastructure/traefik/overlays/flink-demo/values.yaml`
- This aligns the overlay with the base configuration, which correctly specifies NodePort for KIND clusters

## Impact
- ArgoCD will now report traefik as Healthy instead of Progressing
- No functional change - Traefik continues to work via NodePorts (30000, 30001)
- Fixes potential sync wave blocking issues

## Test Plan
- [x] Validated change aligns with base configuration
- [ ] Verify ArgoCD Application changes to Healthy status after sync
- [ ] Confirm Traefik Service updates to NodePort type
- [ ] Verify existing IngressRoutes continue to work

Resolves #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)