### PR TITLE
Add OAuth secret manifests for FlinkApplications

### DIFF
--- a/workloads/flink-resources/overlays/flink-demo-rbac/flink-oauth-secrets.yaml
+++ b/workloads/flink-resources/overlays/flink-demo-rbac/flink-oauth-secrets.yaml
@@ -1,0 +1,24 @@
+---
+# OAuth credentials for shapes group FlinkApplications
+# Service account: sa-shapes-flink (created in Keycloak via Job)
+apiVersion: v1
+kind: Secret
+metadata:
+  name: shapes-flink-oauth
+  namespace: flink-shapes
+type: Opaque
+stringData:
+  client-id: sa-shapes-flink
+  client-secret: sa-shapes-flink-secret
+---
+# OAuth credentials for colors group FlinkApplications
+# Service account: sa-colors-flink (created in Keycloak via Job)
+apiVersion: v1
+kind: Secret
+metadata:
+  name: colors-flink-oauth
+  namespace: flink-colors
+type: Opaque
+stringData:
+  client-id: sa-colors-flink
+  client-secret: sa-colors-flink-secret

--- a/workloads/flink-resources/overlays/flink-demo-rbac/kustomization.yaml
+++ b/workloads/flink-resources/overlays/flink-demo-rbac/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ../../base
   - cfk-oauth-secret.yaml
   - keycloak-service-account-job.yaml
+  - flink-oauth-secrets.yaml
   - flink-environment-shapes.yaml
   - flink-environment-colors.yaml
   - flink-application-shapes.yaml


### PR DESCRIPTION
## Summary
Implements Phase 2 of Issue #109 by creating Kubernetes Secret manifests to inject OAuth credentials into FlinkApplication pods.

## Changes
- **Added** `flink-oauth-secrets.yaml` with two secrets:
  - `shapes-flink-oauth` in `flink-shapes` namespace
  - `colors-flink-oauth` in `flink-colors` namespace
- **Updated** `kustomization.yaml` to include the new resource
- Secrets reference Keycloak service accounts created by Phase 1 GitOps Job

## Configuration Details
Both secrets contain:
- `client-id`: Service account client ID (`sa-shapes-flink` / `sa-colors-flink`)
- `client-secret`: Predictable secret value from Keycloak automation

## Testing Plan
- [ ] Verify secrets are created in correct namespaces after ArgoCD sync
- [ ] Confirm secret values match Keycloak service account credentials
- [ ] Validate kustomize build produces correct output
- [ ] Ready for Phase 3: Container image building

## Related Issues
Part of #109
Closes #123

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)