### PR TITLE
Fix ComputePool API endpoint

### DIFF
--- a/workloads/flink-resources/overlays/flink-demo-rbac/sql-init-jobs.yaml
+++ b/workloads/flink-resources/overlays/flink-demo-rbac/sql-init-jobs.yaml
@@ -66,7 +66,7 @@ spec:
               echo "Creating shapes-pool in shapes-env..."
               curl -v -H "Content-Type: application/json" \
                 -H "Authorization: Bearer ${ACCESS_TOKEN}" \
-                -X POST ${CMF_URL}/compute-pools \
+                -X POST ${CMF_URL}/environments/shapes-env/compute-pools \
                 -d @/config/pool/compute-pool.json || true
 
               echo "Shapes SQL resources initialized successfully"
@@ -153,7 +153,7 @@ spec:
               echo "Creating colors-pool in colors-env..."
               curl -v -H "Content-Type: application/json" \
                 -H "Authorization: Bearer ${ACCESS_TOKEN}" \
-                -X POST ${CMF_URL}/compute-pools \
+                -X POST ${CMF_URL}/environments/colors-env/compute-pools \
                 -d @/config/pool/compute-pool.json || true
 
               echo "Colors SQL resources initialized successfully"


### PR DESCRIPTION
## Summary

Fixes ComputePool creation by correcting the API endpoint to include environment context.

The Job logs showed HTTP 404 errors when creating ComputePools:
```
{"errors":[{"message":"Resource not found: [cmf/api/v1/compute-pools]"}]}
```

According to the CMF API spec, ComputePools must be created within an environment context.

**Incorrect:** `/cmf/api/v1/compute-pools`  
**Correct:** `/cmf/api/v1/environments/{envName}/compute-pools`

## Changes

- Update shapes-pool endpoint to `/cmf/api/v1/environments/shapes-env/compute-pools`
- Update colors-pool endpoint to `/cmf/api/v1/environments/colors-env/compute-pools`

## Test Plan

- [ ] Delete and re-run shapes-sql-init and colors-sql-init Jobs
- [ ] Verify HTTP 200 responses for ComputePool creation
- [ ] Confirm ComputePools appear in CMF
- [ ] Check that Catalogs and Databases remain correctly associated

Part of #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)