### PR TITLE
Fix Grafana crashloop by disabling init-chown-data

### DIFF
--- a/infrastructure/kube-prometheus-stack/base/values.yaml
+++ b/infrastructure/kube-prometheus-stack/base/values.yaml
@@ -62,6 +62,11 @@ grafana:
     type: pvc
     size: 5Gi
 
+  # Disable init-chown-data container (fixes issue #41)
+  # fsGroup in securityContext handles permissions automatically
+  initChownData:
+    enabled: false
+
   # Resource limits
   resources:
     requests:


### PR DESCRIPTION
## Summary

Fixes Grafana pod crashlooping due to `init-chown-data` init container failing with permission denied errors.

## Problem

The Grafana pod fails to start with the following error in the `init-chown-data` init container:

```
chown: /var/lib/grafana/png: Permission denied
chown: /var/lib/grafana/pdf: Permission denied
chown: /var/lib/grafana/csv: Permission denied
```

### Root Cause

The `init-chown-data` container runs as root and attempts to recursively change ownership of `/var/lib/grafana` to `472:472`. When pre-existing directories have mode `700` (no traverse permission for group/other), the recursive `chown -R` operation fails because the container cannot enter those directories.

This typically occurs when:
- Grafana was previously installed and created these directories
- The PVC was deleted and recreated but bound to the same PersistentVolume
- The old directory structure remains with restrictive permissions

## Solution

Disable the `init-chown-data` init container by setting `initChownData.enabled: false`.

This is safe because:
- The pod `securityContext` already sets `fsGroup: 472`
- Kubernetes automatically applies the correct group ownership to mounted volumes when `fsGroup` is set
- This makes the init container redundant

### Configuration Change

```yaml
grafana:
  initChownData:
    enabled: false
```

## Verification

After deployment:
- [ ] Confirm Grafana pod starts successfully without init-chown-data container
- [ ] Verify no permission errors in pod logs
- [ ] Test Grafana functionality (create dashboard, save settings)
- [ ] Confirm pod restarts cleanly

## Testing

Current state shows pod security context is properly configured:
```json
{
  "fsGroup": 472,
  "runAsGroup": 472,
  "runAsNonRoot": true,
  "runAsUser": 472
}
```

This configuration ensures Kubernetes handles permissions automatically.

## Related

Fixes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)