### PR TITLE
Update Confluent Platform and Flink to latest versions

### DIFF
--- a/clusters/flink-demo/workloads/cmf-operator.yaml
+++ b/clusters/flink-demo/workloads/cmf-operator.yaml
@@ -12,7 +12,7 @@ spec:
   sources:
     - repoURL: https://packages.confluent.io/helm
       chart: confluent-manager-for-apache-flink
-      targetRevision: 2.1.0
+      targetRevision: 2.2.0
       helm:
         valueFiles:
           - $values/workloads/cmf-operator/base/values.yaml

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Updated Confluent Platform and Flink components to latest versions** ([#63](https://github.com/osowski/confluent-platform-gitops/issues/63))
+  - Confluent Manager for Apache Flink (CMF): 2.1.0 → 2.2.0
+  - Confluent Platform images: 8.1.0 → 8.2.0
+  - Confluent init container: 3.1.0 → 3.1.1
+  - Control Center next-gen: 2.2.0 → 2.4.0
+  - Prometheus/AlertManager enterprise: 2.2.0 → 2.4.0
+  - Flink image: 1.19.1-cp1 → 1.20.3-cp1
+  - Confluent CLI: latest → 4.53.0 (pinned version)
+  - Updated documentation references in `docs/confluent-flink.md`
+
 ### Added
 - **CP Flink SQL Sandbox application for flink-demo cluster** ([#57](https://github.com/osowski/confluent-platform-gitops/issues/57))
   - New `cp-flink-sql-sandbox` application enables running [cp-flink-sql demo](https://github.com/rjmfernandes/cp-flink-sql) out of the box

--- a/docs/confluent-flink.md
+++ b/docs/confluent-flink.md
@@ -12,14 +12,14 @@ The Flink deployment consists of three ArgoCD Applications:
 
 1. **flink-kubernetes-operator** (sync-wave 116)
    - Manages Flink deployments and jobs on Kubernetes
-   - Helm chart: `confluentinc/flink-kubernetes-operator` v1.130.0
+   - Helm chart: `confluentinc/flink-kubernetes-operator` v1.130.2
    - Resources: 2 CPU, 3 GB RAM
    - Namespace: `confluent`
 
 2. **cmf-operator** (sync-wave 118)
    - Confluent Manager for Apache Flink (CMF)
    - Central management interface for Flink applications
-   - Helm chart: `confluentinc/confluent-manager-for-apache-flink` v2.1.0
+   - Helm chart: `confluentinc/confluent-manager-for-apache-flink` v2.2.0
    - Resources: 2 CPU, 1 GB RAM, 10 GB storage (PVC)
    - Database: SQLite with persistent volume
    - License: Trial license auto-generated
@@ -318,7 +318,7 @@ kubectl logs -n confluent <taskmanager-pod-name>
 1. Verify Kafka broker running: `kubectl get kafka -n confluent`
 2. Test connectivity:
    ```bash
-   kubectl run -it --rm kafka-test --image=confluentinc/cp-kafka:8.1.0 --restart=Never -- \
+   kubectl run -it --rm kafka-test --image=confluentinc/cp-kafka:8.2.0 --restart=Never -- \
      kafka-broker-api-versions --bootstrap-server kafka.confluent.svc.cluster.local:9092
    ```
 3. Check FlinkEnvironment Kafka configuration

--- a/templates/new-cluster/workloads/cmf-operator.yaml.template
+++ b/templates/new-cluster/workloads/cmf-operator.yaml.template
@@ -12,7 +12,7 @@ spec:
   sources:
     - repoURL: https://packages.confluent.io/helm
       chart: confluent-manager-for-apache-flink
-      targetRevision: 2.1.0
+      targetRevision: 2.2.0
       helm:
         valueFiles:
           - $values/workloads/cmf-operator/base/values.yaml

--- a/workloads/confluent-resources/base/connect.yaml
+++ b/workloads/confluent-resources/base/connect.yaml
@@ -8,8 +8,8 @@ metadata:
 spec:
   replicas: 1
   image:
-    application: confluentinc/cp-server-connect:8.1.0
-    init: confluentinc/confluent-init-container:3.1.0
+    application: confluentinc/cp-server-connect:8.2.0
+    init: confluentinc/confluent-init-container:3.1.1
   dependencies:
     kafka:
       bootstrapEndpoint: kafka:9071

--- a/workloads/confluent-resources/base/control-center.yaml
+++ b/workloads/confluent-resources/base/control-center.yaml
@@ -8,8 +8,8 @@ metadata:
 spec:
   replicas: 1
   image:
-    application: confluentinc/cp-enterprise-control-center-next-gen:2.2.0
-    init: confluentinc/confluent-init-container:3.1.0
+    application: confluentinc/cp-enterprise-control-center-next-gen:2.4.0
+    init: confluentinc/confluent-init-container:3.1.1
   configOverrides:
     server:
       - confluent.controlcenter.ksql.enable=false
@@ -34,8 +34,8 @@ spec:
       url: http://controlcenter.kafka.svc.cluster.local:9093
   services:
     prometheus:
-      image: confluentinc/cp-enterprise-prometheus:2.2.0
+      image: confluentinc/cp-enterprise-prometheus:2.4.0
       pvc:
         dataVolumeCapacity: 10Gi
     alertmanager:
-      image: confluentinc/cp-enterprise-alertmanager:2.2.0
+      image: confluentinc/cp-enterprise-alertmanager:2.4.0

--- a/workloads/confluent-resources/base/kafka-broker.yaml
+++ b/workloads/confluent-resources/base/kafka-broker.yaml
@@ -8,8 +8,8 @@ metadata:
 spec:
   replicas: 3
   image:
-    application: confluentinc/cp-server:8.1.0
-    init: confluentinc/confluent-init-container:3.1.0
+    application: confluentinc/cp-server:8.2.0
+    init: confluentinc/confluent-init-container:3.1.1
   dataVolumeCapacity: 100Gi
   dependencies:
     kRaftController:

--- a/workloads/confluent-resources/base/kraft-controller.yaml
+++ b/workloads/confluent-resources/base/kraft-controller.yaml
@@ -8,8 +8,8 @@ metadata:
 spec:
   replicas: 3
   image:
-    application: docker.io/confluentinc/cp-server:8.1.0
-    init: confluentinc/confluent-init-container:3.1.0
+    application: docker.io/confluentinc/cp-server:8.2.0
+    init: confluentinc/confluent-init-container:3.1.1
   dataVolumeCapacity: 10Gi
   dependencies:
     metricsClient:

--- a/workloads/confluent-resources/base/ksqldb.yaml
+++ b/workloads/confluent-resources/base/ksqldb.yaml
@@ -6,6 +6,6 @@ metadata:
 spec:
   replicas: 1
   image:
-    application: confluentinc/cp-ksqldb-server:8.1.0
-    init: confluentinc/confluent-init-container:3.1.0
+    application: confluentinc/cp-ksqldb-server:8.2.0
+    init: confluentinc/confluent-init-container:3.1.1
   dataVolumeCapacity: 10Gi

--- a/workloads/confluent-resources/base/schema-registry.yaml
+++ b/workloads/confluent-resources/base/schema-registry.yaml
@@ -8,8 +8,8 @@ metadata:
 spec:
   replicas: 1
   image:
-    application: confluentinc/cp-schema-registry:8.1.0
-    init: confluentinc/confluent-init-container:3.1.0
+    application: confluentinc/cp-schema-registry:8.2.0
+    init: confluentinc/confluent-init-container:3.1.1
 
   # Dependencies - must wait for Kafka broker
   dependencies:

--- a/workloads/cp-flink-sql-sandbox/base/cmf-compute-pool-job.yaml
+++ b/workloads/cp-flink-sql-sandbox/base/cmf-compute-pool-job.yaml
@@ -40,7 +40,7 @@ spec:
           echo "s3proxy is ready!"
       containers:
       - name: create-compute-pool
-        image: confluentinc/confluent-cli:latest
+        image: confluentinc/confluent-cli:4.53.0
         env:
         - name: CMF_URL
           value: "http://cmf-service.operator.svc.cluster.local:80"

--- a/workloads/cp-flink-sql-sandbox/base/cmf-init-job.yaml
+++ b/workloads/cp-flink-sql-sandbox/base/cmf-init-job.yaml
@@ -41,7 +41,7 @@ spec:
           echo "Schema Registry is ready!"
       containers:
       - name: create-catalog-and-database
-        image: confluentinc/confluent-cli:latest
+        image: confluentinc/confluent-cli:4.53.0
         env:
         - name: CMF_URL
           value: "http://cmf-service.operator.svc.cluster.local:80"

--- a/workloads/flink-resources/base/flink-application.yaml
+++ b/workloads/flink-resources/base/flink-application.yaml
@@ -6,8 +6,8 @@ metadata:
   namespace: flink
 spec:
   flinkEnvironment: default-flink-env
-  image: confluentinc/cp-flink:1.19.1-cp1
-  flinkVersion: v1_19
+  image: confluentinc/cp-flink:1.20.3-cp1
+  flinkVersion: v1_20
   flinkConfiguration:
     "taskmanager.numberOfTaskSlots": "2"
     "metrics.reporter.prom.factory.class": "org.apache.flink.metrics.prometheus.PrometheusReporterFactory"


### PR DESCRIPTION
## Summary
Updates all Confluent Platform and Flink components to the latest stable releases available as of March 2026.

### Helm Charts
- CMF: 2.1.0 → 2.2.0
- CFK: 0.1351.59 (already current)
- FKO: 1.130.2 (already current)

### Container Images
- Confluent Platform: 8.1.0 → 8.2.0
- Init container: 3.1.0 → 3.1.1
- Control Center next-gen: 2.2.0 → 2.4.0
- Enterprise Prometheus: 2.2.0 → 2.4.0
- Enterprise AlertManager: 2.2.0 → 2.4.0
- Flink: 1.19.1-cp1 → 1.20.3-cp1 (includes flinkVersion v1_19 → v1_20)
- Confluent CLI: latest → 4.53.0 (pinned to specific version)

### Documentation
- Updated version references in docs/confluent-flink.md
- Added comprehensive changelog entry
- Updated template for new cluster scaffolding

## Files Changed
- **Helm Charts**: clusters/flink-demo/workloads/cmf-operator.yaml
- **Confluent Resources**: workloads/confluent-resources/base/*.yaml (6 files)
- **Flink Resources**: workloads/flink-resources/base/flink-application.yaml
- **Flink Jobs**: workloads/cp-flink-sql-sandbox/base/cmf-*.yaml (2 files)
- **Templates**: templates/new-cluster/workloads/cmf-operator.yaml.template
- **Documentation**: docs/changelog.md, docs/confluent-flink.md

## Test Plan
- [ ] Verify Kustomize builds successfully for all overlays
- [ ] Deploy to test environment
- [ ] Validate all CFK-managed components start successfully with new images
- [ ] Validate CMF operator deploys and operates with version 2.2.0
- [ ] Validate Flink applications deploy with new Flink 1.20.3-cp1 image
- [ ] Verify confluent-cli Jobs complete successfully with pinned version
- [ ] Check Control Center UI loads and displays all components
- [ ] Monitor for any breaking changes or compatibility issues

Resolves #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)