### PR TITLE
Enable Flink SQL for group FlinkEnvironments

### DIFF
--- a/workloads/confluent-resources/overlays/flink-demo-rbac/confluentrolebindings.yaml
+++ b/workloads/confluent-resources/overlays/flink-demo-rbac/confluentrolebindings.yaml
@@ -48,6 +48,24 @@ spec:
   kafkaRestClassRef:
     name: default
 ---
+# Kafka service account - SystemAdmin role on CMF cluster
+# Allows kafka service account to create Catalogs, Databases, and ComputePools
+# Used by SQL initialization Jobs
+apiVersion: platform.confluent.io/v1beta1
+kind: ConfluentRolebinding
+metadata:
+  name: kafka-cmf-systemadmin
+  namespace: kafka
+spec:
+  principal:
+    type: user
+    name: kafka
+  role: SystemAdmin
+  clustersScopeByIds:
+    cmfId: CMF-id
+  kafkaRestClassRef:
+    name: default
+---
 # Admin user - SystemAdmin role on CMF cluster
 apiVersion: platform.confluent.io/v1beta1
 kind: ConfluentRolebinding

--- a/workloads/confluent-resources/overlays/flink-demo-rbac/oauth-client-secrets.yaml
+++ b/workloads/confluent-resources/overlays/flink-demo-rbac/oauth-client-secrets.yaml
@@ -4,17 +4,27 @@
 # This matches the JAAS format expected by Kafka/KRaft OAuth configuration
 ---
 # OAuth client credentials for Kafka REST Proxy (used by MDS)
+# Also used by Flink SQL initialization Jobs
+# Mirrored to flink-shapes and flink-colors namespaces via Reflector
 apiVersion: v1
 kind: Secret
 metadata:
   name: kafka-oauth-client
   namespace: kafka
+  annotations:
+    # Reflector annotations to mirror secret to Flink namespaces
+    reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+    reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "flink-shapes,flink-colors"
+    reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
 type: Opaque
 stringData:
   # JAAS format for OAuth client credentials
   oauth.txt: |
     clientId=kafka
     clientSecret=kafka-secret
+  # Individual keys for use by Flink SQL initialization Jobs
+  client-id: kafka
+  client-secret: kafka-secret
 ---
 # OAuth client credentials for KRaft Controller
 apiVersion: v1

--- a/workloads/flink-resources/overlays/flink-demo-rbac/kustomization.yaml
+++ b/workloads/flink-resources/overlays/flink-demo-rbac/kustomization.yaml
@@ -9,6 +9,8 @@ resources:
   - flink-environment-colors.yaml
   - flink-application-shapes.yaml
   - flink-application-colors.yaml
+  - sql-config-configmaps.yaml
+  - sql-init-jobs.yaml
 
 # Cluster-specific patches
 patches:

--- a/workloads/flink-resources/overlays/flink-demo-rbac/sql-config-configmaps.yaml
+++ b/workloads/flink-resources/overlays/flink-demo-rbac/sql-config-configmaps.yaml
@@ -1,0 +1,244 @@
+# ConfigMaps containing Flink SQL Catalog, Database, and ComputePool definitions
+# These are applied via Jobs that call the CMF API
+---
+# Shapes Catalog - References Schema Registry
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: shapes-catalog-config
+  namespace: flink-shapes
+data:
+  catalog.json: |
+    {
+      "apiVersion": "cmf.confluent.io/v1",
+      "kind": "KafkaCatalog",
+      "metadata": {
+        "name": "shapes-catalog"
+      },
+      "spec": {
+        "srInstance": {
+          "connectionConfig": {
+            "schema.registry.url": "http://schemaregistry.kafka.svc.cluster.local:8081"
+          }
+        }
+      }
+    }
+---
+# Shapes Database - References Kafka cluster
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: shapes-database-config
+  namespace: flink-shapes
+data:
+  database.json: |
+    {
+      "apiVersion": "cmf.confluent.io/v1",
+      "kind": "KafkaDatabase",
+      "metadata": {
+        "name": "shapes-database"
+      },
+      "spec": {
+        "kafkaCluster": {
+          "connectionConfig": {
+            "bootstrap.servers": "kafka.kafka.svc.cluster.local:9071"
+          }
+        },
+        "alterEnvironments": [
+          "shapes-env"
+        ]
+      }
+    }
+---
+# Shapes Compute Pool - Dedicated compute resources for shapes-env
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: shapes-pool-config
+  namespace: flink-shapes
+data:
+  compute-pool.json: |
+    {
+      "apiVersion": "cmf.confluent.io/v1",
+      "kind": "ComputePool",
+      "metadata": {
+        "name": "shapes-pool",
+        "environment": "shapes-env"
+      },
+      "spec": {
+        "type": "DEDICATED",
+        "clusterSpec": {
+          "flinkVersion": "v1_20",
+          "image": "confluentinc/cp-flink-sql:1.20-cp1",
+          "flinkConfiguration": {
+            "taskmanager.numberOfTaskSlots": "2",
+            "metrics.reporter.prom.factory.class": "org.apache.flink.metrics.prometheus.PrometheusReporterFactory",
+            "metrics.reporter.prom.port": "9249-9250",
+            "pipeline.operator-chaining.enabled": "false",
+            "execution.checkpointing.interval": "10s",
+            "state.checkpoints.dir": "s3://warehouse/checkpoints/shapes/",
+            "state.savepoints.dir": "s3://warehouse/savepoints/shapes/",
+            "s3.endpoint": "http://s3proxy.flink.svc.cluster.local:8000",
+            "s3.path.style.access": "true",
+            "s3.connection.ssl.enabled": "false",
+            "s3.access-key": "admin",
+            "s3.secret-key": "password",
+            "state.backend": "filesystem",
+            "state.checkpoints.timeout": "600000",
+            "execution.checkpointing.min-pause": "5000",
+            "execution.checkpointing.max-concurrent-checkpoints": "1",
+            "high-availability.type": "kubernetes",
+            "high-availability.storageDir": "s3://warehouse/ha/shapes/",
+            "state.checkpoints.num-retained": "10"
+          },
+          "podTemplate": {
+            "spec": {
+              "restartPolicy": "Always",
+              "terminationGracePeriodSeconds": 30,
+              "containers": [
+                {
+                  "name": "flink-main-container",
+                  "imagePullPolicy": "IfNotPresent",
+                  "securityContext": {
+                    "runAsUser": 9999
+                  }
+                }
+              ]
+            }
+          },
+          "taskManager": {
+            "resource": {
+              "cpu": 1.0,
+              "memory": "1700m"
+            }
+          },
+          "jobManager": {
+            "resource": {
+              "cpu": 1,
+              "memory": "1700m"
+            }
+          }
+        }
+      }
+    }
+---
+# Colors Catalog - References Schema Registry
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: colors-catalog-config
+  namespace: flink-colors
+data:
+  catalog.json: |
+    {
+      "apiVersion": "cmf.confluent.io/v1",
+      "kind": "KafkaCatalog",
+      "metadata": {
+        "name": "colors-catalog"
+      },
+      "spec": {
+        "srInstance": {
+          "connectionConfig": {
+            "schema.registry.url": "http://schemaregistry.kafka.svc.cluster.local:8081"
+          }
+        }
+      }
+    }
+---
+# Colors Database - References Kafka cluster
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: colors-database-config
+  namespace: flink-colors
+data:
+  database.json: |
+    {
+      "apiVersion": "cmf.confluent.io/v1",
+      "kind": "KafkaDatabase",
+      "metadata": {
+        "name": "colors-database"
+      },
+      "spec": {
+        "kafkaCluster": {
+          "connectionConfig": {
+            "bootstrap.servers": "kafka.kafka.svc.cluster.local:9071"
+          }
+        },
+        "alterEnvironments": [
+          "colors-env"
+        ]
+      }
+    }
+---
+# Colors Compute Pool - Dedicated compute resources for colors-env
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: colors-pool-config
+  namespace: flink-colors
+data:
+  compute-pool.json: |
+    {
+      "apiVersion": "cmf.confluent.io/v1",
+      "kind": "ComputePool",
+      "metadata": {
+        "name": "colors-pool",
+        "environment": "colors-env"
+      },
+      "spec": {
+        "type": "DEDICATED",
+        "clusterSpec": {
+          "flinkVersion": "v1_20",
+          "image": "confluentinc/cp-flink-sql:1.20-cp1",
+          "flinkConfiguration": {
+            "taskmanager.numberOfTaskSlots": "2",
+            "metrics.reporter.prom.factory.class": "org.apache.flink.metrics.prometheus.PrometheusReporterFactory",
+            "metrics.reporter.prom.port": "9249-9250",
+            "pipeline.operator-chaining.enabled": "false",
+            "execution.checkpointing.interval": "10s",
+            "state.checkpoints.dir": "s3://warehouse/checkpoints/colors/",
+            "state.savepoints.dir": "s3://warehouse/savepoints/colors/",
+            "s3.endpoint": "http://s3proxy.flink.svc.cluster.local:8000",
+            "s3.path.style.access": "true",
+            "s3.connection.ssl.enabled": "false",
+            "s3.access-key": "admin",
+            "s3.secret-key": "password",
+            "state.backend": "filesystem",
+            "state.checkpoints.timeout": "600000",
+            "execution.checkpointing.min-pause": "5000",
+            "execution.checkpointing.max-concurrent-checkpoints": "1",
+            "high-availability.type": "kubernetes",
+            "high-availability.storageDir": "s3://warehouse/ha/colors/",
+            "state.checkpoints.num-retained": "10"
+          },
+          "podTemplate": {
+            "spec": {
+              "restartPolicy": "Always",
+              "terminationGracePeriodSeconds": 30,
+              "containers": [
+                {
+                  "name": "flink-main-container",
+                  "imagePullPolicy": "IfNotPresent",
+                  "securityContext": {
+                    "runAsUser": 9999
+                  }
+                }
+              ]
+            }
+          },
+          "taskManager": {
+            "resource": {
+              "cpu": 1.0,
+              "memory": "1700m"
+            }
+          },
+          "jobManager": {
+            "resource": {
+              "cpu": 1,
+              "memory": "1700m"
+            }
+          }
+        }
+      }
+    }

--- a/workloads/flink-resources/overlays/flink-demo-rbac/sql-init-jobs.yaml
+++ b/workloads/flink-resources/overlays/flink-demo-rbac/sql-init-jobs.yaml
@@ -1,0 +1,178 @@
+# Jobs to initialize Flink SQL Catalogs, Databases, and ComputePools via CMF API
+# These jobs run once to create the resources in CMF
+---
+# Shapes SQL Initialization Job
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: shapes-sql-init
+  namespace: flink-shapes
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: sql-init
+          image: curlimages/curl:8.1.2
+          env:
+            - name: OAUTH_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: kafka-oauth-client
+                  key: client-id
+            - name: OAUTH_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: kafka-oauth-client
+                  key: client-secret
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+
+              CMF_URL="http://cmf-service.operator.svc.cluster.local:80/cmf/api/v1"
+              KEYCLOAK_URL="http://keycloak.keycloak.svc.cluster.local:8080/realms/confluent/protocol/openid-connect/token"
+
+              echo "Obtaining OAuth token..."
+              TOKEN_RESPONSE=$(curl -s -X POST ${KEYCLOAK_URL} \
+                -H "Content-Type: application/x-www-form-urlencoded" \
+                -d "grant_type=client_credentials" \
+                -d "client_id=${OAUTH_CLIENT_ID}" \
+                -d "client_secret=${OAUTH_CLIENT_SECRET}" \
+                -d "scope=kafka")
+
+              ACCESS_TOKEN=$(echo ${TOKEN_RESPONSE} | grep -o '"access_token":"[^"]*' | cut -d'"' -f4)
+
+              if [ -z "${ACCESS_TOKEN}" ]; then
+                echo "Failed to obtain access token"
+                echo "Response: ${TOKEN_RESPONSE}"
+                exit 1
+              fi
+
+              echo "Token obtained successfully"
+
+              echo "Creating shapes-catalog..."
+              curl -v -H "Content-Type: application/json" \
+                -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+                -X POST ${CMF_URL}/catalogs/kafka \
+                -d @/config/catalog/catalog.json || true
+
+              echo "Creating shapes-database in shapes-catalog..."
+              curl -v -H "Content-Type: application/json" \
+                -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+                -X POST ${CMF_URL}/catalogs/kafka/shapes-catalog/databases \
+                -d @/config/database/database.json || true
+
+              echo "Creating shapes-pool in shapes-env..."
+              curl -v -H "Content-Type: application/json" \
+                -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+                -X POST ${CMF_URL}/compute-pools \
+                -d @/config/pool/compute-pool.json || true
+
+              echo "Shapes SQL resources initialized successfully"
+          volumeMounts:
+            - name: catalog-config
+              mountPath: /config/catalog
+            - name: database-config
+              mountPath: /config/database
+            - name: pool-config
+              mountPath: /config/pool
+      volumes:
+        - name: catalog-config
+          configMap:
+            name: shapes-catalog-config
+        - name: database-config
+          configMap:
+            name: shapes-database-config
+        - name: pool-config
+          configMap:
+            name: shapes-pool-config
+---
+# Colors SQL Initialization Job
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: colors-sql-init
+  namespace: flink-colors
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: sql-init
+          image: curlimages/curl:8.1.2
+          env:
+            - name: OAUTH_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: kafka-oauth-client
+                  key: client-id
+            - name: OAUTH_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: kafka-oauth-client
+                  key: client-secret
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+
+              CMF_URL="http://cmf-service.operator.svc.cluster.local:80/cmf/api/v1"
+              KEYCLOAK_URL="http://keycloak.keycloak.svc.cluster.local:8080/realms/confluent/protocol/openid-connect/token"
+
+              echo "Obtaining OAuth token..."
+              TOKEN_RESPONSE=$(curl -s -X POST ${KEYCLOAK_URL} \
+                -H "Content-Type: application/x-www-form-urlencoded" \
+                -d "grant_type=client_credentials" \
+                -d "client_id=${OAUTH_CLIENT_ID}" \
+                -d "client_secret=${OAUTH_CLIENT_SECRET}" \
+                -d "scope=kafka")
+
+              ACCESS_TOKEN=$(echo ${TOKEN_RESPONSE} | grep -o '"access_token":"[^"]*' | cut -d'"' -f4)
+
+              if [ -z "${ACCESS_TOKEN}" ]; then
+                echo "Failed to obtain access token"
+                echo "Response: ${TOKEN_RESPONSE}"
+                exit 1
+              fi
+
+              echo "Token obtained successfully"
+
+              echo "Creating colors-catalog..."
+              curl -v -H "Content-Type: application/json" \
+                -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+                -X POST ${CMF_URL}/catalogs/kafka \
+                -d @/config/catalog/catalog.json || true
+
+              echo "Creating colors-database in colors-catalog..."
+              curl -v -H "Content-Type: application/json" \
+                -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+                -X POST ${CMF_URL}/catalogs/kafka/colors-catalog/databases \
+                -d @/config/database/database.json || true
+
+              echo "Creating colors-pool in colors-env..."
+              curl -v -H "Content-Type: application/json" \
+                -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+                -X POST ${CMF_URL}/compute-pools \
+                -d @/config/pool/compute-pool.json || true
+
+              echo "Colors SQL resources initialized successfully"
+          volumeMounts:
+            - name: catalog-config
+              mountPath: /config/catalog
+            - name: database-config
+              mountPath: /config/database
+            - name: pool-config
+              mountPath: /config/pool
+      volumes:
+        - name: catalog-config
+          configMap:
+            name: colors-catalog-config
+        - name: database-config
+          configMap:
+            name: colors-database-config
+        - name: pool-config
+          configMap:
+            name: colors-pool-config


### PR DESCRIPTION
## Summary

Enables Flink SQL access for group-based FlinkEnvironments by creating separate KafkaCatalog, KafkaDatabase, and ComputePool resources for each group (shapes and colors).

- Create ConfigMaps with CMF resource definitions (Catalog, Database, ComputePool)
- Add Kubernetes Jobs to initialize SQL resources via CMF API with OAuth authentication
- Mirror kafka-oauth-client secret to Flink namespaces via Reflector annotations
- Configure s3proxy for checkpointing and savepoints in ComputePools
- Grant kafka service account SystemAdmin role on CMF cluster for resource creation

**Architecture:** Separate Catalog/Database/ComputePool per group for isolation:
- shapes-catalog → shapes-database → shapes-pool (in shapes-env)
- colors-catalog → colors-database → colors-pool (in colors-env)

## Test Plan

- [ ] Sync flink-demo-rbac cluster applications in ArgoCD
- [ ] Verify kafka-oauth-client secret is mirrored to flink-shapes and flink-colors namespaces
- [ ] Check shapes-sql-init and colors-sql-init Job logs for successful completion
- [ ] Verify Catalogs, Databases, and ComputePools are created in CMF
- [ ] Test SQL query execution as shapes group user
- [ ] Test SQL query execution as colors group user
- [ ] Verify checkpoint/savepoint storage in s3proxy

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)