### PR TITLE
Add RBAC permissions for Flink SQL Catalogs and Databases

### DIFF
--- a/clusters/flink-demo-rbac/README.md
+++ b/clusters/flink-demo-rbac/README.md
@@ -425,20 +425,34 @@ This cluster enforces group-based RBAC for Kafka resources using prefixed naming
 - Subjects: `shapes-*` (e.g., `shapes-value`, `shapes-key`)
 - Consumer Groups: `shapes-*` (e.g., `shapes-consumer-1`)
 - Transactional IDs: `shapes-*` (e.g., `shapes-tx-1`)
+- Flink SQL Catalog: `shapes-catalog`
+- Flink SQL Database: `shapes-database`
 
 **Colors Group Resources:**
 - Topics: `colors-*` (e.g., `colors-input`, `colors-output`, `colors-state`)
 - Subjects: `colors-*` (e.g., `colors-value`, `colors-key`)
 - Consumer Groups: `colors-*` (e.g., `colors-consumer-1`)
 - Transactional IDs: `colors-*` (e.g., `colors-tx-1`)
+- Flink SQL Catalog: `colors-catalog`
+- Flink SQL Database: `colors-database`
 
 ### RBAC Permissions
 
-Each group has `ResourceOwner` role on their prefixed resources, granting:
+Each group has permissions on their group-specific resources:
+
+**Kafka Resources** (`ResourceOwner` role on prefixed resources):
 - **Topics:** Create, read, write, delete, and describe
 - **Subjects:** Register, update, delete, and view schemas
 - **Consumer Groups:** Create and manage consumer groups for Flink applications
 - **Transactional IDs:** Use transactions for exactly-once processing
+
+**Flink SQL Resources** (`DeveloperManage` role):
+- **KafkaCatalog:** View and manage group-specific catalogs (shapes-catalog, colors-catalog)
+- **KafkaDatabase:** View and manage group-specific databases (shapes-database, colors-database)
+
+**Flink Resources** (`DeveloperManage` and `ClusterAdmin` roles):
+- **FlinkEnvironment:** Manage group-specific environments
+- **FlinkApplication:** Full control over applications in group environment
 
 **Admin User:**
 - `SystemAdmin` role on both Kafka cluster and CMF cluster

--- a/workloads/confluent-resources/overlays/flink-demo-rbac/confluentrolebindings.yaml
+++ b/workloads/confluent-resources/overlays/flink-demo-rbac/confluentrolebindings.yaml
@@ -241,6 +241,93 @@ spec:
     name: default
 ---
 # ==============================================================================
+# FLINK SQL CATALOG & DATABASE RBAC - Group-based access control
+# ==============================================================================
+# Shapes group - DeveloperManage on shapes-catalog
+# Allows shapes group users to view and manage shapes-catalog in Flink SQL editor
+apiVersion: platform.confluent.io/v1beta1
+kind: ConfluentRolebinding
+metadata:
+  name: shapes-catalog-owner
+  namespace: kafka
+spec:
+  principal:
+    type: group
+    name: shapes
+  role: DeveloperManage
+  clustersScopeByIds:
+    cmfId: CMF-id
+  resourcePatterns:
+    - patternType: LITERAL
+      name: shapes-catalog
+      resourceType: KafkaCatalog
+  kafkaRestClassRef:
+    name: default
+---
+# Shapes group - DeveloperManage on shapes-database
+# Allows shapes group users to view and manage shapes-database in Flink SQL editor
+apiVersion: platform.confluent.io/v1beta1
+kind: ConfluentRolebinding
+metadata:
+  name: shapes-database-owner
+  namespace: kafka
+spec:
+  principal:
+    type: group
+    name: shapes
+  role: DeveloperManage
+  clustersScopeByIds:
+    cmfId: CMF-id
+  resourcePatterns:
+    - patternType: LITERAL
+      name: shapes-database
+      resourceType: KafkaDatabase
+  kafkaRestClassRef:
+    name: default
+---
+# Colors group - DeveloperManage on colors-catalog
+# Allows colors group users to view and manage colors-catalog in Flink SQL editor
+apiVersion: platform.confluent.io/v1beta1
+kind: ConfluentRolebinding
+metadata:
+  name: colors-catalog-owner
+  namespace: kafka
+spec:
+  principal:
+    type: group
+    name: colors
+  role: DeveloperManage
+  clustersScopeByIds:
+    cmfId: CMF-id
+  resourcePatterns:
+    - patternType: LITERAL
+      name: colors-catalog
+      resourceType: KafkaCatalog
+  kafkaRestClassRef:
+    name: default
+---
+# Colors group - DeveloperManage on colors-database
+# Allows colors group users to view and manage colors-database in Flink SQL editor
+apiVersion: platform.confluent.io/v1beta1
+kind: ConfluentRolebinding
+metadata:
+  name: colors-database-owner
+  namespace: kafka
+spec:
+  principal:
+    type: group
+    name: colors
+  role: DeveloperManage
+  clustersScopeByIds:
+    cmfId: CMF-id
+  resourcePatterns:
+    - patternType: LITERAL
+      name: colors-database
+      resourceType: KafkaDatabase
+  kafkaRestClassRef:
+    name: default
+---
+# ==============================================================================
 # KAFKA TOPIC RBAC - Group-based topic access control
 # ==============================================================================
 # Shapes group - ResourceOwner on shapes-* topics


### PR DESCRIPTION
Fixes #119

## Problem
Group users (shapes/colors) could see FlinkApplications in Control Center but could not see Catalogs or Databases in the Flink SQL Statement editor.

## Root Cause
Missing ConfluentRoleBindings for `KafkaCatalog` and `KafkaDatabase` resource types. While RBAC was configured for Topics, Subjects, Groups, and FlinkApplications, the SQL-specific resources were not included.

## Solution
Added ConfluentRoleBindings with `DeveloperManage` role:
- `shapes-catalog-owner` (shapes group on shapes-catalog)
- `shapes-database-owner` (shapes group on shapes-database)
- `colors-catalog-owner` (colors group on colors-catalog)
- `colors-database-owner` (colors group on colors-database)

## Changes
- Added 4 ConfluentRoleBindings for KafkaCatalog and KafkaDatabase resources
- Updated cluster README with Flink SQL resources in RBAC section

## Verification Steps

After deployment, test in Control Center:

**Shapes group user (`user-square@osow.ski`):**
- ✅ Should see `shapes-catalog` and `shapes-database`
- ❌ Should NOT see `colors-catalog` or `colors-database`

**Colors group user (`user-red@osow.ski`):**
- ✅ Should see `colors-catalog` and `colors-database`
- ❌ Should NOT see `shapes-catalog` or `shapes-database`

**Admin user (`admin@osow.ski`):**
- ✅ Should see all catalogs and databases

## Related
- Issue #105 - Flink SQL enablement (introduced Catalogs/Databases)
- Issue #106 - Kafka topic RBAC configuration
- Issue #90 - End-to-end testing (changelog updates deferred)