### PR TITLE
feat(monitoring): add PodMonitor for CFK components

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **PodMonitor for CFK components in confluent-resources** ([#37](https://github.com/osowski/confluent-platform-gitops/issues/37))
+  - Added `PodMonitor` resource to enable Prometheus metrics scraping from all Confluent for Kubernetes (CFK) managed components
+  - Single `PodMonitor` covers Kafka, KRaft Controller, Schema Registry, Connect, and Control Center via `confluent-platform` label selector
+  - Configured `jobLabel: platform.confluent.io/type` to set per-component Prometheus job labels (e.g., `job="kafka"`, `job="schemaregistry"`), aligning with [confluentinc/jmx-monitoring-stacks](https://github.com/confluentinc/jmx-monitoring-stacks) Grafana dashboard conventions
+  - Metrics exposed on port 7778 via Prometheus JMX Exporter
+  - Updated `docs/confluent-platform.md` with PodMonitor configuration details, verification steps, and Grafana dashboard integration guidance
+
 ### Fixed
 - **Flink ServiceMonitor job label alignment with jmx-monitoring-stacks dashboards** ([#36](https://github.com/osowski/confluent-platform-gitops/issues/36))
   - Removed `jobLabel: type` from the Flink `ServiceMonitor`; Prometheus was assigning `job="flink-native-kubernetes"` which did not match the `job="flink"` selector hardcoded in upstream Flink Grafana dashboards

--- a/workloads/confluent-resources/base/kustomization.yaml
+++ b/workloads/confluent-resources/base/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - kafkarestclass.yaml
   - kraft-controller.yaml
   # - ksqldb.yaml ## DISABLE ksqldb UNTIL IT IS NECESSARY
+  - podmonitor-cfk.yaml
   - schema-registry.yaml
 
 commonLabels:

--- a/workloads/confluent-resources/base/podmonitor-cfk.yaml
+++ b/workloads/confluent-resources/base/podmonitor-cfk.yaml
@@ -1,0 +1,27 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  labels:
+    release: prometheus
+    monitoring: confluent
+  name: confluent-platform
+  namespace: kafka
+  annotations:
+    argocd.argoproj.io/sync-wave: "30"
+spec:
+  jobLabel: platform.confluent.io/type
+  podTargetLabels:
+    - app
+    - clusterId
+    - confluent-platform
+    - platform.confluent.io/type
+    - type
+  podMetricsEndpoints:
+    - port: prometheus
+      interval: 60s
+      scheme: http
+      scrapeTimeout: 30s
+  selector:
+    matchExpressions:
+      - key: confluent-platform
+        operator: Exists


### PR DESCRIPTION
## Summary

Add `PodMonitor` resource to enable Prometheus metrics scraping from all Confluent for Kubernetes (CFK) managed components.

## Changes

- **New File**: `workloads/confluent-resources/base/podmonitor-cfk.yaml`
  - PodMonitor named `confluent-platform` in `kafka` namespace
  - Uses `confluent-platform` label selector to match all CFK pods
  - Configured with `jobLabel: platform.confluent.io/type` for per-component Prometheus job labels (e.g., `job="kafka"`, `job="schemaregistry"`)
  - Scrapes metrics from port `prometheus` (7778) every 60 seconds
  - Sync wave 30 to deploy after CFK components

- **Updated**: `workloads/confluent-resources/base/kustomization.yaml`
  - Added `podmonitor-cfk.yaml` to resources list

- **Updated**: `docs/confluent-platform.md`
  - Expanded Prometheus Integration section with PodMonitor configuration details
  - Added verification steps for checking metrics in Prometheus
  - Added Grafana dashboard integration guidance
  - Included sample PromQL queries for Kafka, Schema Registry, and Controller metrics

- **Updated**: `docs/changelog.md`
  - Added entry under `[Unreleased] > Added`

## Component Coverage

Single `PodMonitor` covers all CFK components:
- ✅ Kafka Broker
- ✅ KRaft Controller
- ✅ Schema Registry
- ✅ Connect
- ✅ Control Center

## Alignment with jmx-monitoring-stacks

This implementation follows the upstream reference from [confluentinc/jmx-monitoring-stacks](https://github.com/confluentinc/jmx-monitoring-stacks/blob/main/jmxexporter-prometheus-grafana/cfk/pm-confluent.yaml), ensuring compatibility with the CFK Grafana dashboards provided in that repository.

## Testing

After deployment, verify metrics collection:
```bash
# Port-forward to Prometheus
kubectl port-forward -n monitoring svc/kube-prometheus-stack-prometheus 9090:9090

# Check targets at: http://localhost:9090/targets
# Look for job labels: kafka, kraftcontroller, schemaregistry, connect, controlcenter
```

Resolves #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)