### PR TITLE
Enable s3proxy in flink-demo-rbac cluster

### DIFF
--- a/clusters/flink-demo-rbac/workloads/kustomization.yaml
+++ b/clusters/flink-demo-rbac/workloads/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - cmf-operator-secrets.yaml
   - cmf-operator.yaml
   - flink-resources.yaml
+  - s3proxy.yaml
 
 # Workload applications are deployed in sync wave order (100-120)
 # Remove any applications you don't need for your cluster

--- a/clusters/flink-demo-rbac/workloads/s3proxy.yaml
+++ b/clusters/flink-demo-rbac/workloads/s3proxy.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: s3proxy
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "115"
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/osowski/confluent-platform-gitops.git
+    targetRevision: HEAD
+    path: workloads/s3proxy/overlays/flink-demo-rbac
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: flink
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/workloads/s3proxy/overlays/flink-demo-rbac/ingressroute-patch.yaml
+++ b/workloads/s3proxy/overlays/flink-demo-rbac/ingressroute-patch.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: s3proxy
+  namespace: flink
+spec:
+  routes:
+    - match: Host(`s3proxy.flink-demo-rbac.confluentdemo.local`)
+      kind: Rule
+      services:
+        - name: s3proxy
+          port: 8000
+          scheme: http

--- a/workloads/s3proxy/overlays/flink-demo-rbac/kustomization.yaml
+++ b/workloads/s3proxy/overlays/flink-demo-rbac/kustomization.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Reference base configuration
+resources:
+  - ../../base
+
+# Cluster-specific patches
+patches:
+  - path: ingressroute-patch.yaml
+    target:
+      kind: IngressRoute
+      name: s3proxy
+
+# Cluster-specific labels
+labels:
+- includeSelectors: false
+  includeTemplates: true
+  pairs:
+    cluster: flink-demo-rbac


### PR DESCRIPTION
## Summary

Enables s3proxy deployment in the flink-demo-rbac cluster for S3-compatible object storage.

## Changes

### New Files
- `workloads/s3proxy/overlays/flink-demo-rbac/kustomization.yaml` - Overlay configuration
- `workloads/s3proxy/overlays/flink-demo-rbac/ingressroute-patch.yaml` - Cluster-specific ingress
- `clusters/flink-demo-rbac/workloads/s3proxy.yaml` - ArgoCD Application manifest

### Modified Files
- `clusters/flink-demo-rbac/workloads/kustomization.yaml` - Added s3proxy.yaml to resources

## Configuration

- **Namespace:** `flink`
- **Image:** `andrewgaul/s3proxy:3.0.0`
- **Storage:** 10Gi PVC (filesystem backend)
- **Ingress:** `http://s3proxy.flink-demo-rbac.confluentdemo.local`
- **Internal URL:** `http://s3proxy.flink:8000`
- **Credentials:** `admin` / `password` (demo environment)
- **Sync Wave:** 115 (after CMF/Flink operators)

## Features

- S3-compatible API (AWS v2/v4 signatures)
- Filesystem backend with 10Gi PVC
- PostSync init job creates 'warehouse' bucket automatically
- Ready for Flink state backend and checkpoint storage

## Use Cases

- Flink state backend storage (s3://warehouse/checkpoints)
- Flink checkpoint storage (s3://warehouse/savepoints)
- S3-based data sources/sinks for Flink applications

## Testing

Verified kustomization builds without errors:
```bash
kubectl kustomize workloads/s3proxy/overlays/flink-demo-rbac/
kubectl kustomize clusters/flink-demo-rbac/workloads/
```

## Deployment

After merge, ArgoCD will automatically:
1. Create PVC for storage (10Gi)
2. Deploy s3proxy pod
3. Create IngressRoute for external access
4. Run init job to create warehouse bucket

## Verification Steps

```bash
# Check ArgoCD Application
argocd app get s3proxy

# Verify pod running
kubectl get pods -n flink -l app=s3proxy

# Check PVC
kubectl get pvc -n flink s3proxy-data

# Test S3 API access
kubectl port-forward -n flink svc/s3proxy 8000:8000
aws --endpoint-url http://localhost:8000 s3 ls
```

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)