### PR TITLE
Deploy dedicated PostgreSQL database for CMF

### DIFF
--- a/workloads/cmf-operator/overlays/flink-demo-rbac/kustomization.yaml
+++ b/workloads/cmf-operator/overlays/flink-demo-rbac/kustomization.yaml
@@ -5,3 +5,5 @@ namespace: operator
 
 resources:
   - cmf-mds-oauth-secret.yaml
+  - postgres-secret.yaml
+  - postgres.yaml

--- a/workloads/cmf-operator/overlays/flink-demo-rbac/postgres-secret.yaml
+++ b/workloads/cmf-operator/overlays/flink-demo-rbac/postgres-secret.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cmf-postgres-credentials
+  namespace: operator
+type: Opaque
+stringData:
+  POSTGRES_DB: cmf
+  POSTGRES_USER: cmf
+  POSTGRES_PASSWORD: cmf-password

--- a/workloads/cmf-operator/overlays/flink-demo-rbac/postgres.yaml
+++ b/workloads/cmf-operator/overlays/flink-demo-rbac/postgres.yaml
@@ -1,0 +1,83 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cmf-postgres-pvc
+  namespace: operator
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+  storageClassName: standard
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cmf-postgres
+  namespace: operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cmf-postgres
+  template:
+    metadata:
+      labels:
+        app: cmf-postgres
+    spec:
+      containers:
+      - name: postgres
+        image: postgres:16
+        envFrom:
+        - secretRef:
+            name: cmf-postgres-credentials
+        ports:
+        - containerPort: 5432
+          name: postgres
+        volumeMounts:
+        - name: postgres-storage
+          mountPath: /var/lib/postgresql/data
+          subPath: postgres
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+        readinessProbe:
+          exec:
+            command:
+            - pg_isready
+            - -U
+            - cmf
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          exec:
+            command:
+            - pg_isready
+            - -U
+            - cmf
+          initialDelaySeconds: 30
+          periodSeconds: 30
+      volumes:
+      - name: postgres-storage
+        persistentVolumeClaim:
+          claimName: cmf-postgres-pvc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cmf-postgres
+  namespace: operator
+spec:
+  selector:
+    app: cmf-postgres
+  ports:
+  - port: 5432
+    targetPort: 5432
+    name: postgres
+  type: ClusterIP

--- a/workloads/cmf-operator/overlays/flink-demo-rbac/values.yaml
+++ b/workloads/cmf-operator/overlays/flink-demo-rbac/values.yaml
@@ -21,6 +21,20 @@ cmf:
   # Enable stack traces in error responses for debugging authorization issues
   stackTraceLogging: true
 
+  # Database configuration - Use PostgreSQL instead of embedded SQLite
+  # SQLite has severe lock contention issues under concurrent operations
+  database:
+    type: postgres
+    jdbc:
+      engine: postgresql
+      database: cmf
+      url: jdbc:postgresql://cmf-postgres.operator.svc.cluster.local:5432/cmf
+      user: cmf
+      password:
+        kubernetesSecretName: cmf-postgres-credentials
+        kubernetesSecretProperty: POSTGRES_PASSWORD
+      port: 5432
+
   authentication:
     type: oauth
     config:


### PR DESCRIPTION
## Summary

Deploys a dedicated PostgreSQL database for CMF (Confluent Manager for Apache Flink) in the `operator` namespace to replace the embedded SQLite database that was causing severe lock contention.

Fixes #118

## Problem

CMF was configured for PostgreSQL but fell back to embedded SQLite due to missing database URL configuration. This caused critical issues:

- **SQLite lock contention:** `[SQLITE_BUSY] The database file is locked` errors under concurrent operations
- **Secret persistence failures:** CMF Secret creation returned HTTP 200 but failed to persist to database
- **FlinkSQL query failures:** CMF Secrets required for Kafka OAuth authentication couldn't be stored
- **Database operations failing:** "Secret not found" errors immediately after successful creation

**Evidence from CMF logs:**
```
org.hibernate.exception.LockAcquisitionException: JDBC exception executing SQL 
[[SQLITE_BUSY] The database file is locked (database is locked)]
ERROR - i.c.c.s.SecretService - Secret 'kafka-oauth-secret-shapes' not found.
```

## Solution

Deploy a dedicated PostgreSQL instance for CMF, following the same pattern as Keycloak's PostgreSQL deployment.

### Changes Made

**New files:**
- `workloads/cmf-operator/overlays/flink-demo-rbac/postgres-secret.yaml` - Database credentials Secret
- `workloads/cmf-operator/overlays/flink-demo-rbac/postgres.yaml` - PostgreSQL deployment with:
  - 2Gi PersistentVolumeClaim for data persistence
  - Deployment with readiness/liveness probes
  - ClusterIP Service exposing port 5432

**Modified files:**
- `workloads/cmf-operator/overlays/flink-demo-rbac/kustomization.yaml` - Added postgres resources
- `workloads/cmf-operator/overlays/flink-demo-rbac/values.yaml` - Configured CMF database connection:
  ```yaml
  database:
    type: postgres
    jdbc:
      engine: postgresql
      database: cmf
      url: jdbc:postgresql://cmf-postgres.operator.svc.cluster.local:5432/cmf
      user: cmf
      password:
        kubernetesSecretName: cmf-postgres-credentials
        kubernetesSecretProperty: POSTGRES_PASSWORD
  ```

## Testing Plan

1. **Deploy PostgreSQL:**
   ```bash
   argocd app sync cmf-operator
   kubectl get pods -n operator -l app=cmf-postgres
   ```

2. **Restart CMF to use PostgreSQL:**
   ```bash
   kubectl rollout restart deployment/confluent-manager-for-apache-flink -n operator
   kubectl rollout status deployment/confluent-manager-for-apache-flink -n operator
   ```

3. **Verify PostgreSQL connection in CMF logs:**
   ```bash
   kubectl logs -n operator deployment/confluent-manager-for-apache-flink | grep -i "postgres\|sqlite"
   ```
   - Should see PostgreSQL JDBC connection logs
   - Should NOT see any SQLite [SQLITE_BUSY] errors

4. **Re-run SQL init Jobs to create CMF Secrets:**
   ```bash
   kubectl delete job shapes-sql-init -n flink-shapes
   kubectl delete job colors-sql-init -n flink-colors
   # ArgoCD will recreate them
   ```

5. **Verify Secrets are persisted:**
   ```bash
   kubectl run -n operator curl-pod --image=curlimages/curl:8.1.2 --rm -i --restart=Never -- sh -c '
     TOKEN=$(curl -s -X POST http://keycloak.keycloak.svc.cluster.local:8080/realms/confluent/protocol/openid-connect/token \
       -d "grant_type=client_credentials" -d "client_id=cmf" -d "client_secret=cmf-secret" | grep -o "\"access_token\":\"[^\"]*" | cut -d"\"" -f4)
     curl -s -H "Authorization: Bearer $TOKEN" http://cmf-service.operator.svc.cluster.local:80/cmf/api/v1/secrets
   '
   ```
   - Should show CMF Secrets with actual `spec` data (not `"spec":null`)

6. **Test FlinkSQL query execution from Control Center UI:**
   ```sql
   SELECT * FROM shapes_input LIMIT 10;
   ```
   - Should execute successfully without timeout errors

## Benefits

- ✅ Eliminates SQLite lock contention
- ✅ Enables concurrent CMF API operations
- ✅ Allows proper CMF Secret persistence
- ✅ Unblocks FlinkSQL functionality
- ✅ Production-ready database backend

## Deployment Notes

- PostgreSQL will be deployed in the `operator` namespace alongside CMF
- 2Gi storage allocated for CMF database (can be adjusted if needed)
- Database credentials stored in `cmf-postgres-credentials` Secret
- CMF will automatically create database schema on first startup