### PR TITLE
Fix CFK health checks to use phase instead of state field

### DIFF
--- a/infrastructure/argocd-config/base/argocd-cm-patch.yaml
+++ b/infrastructure/argocd-config/base/argocd-cm-patch.yaml
@@ -13,13 +13,13 @@ data:
     return hs
   resource.customizations.health.platform.confluent.io_KRaftController: |
     hs = {}
-    if obj.status ~= nil and obj.status.state ~= nil then
-      if obj.status.state == "RUNNING" then
+    if obj.status ~= nil and obj.status.phase ~= nil then
+      if obj.status.phase == "RUNNING" then
         hs.status = "Healthy"
         hs.message = "KRaftController is running"
       else
         hs.status = "Progressing"
-        hs.message = "KRaftController state: " .. obj.status.state
+        hs.message = "KRaftController phase: " .. obj.status.phase
       end
     else
       hs.status = "Progressing"
@@ -28,13 +28,13 @@ data:
     return hs
   resource.customizations.health.platform.confluent.io_Kafka: |
     hs = {}
-    if obj.status ~= nil and obj.status.state ~= nil then
-      if obj.status.state == "RUNNING" then
+    if obj.status ~= nil and obj.status.phase ~= nil then
+      if obj.status.phase == "RUNNING" then
         hs.status = "Healthy"
         hs.message = "Kafka is running"
       else
         hs.status = "Progressing"
-        hs.message = "Kafka state: " .. obj.status.state
+        hs.message = "Kafka phase: " .. obj.status.phase
       end
     else
       hs.status = "Progressing"
@@ -43,13 +43,13 @@ data:
     return hs
   resource.customizations.health.platform.confluent.io_SchemaRegistry: |
     hs = {}
-    if obj.status ~= nil and obj.status.state ~= nil then
-      if obj.status.state == "RUNNING" then
+    if obj.status ~= nil and obj.status.phase ~= nil then
+      if obj.status.phase == "RUNNING" then
         hs.status = "Healthy"
         hs.message = "SchemaRegistry is running"
       else
         hs.status = "Progressing"
-        hs.message = "SchemaRegistry state: " .. obj.status.state
+        hs.message = "SchemaRegistry phase: " .. obj.status.phase
       end
     else
       hs.status = "Progressing"
@@ -58,13 +58,13 @@ data:
     return hs
   resource.customizations.health.platform.confluent.io_Connect: |
     hs = {}
-    if obj.status ~= nil and obj.status.state ~= nil then
-      if obj.status.state == "RUNNING" then
+    if obj.status ~= nil and obj.status.phase ~= nil then
+      if obj.status.phase == "RUNNING" then
         hs.status = "Healthy"
         hs.message = "Connect is running"
       else
         hs.status = "Progressing"
-        hs.message = "Connect state: " .. obj.status.state
+        hs.message = "Connect phase: " .. obj.status.phase
       end
     else
       hs.status = "Progressing"
@@ -73,13 +73,13 @@ data:
     return hs
   resource.customizations.health.platform.confluent.io_ControlCenter: |
     hs = {}
-    if obj.status ~= nil and obj.status.state ~= nil then
-      if obj.status.state == "RUNNING" then
+    if obj.status ~= nil and obj.status.phase ~= nil then
+      if obj.status.phase == "RUNNING" then
         hs.status = "Healthy"
         hs.message = "ControlCenter is running"
       else
         hs.status = "Progressing"
-        hs.message = "ControlCenter state: " .. obj.status.state
+        hs.message = "ControlCenter phase: " .. obj.status.phase
       end
     else
       hs.status = "Progressing"


### PR DESCRIPTION
## Summary
Fixes all Confluent Platform resource health checks in ArgoCD to use the correct status field name, enabling proper health reporting and unblocking sync wave progression.

## Problem
All CFK resources (KRaftController, Kafka, SchemaRegistry, Connect, ControlCenter) were reporting as "Progressing" in ArgoCD even when they were healthy and running. This was blocking sync wave progression since ArgoCD waits for resources to become healthy before proceeding to the next wave.

## Root Cause
The custom health checks in `argocd-cm-patch.yaml` were checking `obj.status.state`, but CFK resources use `obj.status.phase` for their status field.

**Incorrect**:
```lua
if obj.status.state == "RUNNING" then
```

**Correct**:
```lua
if obj.status.phase == "RUNNING" then
```

## Changes
Updated all 5 CFK resource health checks to use `obj.status.phase`:
- ✅ KRaftController
- ✅ Kafka
- ✅ SchemaRegistry
- ✅ Connect
- ✅ ControlCenter

## Impact
- KRaftController (and other CFK resources) will now correctly report as Healthy
- Sync wave progression unblocked - Kafka (wave 10) can deploy after KRaftController (wave 0)
- Accurate health status in ArgoCD UI

## Test Plan
- [x] Verified field name in actual KRaftController resource (status.phase exists)
- [ ] Deploy to cluster and verify KRaftController shows Healthy
- [ ] Verify sync wave progression proceeds to Kafka and downstream resources
- [ ] Confirm all CFK resources report correct health status

Resolves #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)