### PR TITLE
Update Control Center dependencies management

### DIFF
--- a/workloads/confluent-resources/base/control-center.yaml
+++ b/workloads/confluent-resources/base/control-center.yaml
@@ -20,9 +20,9 @@ spec:
   dependencies:
     schemaRegistry:
       url: http://schemaregistry.kafka.svc.cluster.local:8081
-    #ksqldb:
-    #- name: ksqldb
-    #  url: http://ksqldb.kafka.svc.cluster.local:8088
+    ksqldb:
+    - name: ksqldb
+      url: http://ksqldb.kafka.svc.cluster.local:8088
     connect:
     - name: connect
       url: http://connect.kafka.svc.cluster.local:8083

--- a/workloads/confluent-resources/overlays/flink-demo-rbac/control-center-patch.yaml
+++ b/workloads/confluent-resources/overlays/flink-demo-rbac/control-center-patch.yaml
@@ -14,3 +14,15 @@ spec:
       limits:
         cpu: 500m
         memory: 2Gi
+  # Disable connect UI in Control Center (must include all base configOverrides)
+  configOverrides:
+    server:
+      - confluent.controlcenter.ksql.enable=false
+      - confluent.controlcenter.ui.replicator.monitoring.enable=false
+      - confluent.controlcenter.cmf.enable=true
+      - confluent.controlcenter.cmf.url=http://cmf-service.operator.svc.cluster.local:80
+      - confluent.controlcenter.connect.enable=false
+  # Remove connect and ksqldb dependencies for this cluster
+  dependencies:
+    connect: null
+    ksqldb: null

--- a/workloads/confluent-resources/overlays/flink-demo/control-center-patch.yaml
+++ b/workloads/confluent-resources/overlays/flink-demo/control-center-patch.yaml
@@ -14,3 +14,6 @@ spec:
       limits:
         cpu: 500m
         memory: 2Gi
+  # Remove ksqldb dependency for this cluster
+  dependencies:
+    ksqldb: null


### PR DESCRIPTION
## Summary

Follow-up to #96 - Updates Control Center dependency configuration to align with the new pattern:
- Uncomments ksqldb dependency in base control-center.yaml (now available since PR #96)
- Adds explicit null overrides in overlays to remove dependencies where not needed
- Disables Connect UI in flink-demo-rbac cluster

## Changes

**Base configuration** (`workloads/confluent-resources/base/control-center.yaml`):
- Uncommented ksqldb dependency configuration

**flink-demo overlay** (`workloads/confluent-resources/overlays/flink-demo/control-center-patch.yaml`):
- Added explicit `ksqldb: null` to remove ksqldb dependency

**flink-demo-rbac overlay** (`workloads/confluent-resources/overlays/flink-demo-rbac/control-center-patch.yaml`):
- Added explicit `connect: null` and `ksqldb: null` to remove both dependencies
- Added `confluent.controlcenter.connect.enable=false` to disable Connect UI tab

## Rationale

This completes the refactoring started in #96 by ensuring Control Center's dependency configuration follows the same pattern: enable in base, explicitly disable in overlays where resources don't exist.

Since flink-demo doesn't deploy ksqlDB and flink-demo-rbac doesn't deploy either Connect or ksqlDB (via `$patch: delete` in #96), Control Center should not reference these dependencies.

## Test Plan

- [ ] Validate kustomize build for all overlays
- [ ] Verify Control Center starts without errors in flink-demo (no ksqldb dependency)
- [ ] Verify Control Center starts without errors in flink-demo-rbac (no connect or ksqldb dependencies)
- [ ] Verify Connect tab is hidden in flink-demo-rbac Control Center UI

Part of #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)