### PR TITLE
fix: add missing parameters to cmf-compute-pool-init job

### DIFF
--- a/workloads/cp-flink-sql-sandbox/base/cmf-compute-pool-job.yaml
+++ b/workloads/cp-flink-sql-sandbox/base/cmf-compute-pool-job.yaml
@@ -55,7 +55,7 @@ spec:
 
           ##TODO Convert this to FlinkEnvironment CR in the future
           echo "Creating Flink environment env1..."
-          confluent flink environment create env1 --url ${CMF_URL} || echo "Environment may already exist"
+          confluent flink environment create env1 --kubernetes-namespace flink --url ${CMF_URL} || echo "Environment may already exist"
 
           echo "Creating Flink compute pool..."
           confluent flink compute-pool create /config/compute-pool.json --environment env1 --url ${CMF_URL} || echo "Compute pool may already exist"

--- a/workloads/cp-flink-sql-sandbox/base/cmf-config-configmap.yaml
+++ b/workloads/cp-flink-sql-sandbox/base/cmf-config-configmap.yaml
@@ -54,6 +54,7 @@ data:
         "name": "pool"
       },
       "spec": {
+        "type": "DEDICATED",
         "flinkVersion": "1.19",
         "image": "confluentinc/cp-flink-sql:1.19-cp5",
         "maxCfu": 100,


### PR DESCRIPTION
## Summary
Fixes #61 - Resolves `cmf-compute-pool-init` Job CrashLoopBackOff failures by adding missing required parameters.

## Changes
- ✅ Added `--kubernetes-namespace flink` flag to `confluent flink environment create` command
- ✅ Added `"type": "DEDICATED"` field to compute pool configuration spec

## Problem
The `cmf-compute-pool-init` Job was failing with two errors:
1. **Missing kubernetes-namespace flag**: The `confluent flink environment create` command requires `--kubernetes-namespace` but it wasn't provided
2. **Missing compute pool type**: The compute pool JSON configuration was missing the required `type` field

## Solution
Both issues have been fixed by:
1. Adding the required `--kubernetes-namespace flink` flag to match the target namespace
2. Adding `"type": "DEDICATED"` to the compute pool spec, aligning with the upstream [cp-flink-sql repository](https://github.com/rjmfernandes/cp-flink-sql) structure

## Testing
- ✅ Kustomize build validates successfully
- ✅ Changes align with upstream cp-flink-sql repository patterns
- Ready for ArgoCD sync and validation in cluster

## Files Changed
- `workloads/cp-flink-sql-sandbox/base/cmf-compute-pool-job.yaml`
- `workloads/cp-flink-sql-sandbox/base/cmf-config-configmap.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)