### PR TITLE
Fix SQL init Jobs: remove environment field and switch to CMF service account

### DIFF
--- a/workloads/flink-resources/overlays/flink-demo-rbac/sql-config-configmaps.yaml
+++ b/workloads/flink-resources/overlays/flink-demo-rbac/sql-config-configmaps.yaml
@@ -62,8 +62,7 @@ data:
       "apiVersion": "cmf.confluent.io/v1",
       "kind": "ComputePool",
       "metadata": {
-        "name": "shapes-pool",
-        "environment": "shapes-env"
+        "name": "shapes-pool"
       },
       "spec": {
         "type": "DEDICATED",
@@ -183,8 +182,7 @@ data:
       "apiVersion": "cmf.confluent.io/v1",
       "kind": "ComputePool",
       "metadata": {
-        "name": "colors-pool",
-        "environment": "colors-env"
+        "name": "colors-pool"
       },
       "spec": {
         "type": "DEDICATED",


### PR DESCRIPTION
## Summary

Fixes SQL initialization Job failures by addressing two issues:

### 1. Remove environment field from ComputePool metadata

The CMF API rejects ComputePool creation with HTTP 400 error:
```
{"errors":[{"message":"Unrecognized property 'environment' in request body."}]}
```

The environment context is already specified in the URL path (`/cmf/api/v1/environments/{envName}/compute-pools`), so the environment field should not be included in the metadata section of the request body.

### 2. Switch to CMF service account for SQL init Jobs

Jobs were getting HTTP 401 Unauthorized when creating ComputePools because the kafka service account lacked environment-specific permissions.

**CMF service account already has:**
- SystemAdmin on CMF cluster
- ClusterAdmin on shapes-env FlinkEnvironment
- ClusterAdmin on colors-env FlinkEnvironment

This is semantically correct since CMF service account is designed to manage CMF resources.

## Changes

**ComputePool metadata:**
- Remove `"environment": "shapes-env"` from shapes-pool metadata
- Remove `"environment": "colors-env"` from colors-pool metadata

**Service account switch:**
- Update Jobs to use `cmf-mds-oauth-client` secret instead of `kafka-oauth-client`
- Add Reflector annotations to `cmf-mds-oauth-client` to mirror to flink-shapes and flink-colors namespaces
- Remove `kafka-cmf-systemadmin` ConfluentRolebinding (no longer needed)
- Revert `kafka-oauth-client` secret to original state

## Test Plan

- [ ] Delete existing sql-init Jobs and their pods
- [ ] Re-sync applications to recreate Jobs
- [ ] Verify HTTP 200 responses for all three resource types (Catalog, Database, ComputePool) in Job logs
- [ ] Confirm ComputePools are successfully created in CMF
- [ ] Verify shapes-pool and colors-pool are accessible in their respective environments

Fixes #115
Fixes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)