### PR TITLE
Add Avro schema definitions for Flink SQL table discovery

### DIFF
--- a/workloads/confluent-resources/overlays/flink-demo-rbac/kustomization.yaml
+++ b/workloads/confluent-resources/overlays/flink-demo-rbac/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - controlcenter-oauth-client-secret.yaml  # OAuth client credentials for Control Center service account
   - confluentrolebindings.yaml
   - topics.yaml  # Group-based Kafka topics (shapes-*, colors-*)
+  - schemas.yaml  # Avro schemas for Flink SQL table discovery (shapes-*, colors-*)
 
 # Cluster-specific patches
 patches:

--- a/workloads/confluent-resources/overlays/flink-demo-rbac/schemas.yaml
+++ b/workloads/confluent-resources/overlays/flink-demo-rbac/schemas.yaml
@@ -1,0 +1,194 @@
+# Schema definitions for Flink SQL table discovery via CMF KafkaDatabase
+# Enables automatic creation of Flink SQL tables from Kafka topics
+#
+# Data source: flink-autoscaler from https://github.com/osowski/flink-sandbox
+# Producer: python-producer/producer.py (generates sensor events)
+# Processor: flink-java-app/KafkaFlinkJob.java (adds encoded field to events)
+#
+# Both shapes and colors groups use identical schemas:
+# - Input: SensorEvent (timestamp, type, location, value, status, id)
+# - Output: ProcessedSensorEvent (input fields + encoded/error/original)
+#
+# Schema reuse strategy:
+# - 2 shared ConfigMaps define the Avro schemas
+# - 4 Schema CRDs (one per topic) reference the shared ConfigMaps
+---
+# ConfigMap: Input schema (shared by shapes-input and colors-input)
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sensor-event-input-value-avro-schema
+  namespace: kafka
+data:
+  schema: |
+    {
+      "type": "record",
+      "name": "SensorEvent",
+      "namespace": "com.confluent.examples.sensors",
+      "doc": "Sensor event data from Kafka producer - used by both shapes and colors groups",
+      "fields": [
+        {
+          "name": "timestamp",
+          "type": "string",
+          "doc": "Event timestamp in ISO 8601 format (e.g., 2024-03-23T10:30:45.123456)"
+        },
+        {
+          "name": "type",
+          "type": "string",
+          "doc": "Data type (e.g., temperature, pressure, humidity, speed, count)"
+        },
+        {
+          "name": "location",
+          "type": "string",
+          "doc": "Sensor location identifier (e.g., sensor-A, sensor-B, sensor-C)"
+        },
+        {
+          "name": "value",
+          "type": "double",
+          "doc": "Numeric sensor reading value (float rounded to 2 decimals)"
+        },
+        {
+          "name": "status",
+          "type": "string",
+          "doc": "Sensor status (normal, warning, or critical)"
+        },
+        {
+          "name": "id",
+          "type": "string",
+          "doc": "Unique event identifier (8-character alphanumeric)"
+        }
+      ]
+    }
+---
+# ConfigMap: Output schema (shared by shapes-output and colors-output)
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sensor-event-output-value-avro-schema
+  namespace: kafka
+data:
+  schema: |
+    {
+      "type": "record",
+      "name": "ProcessedSensorEvent",
+      "namespace": "com.confluent.examples.sensors",
+      "doc": "Sensor event enriched by Flink processing - used by both shapes and colors groups",
+      "fields": [
+        {
+          "name": "timestamp",
+          "type": "string",
+          "doc": "Event timestamp in ISO 8601 format"
+        },
+        {
+          "name": "type",
+          "type": "string",
+          "doc": "Data type (e.g., temperature, pressure, humidity)"
+        },
+        {
+          "name": "location",
+          "type": "string",
+          "doc": "Sensor location identifier"
+        },
+        {
+          "name": "value",
+          "type": "double",
+          "doc": "Numeric sensor reading value"
+        },
+        {
+          "name": "status",
+          "type": "string",
+          "doc": "Sensor status (normal, warning, critical)"
+        },
+        {
+          "name": "id",
+          "type": "string",
+          "doc": "Unique event identifier"
+        },
+        {
+          "name": "encoded",
+          "type": ["null", "string"],
+          "default": null,
+          "doc": "Base64-encoded result of CPU-intensive transformations (added by Flink job)"
+        },
+        {
+          "name": "error",
+          "type": ["null", "string"],
+          "default": null,
+          "doc": "Error message if processing failed (only present on error)"
+        },
+        {
+          "name": "original",
+          "type": ["null", "string"],
+          "default": null,
+          "doc": "Original raw value if error occurred (only present on error)"
+        }
+      ]
+    }
+---
+# Schema CRD: shapes-input-value
+apiVersion: platform.confluent.io/v1beta1
+kind: Schema
+metadata:
+  name: shapes-input-value
+  namespace: kafka
+  annotations:
+    argocd.argoproj.io/sync-wave: "35"
+spec:
+  schemaRegistryClusterRef:
+    name: schemaregistry
+    namespace: kafka
+  data:
+    configRef: sensor-event-input-value-avro-schema
+    format: avro
+  compatibilityLevel: BACKWARD
+---
+# Schema CRD: shapes-output-value
+apiVersion: platform.confluent.io/v1beta1
+kind: Schema
+metadata:
+  name: shapes-output-value
+  namespace: kafka
+  annotations:
+    argocd.argoproj.io/sync-wave: "35"
+spec:
+  schemaRegistryClusterRef:
+    name: schemaregistry
+    namespace: kafka
+  data:
+    configRef: sensor-event-output-value-avro-schema
+    format: avro
+  compatibilityLevel: BACKWARD
+---
+# Schema CRD: colors-input-value
+apiVersion: platform.confluent.io/v1beta1
+kind: Schema
+metadata:
+  name: colors-input-value
+  namespace: kafka
+  annotations:
+    argocd.argoproj.io/sync-wave: "35"
+spec:
+  schemaRegistryClusterRef:
+    name: schemaregistry
+    namespace: kafka
+  data:
+    configRef: sensor-event-input-value-avro-schema
+    format: avro
+  compatibilityLevel: BACKWARD
+---
+# Schema CRD: colors-output-value
+apiVersion: platform.confluent.io/v1beta1
+kind: Schema
+metadata:
+  name: colors-output-value
+  namespace: kafka
+  annotations:
+    argocd.argoproj.io/sync-wave: "35"
+spec:
+  schemaRegistryClusterRef:
+    name: schemaregistry
+    namespace: kafka
+  data:
+    configRef: sensor-event-output-value-avro-schema
+    format: avro
+  compatibilityLevel: BACKWARD


### PR DESCRIPTION
## Overview

Create Avro schema definitions for shapes and colors Kafka topics to enable Flink SQL table discovery via CMF KafkaDatabase.

Closes #127

## Changes

### New File: `schemas.yaml`
- **2 ConfigMaps** defining reusable Avro schemas:
  - `sensor-event-input-value-avro-schema` - Input schema (SensorEvent)
  - `sensor-event-output-value-avro-schema` - Output schema (ProcessedSensorEvent)
  
- **4 Schema CRDs** (one per topic):
  - `shapes-input-value` → references input schema
  - `shapes-output-value` → references output schema
  - `colors-input-value` → references input schema
  - `colors-output-value` → references output schema

### Modified: `kustomization.yaml`
- Added `schemas.yaml` to resources list

## Schema Architecture

**Key Design:** Schema reuse strategy - both shapes and colors groups use identical schemas (same data structure, different topics)

**Input Schema (SensorEvent):**
```
timestamp: string (ISO 8601)
type: string
location: string
value: double
status: string
id: string
```

**Output Schema (ProcessedSensorEvent):**
```
...all input fields...
+ encoded: string (optional, added by Flink job)
+ error: string (optional, error case)
+ original: string (optional, error case)
```

## Data Model Validation

✅ Schemas match **actual producer** output (python-producer/producer.py from flink-sandbox)
✅ Schemas match **Flink job** transformations (KafkaFlinkJob.java from flink-sandbox)
✅ Uses proper Avro union types for optional fields
✅ BACKWARD compatibility level for schema evolution

## Reference Implementation

Follows established pattern from `workloads/cp-flink-sql-sandbox/base/schemas.yaml`:
- ConfigMap + Schema CRD pattern
- Proper schemaRegistryClusterRef configuration
- ArgoCD sync-wave: "35" (deploys after Schema Registry)

## Testing

**Pre-deployment validation:**
- ✅ Avro JSON syntax validated
- ✅ Required Avro fields present (type, name, namespace, fields)
- ✅ Comparison with reference implementation complete
- ✅ Schema-to-code mapping verified

**Post-deployment:**
1. Verify schemas register in Schema Registry: `kubectl get schema -n kafka`
2. Check Schema Registry UI for registered schemas
3. Validate with producer deployment (issue #128)
4. Test Flink SQL table discovery via CMF KafkaDatabase (issue #129)

## Dependencies

**Required for deployment:**
- ✅ Schema Registry deployed (already exists)
- ✅ Topics created (already exists in topics.yaml)

**Blocks:**
- Issue #128: Producer deployment (needs schemas registered)
- Issue #129: End-to-end testing

## Documentation

Part of Issue #109 (Phase 5a) - Deploy Kafka-connected FlinkApplications with RBAC