### PR TITLE
Replace StateMachine apps with Kafka-connected FlinkApplications

### DIFF
--- a/workloads/flink-resources/overlays/flink-demo-rbac/flink-application-colors.yaml
+++ b/workloads/flink-resources/overlays/flink-demo-rbac/flink-application-colors.yaml
@@ -1,9 +1,9 @@
-# FlinkApplication for colors group - StateMachine example
+# FlinkApplication for colors group - Kafka-connected with OAuth
 # Deployed in flink-colors namespace, accessible only to colors group members
 apiVersion: platform.confluent.io/v1beta1
 kind: FlinkApplication
 metadata:
-  name: colors-statemachine
+  name: colors
   namespace: flink-colors
 spec:
   # Reference to FlinkEnvironment
@@ -17,11 +17,15 @@ spec:
   # Flink version
   flinkVersion: v1_20
 
-  # Flink Docker image
-  image: confluentinc/cp-flink:1.20.3-cp1
+  # Flink Docker image with bundled application JAR
+  image: quay.io/osowski/flink-kafka-demo:2.1.1-202603231630
+
+  # ServiceAccount for Kubernetes RBAC
+  serviceAccount: flink
 
   # JobManager configuration
   jobManager:
+    replicas: 1
     resource:
       memory: "1048m"
       cpu: 1
@@ -31,17 +35,83 @@ spec:
     resource:
       memory: "1048m"
       cpu: 1
+    replicas: 2
 
-  # ServiceAccount for Flink pods
-  serviceAccount: flink
+  # OAuth credentials injection
+  # Inject OAuth client credentials from Kubernetes Secret into pod environment
+  podTemplate:
+    spec:
+      containers:
+        - name: flink-main-container
+          env:
+            # OAuth client ID from secret
+            - name: KAFKA_OAUTH_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: colors-flink-oauth
+                  key: client-id
+            # OAuth client secret from secret
+            - name: KAFKA_OAUTH_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: colors-flink-oauth
+                  key: client-secret
+
+  # Flink configuration - Kafka OAuth Authentication
+  flinkConfiguration:
+    # Kafka bootstrap servers (internal SASL_PLAINTEXT listener)
+    # Port 9071 is the internal listener with OAuth enabled
+    kafka.bootstrap.servers: kafka.kafka.svc.cluster.local:9071
+
+    # Kafka security configuration
+    kafka.security.protocol: SASL_PLAINTEXT
+    kafka.sasl.mechanism: OAUTHBEARER
+
+    # JAAS configuration for OAuth authentication
+    # Uses environment variables injected via podTemplate
+    kafka.sasl.jaas.config: |
+      org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required
+      clientId="${env:KAFKA_OAUTH_CLIENT_ID}"
+      clientSecret="${env:KAFKA_OAUTH_CLIENT_SECRET}"
+      tokenEndpointUri="http://keycloak.keycloak.svc.cluster.local:8080/realms/confluent/protocol/openid-connect/token";
+
+    # OAuth callback handler
+    kafka.sasl.login.callback.handler.class: org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginCallbackHandler
+
+    # Consumer configuration
+    kafka.consumer.group.id: colors-autoscaler
+    kafka.consumer.auto.offset.reset: earliest
+
+    # Producer configuration
+    kafka.producer.transaction.timeout.ms: "900000"
+
+    # Application-specific topic configuration
+    kafka.input.topic: colors-input
+    kafka.output.topic: colors-output
+
+    # Flink autoscaling configuration (disabled for this demo environment)
+    kubernetes.operator.job.autoscaler.enabled: "false"
+
+    # Flink task slots
+    taskmanager.numberOfTaskSlots: "2"
+
+    # Prometheus metrics
+    metrics.reporter.prom.factory.class: org.apache.flink.metrics.prometheus.PrometheusReporterFactory
+    metrics.reporter.prom.port: "9249-9250"
 
   # Job configuration
   job:
-    jarURI: local:///opt/flink/examples/streaming/StateMachineExample.jar
-    parallelism: 3
+    # JAR location (bundled in container image)
+    jarURI: local:///opt/flink/usrlib/flink-autoscaler.jar
+
+    # Parallelism
+    parallelism: 2
+
+    # Upgrade mode (stateless for demo)
     upgradeMode: stateless
+
+    # Job state
     state: running
 
-  # Flink configuration overrides
-  flinkConfiguration:
-    taskmanager.numberOfTaskSlots: "2"
+    # Application arguments
+    args: []

--- a/workloads/flink-resources/overlays/flink-demo-rbac/flink-application-shapes.yaml
+++ b/workloads/flink-resources/overlays/flink-demo-rbac/flink-application-shapes.yaml
@@ -1,9 +1,9 @@
-# FlinkApplication for shapes group - StateMachine example
+# FlinkApplication for shapes group - Kafka-connected with OAuth
 # Deployed in flink-shapes namespace, accessible only to shapes group members
 apiVersion: platform.confluent.io/v1beta1
 kind: FlinkApplication
 metadata:
-  name: shapes-statemachine
+  name: shapes
   namespace: flink-shapes
 spec:
   # Reference to FlinkEnvironment
@@ -17,11 +17,15 @@ spec:
   # Flink version
   flinkVersion: v1_20
 
-  # Flink Docker image
-  image: confluentinc/cp-flink:1.20.3-cp1
+  # Flink Docker image with bundled application JAR
+  image: quay.io/osowski/flink-kafka-demo:2.1.1-202603231630
+
+  # ServiceAccount for Kubernetes RBAC
+  serviceAccount: flink
 
   # JobManager configuration
   jobManager:
+    replicas: 1
     resource:
       memory: "1048m"
       cpu: 1
@@ -31,17 +35,83 @@ spec:
     resource:
       memory: "1048m"
       cpu: 1
+    replicas: 2
 
-  # ServiceAccount for Flink pods
-  serviceAccount: flink
+  # OAuth credentials injection
+  # Inject OAuth client credentials from Kubernetes Secret into pod environment
+  podTemplate:
+    spec:
+      containers:
+        - name: flink-main-container
+          env:
+            # OAuth client ID from secret
+            - name: KAFKA_OAUTH_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: shapes-flink-oauth
+                  key: client-id
+            # OAuth client secret from secret
+            - name: KAFKA_OAUTH_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: shapes-flink-oauth
+                  key: client-secret
+
+  # Flink configuration - Kafka OAuth Authentication
+  flinkConfiguration:
+    # Kafka bootstrap servers (internal SASL_PLAINTEXT listener)
+    # Port 9071 is the internal listener with OAuth enabled
+    kafka.bootstrap.servers: kafka.kafka.svc.cluster.local:9071
+
+    # Kafka security configuration
+    kafka.security.protocol: SASL_PLAINTEXT
+    kafka.sasl.mechanism: OAUTHBEARER
+
+    # JAAS configuration for OAuth authentication
+    # Uses environment variables injected via podTemplate
+    kafka.sasl.jaas.config: |
+      org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required
+      clientId="${env:KAFKA_OAUTH_CLIENT_ID}"
+      clientSecret="${env:KAFKA_OAUTH_CLIENT_SECRET}"
+      tokenEndpointUri="http://keycloak.keycloak.svc.cluster.local:8080/realms/confluent/protocol/openid-connect/token";
+
+    # OAuth callback handler
+    kafka.sasl.login.callback.handler.class: org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginCallbackHandler
+
+    # Consumer configuration
+    kafka.consumer.group.id: shapes-autoscaler
+    kafka.consumer.auto.offset.reset: earliest
+
+    # Producer configuration
+    kafka.producer.transaction.timeout.ms: "900000"
+
+    # Application-specific topic configuration
+    kafka.input.topic: shapes-input
+    kafka.output.topic: shapes-output
+
+    # Flink autoscaling configuration (disabled for this demo environment)
+    kubernetes.operator.job.autoscaler.enabled: "false"
+
+    # Flink task slots
+    taskmanager.numberOfTaskSlots: "2"
+
+    # Prometheus metrics
+    metrics.reporter.prom.factory.class: org.apache.flink.metrics.prometheus.PrometheusReporterFactory
+    metrics.reporter.prom.port: "9249-9250"
 
   # Job configuration
   job:
-    jarURI: local:///opt/flink/examples/streaming/StateMachineExample.jar
+    # JAR location (bundled in container image)
+    jarURI: local:///opt/flink/usrlib/flink-autoscaler.jar
+
+    # Parallelism
     parallelism: 2
+
+    # Upgrade mode (stateless for demo)
     upgradeMode: stateless
+
+    # Job state
     state: running
 
-  # Flink configuration overrides
-  flinkConfiguration:
-    taskmanager.numberOfTaskSlots: "2"
+    # Application arguments
+    args: []


### PR DESCRIPTION
## Summary
Implements Phase 4 of Issue #109 by replacing StateMachine examples with production-ready Kafka-connected FlinkApplications using OAuth authentication.

## Changes
**FlinkApplication Updates (both shapes and colors):**
- **Image:** Updated to `quay.io/osowski/flink-kafka-demo:2.1.1-202603231630`
- **OAuth Injection:** Added podTemplate to inject client credentials from OAuth secrets
- **Kafka Configuration:**
  - Bootstrap servers: `kafka.kafka.svc.cluster.local:9071` (SASL_PLAINTEXT with OAuth)
  - Security protocol: `SASL_PLAINTEXT`
  - SASL mechanism: `OAUTHBEARER`
  - JAAS config with environment variable substitution for client credentials
  - **Scope parameter removed** - service accounts have protocol mappers configured directly on client
- **RBAC Compliance:**
  - Consumer groups: `shapes-autoscaler` / `colors-autoscaler` (matches RBAC prefixes)
  - Topics: `shapes-input/output`, `colors-input/output` (matches RBAC prefixes)
- **Resource Configuration:**
  - JobManager: 1 replica, 1048m memory, 1 CPU
  - TaskManager: 2 replicas, 1048m memory, 1 CPU
- **Autoscaling:** Disabled for demo environment
- **Application Name:** Simplified from `shapes-statemachine`/`colors-statemachine` to `shapes`/`colors`

## OAuth Configuration Fix
✅ **Removed invalid `scope="kafka"` parameter** from JAAS configuration:
- "kafka" is not a defined scope in Keycloak realm
- Service accounts (`sa-shapes-flink`, `sa-colors-flink`) have protocol mappers configured directly on the client (email, groups, client_id)
- Client credentials flow will include all claims from client's protocol mappers without scope parameter
- Matches pattern from other working OAuth configurations in the cluster

## Testing Plan
- [ ] Verify FlinkApplications deploy successfully
- [ ] Check JobManager and TaskManager pods are running
- [ ] Validate OAuth authentication to Kafka (check logs for successful auth)
- [ ] Confirm consumer groups created with correct prefixes
- [ ] Verify JWT tokens include required claims (groups, client_id)
- [ ] Test RBAC enforcement (cross-group access should be denied)
- [ ] Monitor Prometheus metrics endpoint

## Known Limitations
- Producer application may need OIDC authentication support (to be addressed in future phase)
- Autoscaling disabled for demo stability

## Next Steps
After merge:
- Phase 5a: Schema definitions (#127)
- Phase 5b: Producer deployments (#128)
- Phase 6: End-to-end testing (#129)

## Related Issues
Part of #109
Closes #126

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)