### PR TITLE
Update producer deployment documentation for simplified data generation

### DIFF
--- a/workloads/flink-resources/overlays/flink-demo-rbac/producers.yaml
+++ b/workloads/flink-resources/overlays/flink-demo-rbac/producers.yaml
@@ -32,7 +32,7 @@ spec:
             - name: KAFKA_TOPIC
               value: "shapes-input"
 
-            # Data type for message generation
+            # Data type label (for logging/identification only - all producers generate same sensor data)
             - name: DATA_TYPE
               value: "shapes"
 
@@ -105,7 +105,7 @@ spec:
             - name: KAFKA_TOPIC
               value: "colors-input"
 
-            # Data type for message generation
+            # Data type label (for logging/identification only - all producers generate same sensor data)
             - name: DATA_TYPE
               value: "colors"
 


### PR DESCRIPTION
## Summary

Updates producer deployment documentation to reflect the simplified data generation implementation where all producers now use the same randomized sensor data format.

## Context

After PR #137 was merged, the Python producer code in the flink-sandbox repository was simplified to use a single data generation format for all producers (commit osowski/flink-sandbox@dce0187). The `generate_shapes_data()` and `generate_colors_data()` functions were commented out in favor of using `generate_random_data()` for all message types.

This PR updates the deployment manifest comments to accurately reflect this change.

## Changes

**File:** `workloads/flink-resources/overlays/flink-demo-rbac/producers.yaml`

### Updated Comments
- **shapes-producer**: Clarified that `DATA_TYPE` is "for logging/identification only"
- **colors-producer**: Clarified that `DATA_TYPE` is "for logging/identification only"
- Added note: "all producers generate same sensor data"

### What Changed in Producer Behavior

**Before (PR #137):**
- `DATA_TYPE=shapes` → generated shape-specific data (shape, size, color fields)
- `DATA_TYPE=colors` → generated color-specific data (color, intensity, hue fields)
- `DATA_TYPE=autoscale` → generated sensor data (type, location, value, status fields)

**After (flink-sandbox@dce0187):**
- All `DATA_TYPE` values → generate same sensor data format
- `DATA_TYPE` variable still exists but only affects log output, not message structure
- All messages use randomized sensor data: type, location, value, status, id

### Message Format (All Producers)

```json
{
  "timestamp": "2024-01-01T12:00:00.000000",
  "type": "temperature|pressure|humidity|speed|count",
  "location": "sensor-A|sensor-B|sensor-C|sensor-D|sensor-E",
  "value": 42.15,
  "status": "normal|warning|critical",
  "id": "abc123de"
}
```

## What Still Works

- ✅ OAuth authentication (fully functional)
- ✅ RBAC permissions (unchanged)
- ✅ Fixed rate mode via `MESSAGE_RATE` environment variable
- ✅ Sinusoidal rate mode (when MESSAGE_RATE not set)
- ✅ Deployment with replicas: 0 (scale manually to enable)

## Related Changes

**flink-sandbox repository:**
- Commit dce0187: "Manually reverted the data type changes"
- Commit 38265b9: "Update producer documentation to reflect simplified data generation"

**confluent-platform-gitops:**
- PR #137: ✅ Merged (original producer deployment manifests)
- This PR: Documentation update to reflect simplified implementation

## Testing

No functional changes - documentation update only. The deployments continue to work as before with the updated producer code from flink-sandbox.

Part of #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)