### PR TITLE
Refactor confluent-resources to use base ksqldb configuration

### DIFF
--- a/workloads/confluent-resources/base/kustomization.yaml
+++ b/workloads/confluent-resources/base/kustomization.yaml
@@ -11,7 +11,7 @@ resources:
   - kafka-broker.yaml
   - kafkarestclass.yaml
   - kraft-controller.yaml
-  # - ksqldb.yaml ## DISABLE ksqldb UNTIL IT IS NECESSARY
+  - ksqldb.yaml
   - podmonitor-cfk.yaml
   - schema-registry.yaml
   - schema-registry-ingress.yaml

--- a/workloads/confluent-resources/overlays/flink-demo-rbac/kustomization.yaml
+++ b/workloads/confluent-resources/overlays/flink-demo-rbac/kustomization.yaml
@@ -38,13 +38,31 @@ patches:
       name: schema-registry
 
   # Connect - resources and JVM tuning
-  - path: connect-patch.yaml
-    target:
-      kind: Connect
-      name: connect
+  # - path: connect-patch.yaml
+  #   target:
+  #     kind: Connect
+  #     name: connect
 
   # ksqlDB - resources and JVM tuning
-  - path: ksqldb-patch.yaml
-    target:
+  # - path: ksqldb-patch.yaml
+  #   target:
+  #     kind: KsqlDB
+  #     name: ksqldb
+
+  # Explicitly delete Connect from this cluster overlay
+  - patch: |-
+      $patch: delete
+      apiVersion: platform.confluent.io/v1beta1
+      kind: Connect
+      metadata:
+        name: connect
+        namespace: kafka
+
+  # Explicitly delete ksqlDB from this cluster overlay
+  - patch: |-
+      $patch: delete
+      apiVersion: platform.confluent.io/v1beta1
       kind: KsqlDB
-      name: ksqldb
+      metadata:
+        name: ksqldb
+        namespace: kafka

--- a/workloads/confluent-resources/overlays/flink-demo/kustomization.yaml
+++ b/workloads/confluent-resources/overlays/flink-demo/kustomization.yaml
@@ -44,7 +44,16 @@ patches:
       name: connect
 
   # ksqlDB - resources and JVM tuning
-  - path: ksqldb-patch.yaml
-    target:
+  # - path: ksqldb-patch.yaml
+  #   target:
+  #     kind: KsqlDB
+  #     name: ksqldb
+
+  # Explicitly delete ksqlDB from this cluster overlay
+  - patch: |-
+      $patch: delete
+      apiVersion: platform.confluent.io/v1beta1
       kind: KsqlDB
-      name: ksqldb
+      metadata:
+        name: ksqldb
+        namespace: kafka


### PR DESCRIPTION
## Summary

Refactors confluent-resources workload management to better leverage base configuration:
- Uncomments ksqldb.yaml in base kustomization to make it available by default
- Adds explicit `$patch: delete` directives for ksqldb in flink-demo overlay
- Adds explicit `$patch: delete` directives for connect and ksqldb in flink-demo-rbac overlay
- Comments out old patch references for documentation purposes

## Changes

**Base configuration** (`workloads/confluent-resources/base/kustomization.yaml`):
- Uncommented `ksqldb.yaml` resource

**flink-demo overlay** (`workloads/confluent-resources/overlays/flink-demo/kustomization.yaml`):
- Commented out ksqldb-patch reference
- Added explicit delete patch for ksqldb resource

**flink-demo-rbac overlay** (`workloads/confluent-resources/overlays/flink-demo-rbac/kustomization.yaml`):
- Commented out connect-patch and ksqldb-patch references
- Added explicit delete patches for connect and ksqldb resources

## Rationale

Using explicit `$patch: delete` directives makes it clear which resources are intentionally excluded from specific cluster overlays, rather than relying on commented configuration or absence of resources.

## Test Plan

- [ ] Validate kustomize build for flink-demo overlay
- [ ] Validate kustomize build for flink-demo-rbac overlay
- [ ] Verify ksqldb is NOT included in flink-demo rendered manifests
- [ ] Verify connect and ksqldb are NOT included in flink-demo-rbac rendered manifests

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)