### PR TITLE
Consolidate and complete /etc/hosts documentation

### DIFF
--- a/clusters/flink-demo/README.md
+++ b/clusters/flink-demo/README.md
@@ -26,6 +26,45 @@ The `flink-demo` cluster demonstrates a complete Confluent Platform deployment i
 
 The sections below provide cluster-specific reference information and advanced configuration.
 
+<!--
+INTENTIONAL DUPLICATION: The /etc/hosts entries below are duplicated from
+docs/getting-started-for-the-uninitiated.md for quick reference. This is
+explicitly allowed as a one-off exception to avoid users jumping between files.
+Changes should be kept in sync with the canonical source.
+-->
+
+### DNS Configuration
+
+Add these entries to `/etc/hosts`:
+
+```
+127.0.0.1  alertmanager.flink-demo.confluentdemo.local
+127.0.0.1  argocd.flink-demo.confluentdemo.local
+127.0.0.1  cmf.flink-demo.confluentdemo.local
+127.0.0.1  controlcenter.flink-demo.confluentdemo.local
+127.0.0.1  grafana.flink-demo.confluentdemo.local
+127.0.0.1  kafka.flink-demo.confluentdemo.local
+127.0.0.1  prometheus.flink-demo.confluentdemo.local
+127.0.0.1  s3proxy.flink-demo.confluentdemo.local
+127.0.0.1  schemaregistry.flink-demo.confluentdemo.local
+127.0.0.1  vault.flink-demo.confluentdemo.local
+```
+
+> [!WARNING]
+> If you experience ~5-second timeouts when accessing services, add IPv6 entries as well:
+> ```
+> ::1  alertmanager.flink-demo.confluentdemo.local
+> ::1  argocd.flink-demo.confluentdemo.local
+> ::1  cmf.flink-demo.confluentdemo.local
+> ::1  controlcenter.flink-demo.confluentdemo.local
+> ::1  grafana.flink-demo.confluentdemo.local
+> ::1  kafka.flink-demo.confluentdemo.local
+> ::1  prometheus.flink-demo.confluentdemo.local
+> ::1  s3proxy.flink-demo.confluentdemo.local
+> ::1  schemaregistry.flink-demo.confluentdemo.local
+> ::1  vault.flink-demo.confluentdemo.local
+> ```
+
 ## Deploy Confluent and Flink Resources
 
 The `confluent-resources` and `flink-resources` Applications require manual sync to ensure operators and namespaces are fully ready.

--- a/docs/bootstrap-procedure.md
+++ b/docs/bootstrap-procedure.md
@@ -414,13 +414,12 @@ After successful bootstrap:
    ```bash
    # Get LoadBalancer IP
    kubectl get svc -n ingress traefik
-
-   # Update /etc/hosts with application FQDNs
-   # Test with curl
    ```
 
-   > [!WARNING]
-   > If you experience ~5-second timeouts when accessing services, you may need to add IPv6 entries to `/etc/hosts` as well. Some HTTP clients prefer IPv6 and will timeout trying `::1` before falling back to IPv4.
+   > [!TIP]
+   > **For local testing with kind (flink-demo cluster):** See [Getting Started - DNS Configuration](getting-started-for-the-uninitiated.md#dns-configuration) for complete `/etc/hosts` entries including IPv6 timeout workaround.
+   >
+   > **For production clusters:** Add DNS records matching the pattern `<service>.<cluster-name>.<domain>` pointing to your LoadBalancer IP.
 
 4. **Configure ArgoCD notifications** (optional):
    - Slack, email, or webhook notifications for sync events

--- a/docs/cluster-onboarding.md
+++ b/docs/cluster-onboarding.md
@@ -202,16 +202,33 @@ kubectl get svc -n ingress traefik -o jsonpath='{.status.loadBalancer.ingress[0]
 
 ### Update DNS
 
-Add DNS records for the cluster applications:
-- `*.{cluster-name}.confluentdemo.local` → LoadBalancer IP
+**For local testing (kind clusters):**
 
-Or update `/etc/hosts` for local testing:
+See [Getting Started - DNS Configuration](getting-started-for-the-uninitiated.md#dns-configuration) for the complete list of `/etc/hosts` entries for the `flink-demo` cluster, including IPv6 timeout workaround.
+
+For other local clusters, follow the same pattern using your cluster name:
 ```
-<LoadBalancer-IP>  echo.<cluster-name>.confluentdemo.local
+127.0.0.1  alertmanager.<cluster-name>.confluentdemo.local
+127.0.0.1  argocd.<cluster-name>.confluentdemo.local
+127.0.0.1  grafana.<cluster-name>.confluentdemo.local
+... (add entries for all your services)
 ```
 
-> [!WARNING]
-> If you experience ~5-second timeouts when accessing services, you may need to add IPv6 entries as well. Some HTTP clients prefer IPv6 and will timeout before falling back to IPv4. Add the corresponding `::1` entry to `/etc/hosts` if needed.
+**For production clusters:**
+
+Add DNS records pointing to your LoadBalancer IP:
+```bash
+# Get LoadBalancer IP
+LOADBALANCER_IP=$(kubectl get svc -n ingress traefik -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+
+# Add A records in your DNS provider for each service:
+# alertmanager.<cluster-name>.<domain> → $LOADBALANCER_IP
+# grafana.<cluster-name>.<domain> → $LOADBALANCER_IP
+# prometheus.<cluster-name>.<domain> → $LOADBALANCER_IP
+# ... (add records for all your services)
+```
+
+Or use wildcard DNS: `*.<cluster-name>.<domain>` → LoadBalancer IP
 
 ### Test Application
 

--- a/docs/getting-started-for-the-uninitiated.md
+++ b/docs/getting-started-for-the-uninitiated.md
@@ -22,8 +22,10 @@ brew install colima \
 127.0.0.1  cmf.flink-demo.confluentdemo.local
 127.0.0.1  controlcenter.flink-demo.confluentdemo.local
 127.0.0.1  grafana.flink-demo.confluentdemo.local
+127.0.0.1  kafka.flink-demo.confluentdemo.local
 127.0.0.1  prometheus.flink-demo.confluentdemo.local
 127.0.0.1  s3proxy.flink-demo.confluentdemo.local
+127.0.0.1  schemaregistry.flink-demo.confluentdemo.local
 127.0.0.1  vault.flink-demo.confluentdemo.local
 ```
 
@@ -35,8 +37,10 @@ brew install colima \
 > ::1  cmf.flink-demo.confluentdemo.local
 > ::1  controlcenter.flink-demo.confluentdemo.local
 > ::1  grafana.flink-demo.confluentdemo.local
+> ::1  kafka.flink-demo.confluentdemo.local
 > ::1  prometheus.flink-demo.confluentdemo.local
 > ::1  s3proxy.flink-demo.confluentdemo.local
+> ::1  schemaregistry.flink-demo.confluentdemo.local
 > ::1  vault.flink-demo.confluentdemo.local
 > ```
 


### PR DESCRIPTION
## Summary

Consolidates `/etc/hosts` documentation following CLAUDE.md Documentation Maintenance Principles. Establishes `docs/getting-started-for-the-uninitiated.md` as the single source of truth for `/etc/hosts` configuration, with cross-references from other documents to avoid duplication.

## Problem

Documentation for `/etc/hosts` configuration was duplicated across multiple files with inconsistencies:

1. **Missing hostnames**: `kafka` and `schemaregistry` not documented despite having ingress routes
2. **IPv6 warning duplicated** in 3 locations
3. **Incomplete documentation** in bootstrap-procedure and cluster-onboarding
4. **No quick reference** for flink-demo cluster users

## Changes

### 1. Completed canonical source: `docs/getting-started-for-the-uninitiated.md`
- ✅ Added missing `kafka.flink-demo.confluentdemo.local`
- ✅ Added missing `schemaregistry.flink-demo.confluentdemo.local`
- ✅ Updated both IPv4 and IPv6 sections
- ✅ Now documents **10 services** (was 8)

### 2. Added quick reference: `clusters/flink-demo/README.md`
- ✅ Added new "DNS Configuration" section
- ✅ Duplicates complete `/etc/hosts` list for immediate access
- ✅ Includes HTML comment explicitly marking this as allowed one-off duplication
- ✅ Prevents users from jumping between files

### 3. Cleaned up: `docs/bootstrap-procedure.md`
- ❌ Removed redundant IPv6 warning
- ❌ Removed incomplete `/etc/hosts` mention
- ✅ Added clear cross-reference to getting-started guide
- ✅ Separated local vs. production guidance

### 4. Enhanced: `docs/cluster-onboarding.md`
- ❌ Removed redundant IPv6 warning
- ❌ Removed incomplete generic template
- ✅ Added comprehensive local/production guidance
- ✅ Added cross-reference to getting-started guide
- ✅ Added specific examples for both scenarios

## Complete `/etc/hosts` List

**Now documented (10 services):**
```
127.0.0.1  alertmanager.flink-demo.confluentdemo.local
127.0.0.1  argocd.flink-demo.confluentdemo.local
127.0.0.1  cmf.flink-demo.confluentdemo.local
127.0.0.1  controlcenter.flink-demo.confluentdemo.local
127.0.0.1  grafana.flink-demo.confluentdemo.local
127.0.0.1  kafka.flink-demo.confluentdemo.local              ← NEW
127.0.0.1  prometheus.flink-demo.confluentdemo.local
127.0.0.1  s3proxy.flink-demo.confluentdemo.local
127.0.0.1  schemaregistry.flink-demo.confluentdemo.local     ← NEW
127.0.0.1  vault.flink-demo.confluentdemo.local
```

Plus corresponding IPv6 (::1) entries for timeout workaround.

## Documentation Structure (After)

```
docs/getting-started-for-the-uninitiated.md
    ↑ CANONICAL SOURCE - Complete list with IPv6 workaround
    
clusters/flink-demo/README.md
    ↑ QUICK REFERENCE - Explicitly allowed duplication
    
docs/bootstrap-procedure.md
docs/cluster-onboarding.md
    ↑ CROSS-REFERENCES - Link to canonical source
```

## One-Off Duplication Exception

The flink-demo README contains an **explicitly allowed duplication** marked with HTML comment:

```html
<!--
INTENTIONAL DUPLICATION: The /etc/hosts entries below are duplicated from
docs/getting-started-for-the-uninitiated.md for quick reference. This is
explicitly allowed as a one-off exception to avoid users jumping between files.
Changes should be kept in sync with the canonical source.
-->
```

This ensures future reviewers understand the duplication is intentional and prevents flagging in code reviews.

## Benefits

1. **Complete**: All services with ingress routes now documented
2. **Consistent**: Single source of truth established
3. **Convenient**: Quick reference in cluster README
4. **Maintainable**: HTML comment marks allowed duplication
5. **Clear guidance**: Distinct instructions for local vs. production

## Test Plan

- [ ] Verify getting-started guide lists all 10 services correctly
- [ ] Verify flink-demo README duplicates exactly match canonical source
- [ ] Verify cross-references in bootstrap-procedure and cluster-onboarding work
- [ ] Test local cluster access with updated /etc/hosts entries
- [ ] Confirm IPv6 timeout workaround guidance is accessible

## Related

Fixes #80

Follows CLAUDE.md "Documentation Maintenance Principles":
- ✅ Each piece of information lives in ONE authoritative location
- ✅ Use cross-references instead of duplicating content
- ✅ Clear document boundaries
- ✅ "Next Steps" sections provide navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)