### PR TITLE
Fix OAuth scope in SQL init Jobs

### DIFF
--- a/workloads/flink-resources/overlays/flink-demo-rbac/sql-init-jobs.yaml
+++ b/workloads/flink-resources/overlays/flink-demo-rbac/sql-init-jobs.yaml
@@ -39,8 +39,7 @@ spec:
                 -H "Content-Type: application/x-www-form-urlencoded" \
                 -d "grant_type=client_credentials" \
                 -d "client_id=${OAUTH_CLIENT_ID}" \
-                -d "client_secret=${OAUTH_CLIENT_SECRET}" \
-                -d "scope=kafka")
+                -d "client_secret=${OAUTH_CLIENT_SECRET}")
 
               ACCESS_TOKEN=$(echo ${TOKEN_RESPONSE} | grep -o '"access_token":"[^"]*' | cut -d'"' -f4)
 
@@ -127,8 +126,7 @@ spec:
                 -H "Content-Type: application/x-www-form-urlencoded" \
                 -d "grant_type=client_credentials" \
                 -d "client_id=${OAUTH_CLIENT_ID}" \
-                -d "client_secret=${OAUTH_CLIENT_SECRET}" \
-                -d "scope=kafka")
+                -d "client_secret=${OAUTH_CLIENT_SECRET}")
 
               ACCESS_TOKEN=$(echo ${TOKEN_RESPONSE} | grep -o '"access_token":"[^"]*' | cut -d'"' -f4)
 


### PR DESCRIPTION
## Summary

Fixes crashlooping SQL initialization Jobs by removing the invalid `scope=kafka` parameter from OAuth token requests.

The Keycloak realm does not recognize "kafka" as a valid scope, causing token requests to fail with:
```
{"error":"invalid_scope","error_description":"Invalid scopes: kafka"}
```

The fix removes the scope parameter to match the CMFRestClass OAuth configuration pattern, which successfully authenticates without specifying a scope. In OAuth 2.0 client credentials flow, the scope parameter is optional and defaults to the client's configured scopes in Keycloak.

## Changes

- Remove `-d "scope=kafka"` from OAuth token requests in both shapes-sql-init and colors-sql-init Jobs

## Test Plan

- [ ] Delete existing failed Job pods
- [ ] Verify new Job pods complete successfully
- [ ] Check Job logs confirm "Token obtained successfully"
- [ ] Verify Catalogs, Databases, and ComputePools are created in CMF

Fixes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)