### PR TITLE
Add Kafka OAuth authentication to Flink SQL Databases

### DIFF
--- a/workloads/flink-resources/overlays/flink-demo-rbac/cmf-secret-configmaps.yaml
+++ b/workloads/flink-resources/overlays/flink-demo-rbac/cmf-secret-configmaps.yaml
@@ -1,0 +1,65 @@
+# ConfigMaps containing CMF Secret and EnvironmentSecretMapping definitions
+# These are applied via Jobs that call the CMF API
+---
+# Kafka OAuth Secret - Shared across all databases
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kafka-oauth-secret-config
+  namespace: flink-shapes
+data:
+  secret.json: |
+    {
+      "apiVersion": "cmf.confluent.io/v1",
+      "kind": "Secret",
+      "metadata": {
+        "name": "kafka-oauth-secret"
+      },
+      "spec": {
+        "data": {
+          "security.protocol": "SASL_PLAINTEXT",
+          "sasl.mechanism": "OAUTHBEARER",
+          "sasl.oauthbearer.token.endpoint.url": "http://keycloak.keycloak.svc.cluster.local:8080/realms/confluent/protocol/openid-connect/token",
+          "sasl.login.callback.handler.class": "org.apache.kafka.common.security.oauthbearer.secured.OAuthBearerLoginCallbackHandler",
+          "sasl.jaas.config": "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required clientId='cmf' clientSecret='cmf-secret' scope='profile email';"
+        }
+      }
+    }
+---
+# Shapes Environment Secret Mapping
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: shapes-secret-mapping-config
+  namespace: flink-shapes
+data:
+  secret-mapping.json: |
+    {
+      "apiVersion": "cmf.confluent.io/v1",
+      "kind": "EnvironmentSecretMapping",
+      "metadata": {
+        "name": "kafka-conn-secret-id"
+      },
+      "spec": {
+        "secretName": "kafka-oauth-secret"
+      }
+    }
+---
+# Colors Environment Secret Mapping
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: colors-secret-mapping-config
+  namespace: flink-colors
+data:
+  secret-mapping.json: |
+    {
+      "apiVersion": "cmf.confluent.io/v1",
+      "kind": "EnvironmentSecretMapping",
+      "metadata": {
+        "name": "kafka-conn-secret-id"
+      },
+      "spec": {
+        "secretName": "kafka-oauth-secret"
+      }
+    }

--- a/workloads/flink-resources/overlays/flink-demo-rbac/kustomization.yaml
+++ b/workloads/flink-resources/overlays/flink-demo-rbac/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - flink-application-shapes.yaml
   - flink-application-colors.yaml
   - sql-config-configmaps.yaml
+  - cmf-secret-configmaps.yaml
   - sql-init-jobs.yaml
 
 # Cluster-specific patches

--- a/workloads/flink-resources/overlays/flink-demo-rbac/sql-config-configmaps.yaml
+++ b/workloads/flink-resources/overlays/flink-demo-rbac/sql-config-configmaps.yaml
@@ -42,7 +42,8 @@ data:
         "kafkaCluster": {
           "connectionConfig": {
             "bootstrap.servers": "kafka.kafka.svc.cluster.local:9071"
-          }
+          },
+          "connectionSecretId": "kafka-conn-secret-id"
         },
         "alterEnvironments": [
           "shapes-env"
@@ -162,7 +163,8 @@ data:
         "kafkaCluster": {
           "connectionConfig": {
             "bootstrap.servers": "kafka.kafka.svc.cluster.local:9071"
-          }
+          },
+          "connectionSecretId": "kafka-conn-secret-id"
         },
         "alterEnvironments": [
           "colors-env"

--- a/workloads/flink-resources/overlays/flink-demo-rbac/sql-init-jobs.yaml
+++ b/workloads/flink-resources/overlays/flink-demo-rbac/sql-init-jobs.yaml
@@ -51,6 +51,27 @@ spec:
 
               echo "Token obtained successfully"
 
+              echo "Checking if kafka-oauth-secret exists..."
+              SECRET_EXISTS=$(curl -s -o /dev/null -w "%{http_code}" \
+                -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+                -X GET ${CMF_URL}/secrets/kafka-oauth-secret)
+
+              if [ "${SECRET_EXISTS}" = "404" ]; then
+                echo "Creating kafka-oauth-secret..."
+                curl -v -H "Content-Type: application/json" \
+                  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+                  -X POST ${CMF_URL}/secrets \
+                  -d @/config/secret/secret.json
+              else
+                echo "kafka-oauth-secret already exists (HTTP ${SECRET_EXISTS})"
+              fi
+
+              echo "Creating shapes-env secret mapping..."
+              curl -v -H "Content-Type: application/json" \
+                -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+                -X POST ${CMF_URL}/environments/shapes-env/secret-mappings \
+                -d @/config/secret-mapping/secret-mapping.json || true
+
               echo "Creating shapes-catalog..."
               curl -v -H "Content-Type: application/json" \
                 -H "Authorization: Bearer ${ACCESS_TOKEN}" \
@@ -77,6 +98,10 @@ spec:
               mountPath: /config/database
             - name: pool-config
               mountPath: /config/pool
+            - name: secret-config
+              mountPath: /config/secret
+            - name: secret-mapping-config
+              mountPath: /config/secret-mapping
       volumes:
         - name: catalog-config
           configMap:
@@ -87,6 +112,12 @@ spec:
         - name: pool-config
           configMap:
             name: shapes-pool-config
+        - name: secret-config
+          configMap:
+            name: kafka-oauth-secret-config
+        - name: secret-mapping-config
+          configMap:
+            name: shapes-secret-mapping-config
 ---
 # Colors SQL Initialization Job
 apiVersion: batch/v1
@@ -138,6 +169,27 @@ spec:
 
               echo "Token obtained successfully"
 
+              echo "Checking if kafka-oauth-secret exists..."
+              SECRET_EXISTS=$(curl -s -o /dev/null -w "%{http_code}" \
+                -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+                -X GET ${CMF_URL}/secrets/kafka-oauth-secret)
+
+              if [ "${SECRET_EXISTS}" = "404" ]; then
+                echo "Creating kafka-oauth-secret..."
+                curl -v -H "Content-Type: application/json" \
+                  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+                  -X POST ${CMF_URL}/secrets \
+                  -d @/config/secret/secret.json
+              else
+                echo "kafka-oauth-secret already exists (HTTP ${SECRET_EXISTS})"
+              fi
+
+              echo "Creating colors-env secret mapping..."
+              curl -v -H "Content-Type: application/json" \
+                -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+                -X POST ${CMF_URL}/environments/colors-env/secret-mappings \
+                -d @/config/secret-mapping/secret-mapping.json || true
+
               echo "Creating colors-catalog..."
               curl -v -H "Content-Type: application/json" \
                 -H "Authorization: Bearer ${ACCESS_TOKEN}" \
@@ -164,6 +216,10 @@ spec:
               mountPath: /config/database
             - name: pool-config
               mountPath: /config/pool
+            - name: secret-config
+              mountPath: /config/secret
+            - name: secret-mapping-config
+              mountPath: /config/secret-mapping
       volumes:
         - name: catalog-config
           configMap:
@@ -174,3 +230,9 @@ spec:
         - name: pool-config
           configMap:
             name: colors-pool-config
+        - name: secret-config
+          configMap:
+            name: kafka-oauth-secret-config
+        - name: secret-mapping-config
+          configMap:
+            name: colors-secret-mapping-config


### PR DESCRIPTION
## Problem

Control Center SQL workspace queries were failing with timeout errors:
```
CatalogException: Timeout occurred while fetching topics
Node -1 disconnected
```

CMF was unable to connect to the Kafka cluster because the Database configuration was missing authentication credentials. The Kafka cluster uses OAuth/RBAC on port 9071, but the Database only had `bootstrap.servers` configured without any authentication settings.

## Solution

Add Kafka OAuth authentication to Database configurations using CMF Secrets and Secret Mappings.

## Changes

**CMF Secret creation:**
- Created `kafka-oauth-secret` ConfigMap with OAuth configuration:
  - `security.protocol`: SASL_PLAINTEXT
  - `sasl.mechanism`: OAUTHBEARER
  - `sasl.jaas.config`: CMF service account credentials (clientId: cmf, clientSecret: cmf-secret)

**Environment Secret Mappings:**
- Created Secret Mappings for shapes-env and colors-env
- Link the `kafka-oauth-secret` to `connectionSecretId: "kafka-conn-secret-id"`

**Database configuration:**
- Added `connectionSecretId: "kafka-conn-secret-id"` to both shapes-database and colors-database

**Job updates:**
- Both Jobs check if `kafka-oauth-secret` exists before creating (idempotent)
- Create Secret Mappings for their respective environments
- Mount new ConfigMaps for secret and secret-mapping definitions

## How it works

CMF combines the Database's public `connectionConfig` with the environment-specific secret properties:
```
// From Database connectionConfig
bootstrap.servers: kafka.kafka.svc.cluster.local:9071

// From Secret mapped via connectionSecretId
security.protocol: SASL_PLAINTEXT
sasl.mechanism: OAUTHBEARER
sasl.jaas.config: ...CMF OAuth credentials...
```

This allows CMF to authenticate to Kafka when fetching topic metadata and executing SQL queries.

## Test Plan

- [ ] Delete existing sql-init Jobs
- [ ] Re-sync flink-resources application
- [ ] Verify Jobs complete successfully
- [ ] Check CMF logs - should not see "Node -1 disconnected" errors
- [ ] Execute `SELECT * FROM colors_input LIMIT 10;` in Control Center SQL workspace
- [ ] Verify query succeeds without timeout errors

Part of #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)