### PR TITLE
Fix kube-prometheus-stack resource configuration for subcharts

### DIFF
--- a/infrastructure/kube-prometheus-stack/base/values.yaml
+++ b/infrastructure/kube-prometheus-stack/base/values.yaml
@@ -147,11 +147,11 @@ prometheus:
     # Resource limits
     resources:
       requests:
-        cpu: 500m
-        memory: 1Gi
+        cpu: 1000m
+        memory: 1500Mi
       limits:
-        cpu: 2000m
-        memory: 2Gi
+        cpu: 1000m
+        memory: 1500Mi
 
     # Scrape configuration
     scrapeInterval: 30s
@@ -177,19 +177,23 @@ prometheus:
 nodeExporter:
   enabled: true
 
+# Node Exporter subchart configuration
+prometheus-node-exporter:
   # Resource limits
   resources:
     requests:
-      cpu: 50m
+      cpu: 100m
       memory: 64Mi
     limits:
-      cpu: 100m
+      cpu: 200m
       memory: 128Mi
 
 # Kube State Metrics configuration
 kubeStateMetrics:
   enabled: true
 
+# Kube State Metrics subchart configuration
+kube-state-metrics:
   # Resource limits
   resources:
     requests:


### PR DESCRIPTION
## Summary

Fixes resource requests and limits not being applied to `kube-state-metrics` and `prometheus-node-exporter` components due to incorrect Helm values structure. Also reduces Prometheus resource limits to improve cluster stability.

## Problem

The kube-prometheus-stack resources were configured under incorrect keys:
- `kubeStateMetrics.resources` instead of `kube-state-metrics.resources` (subchart)
- `nodeExporter.resources` instead of `prometheus-node-exporter.resources` (subchart)

This resulted in deployed pods having `resources: {}` despite values.yaml configuration.

## Changes

### Fixed Subchart Configurations
- **kube-state-metrics**: Added subchart config with 100m/64Mi requests, 200m/128Mi limits
- **prometheus-node-exporter**: Added subchart config with 100m/64Mi requests, 200m/128Mi limits

### Reduced Prometheus Resources
- Requests: 500m/1Gi → 1000m/1500Mi
- Limits: 2000m/2Gi → 1000m/1500Mi

## Test Plan

- [ ] Verify ArgoCD sync succeeds
- [ ] Confirm kube-state-metrics pod has resources applied: `kubectl get pod -n monitoring -l app.kubernetes.io/name=kube-state-metrics -o jsonpath='{.items[0].spec.containers[0].resources}'`
- [ ] Confirm node-exporter daemonset has resources applied: `kubectl get daemonset -n monitoring -l app.kubernetes.io/name=prometheus-node-exporter -o jsonpath='{.spec.template.spec.containers[0].resources}'`
- [ ] Confirm Prometheus resources updated: `kubectl get prometheus -n monitoring kube-prometheus-stack-prometheus -o jsonpath='{.spec.resources}'`
- [ ] Monitor cluster stability after deployment

## Related

Fixes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)