### PR TITLE
Add checkpointing to flink-colors and flink-shapes applications

### DIFF
--- a/workloads/flink-resources/overlays/flink-demo-rbac/flink-application-colors.yaml
+++ b/workloads/flink-resources/overlays/flink-demo-rbac/flink-application-colors.yaml
@@ -114,6 +114,30 @@ spec:
     metrics.reporter.prom.factory.class: org.apache.flink.metrics.prometheus.PrometheusReporterFactory
     metrics.reporter.prom.port: "9249-9250"
 
+    # Checkpointing configuration
+    execution.checkpointing.interval: "10s"
+    execution.checkpointing.mode: EXACTLY_ONCE
+    execution.checkpointing.min-pause: "5s"
+    execution.checkpointing.max-concurrent-checkpoints: "1"
+    execution.checkpointing.timeout: "600000"
+
+    # State backend configuration
+    state.backend: filesystem
+    state.checkpoints.dir: "s3://warehouse/checkpoints/colors/"
+    state.savepoints.dir: "s3://warehouse/savepoints/colors/"
+    state.checkpoints.num-retained: "10"
+
+    # S3 configuration (points to s3proxy service)
+    s3.endpoint: "http://s3proxy.flink.svc.cluster.local:8000"
+    s3.path.style.access: "true"
+    s3.connection.ssl.enabled: "false"
+    s3.access-key: "admin"
+    s3.secret-key: "password"
+
+    # High availability configuration
+    high-availability.type: kubernetes
+    high-availability.storageDir: "s3://warehouse/ha/colors/"
+
   # Job configuration
   job:
     # JAR location (bundled in container image)
@@ -122,8 +146,8 @@ spec:
     # Parallelism
     parallelism: 2
 
-    # Upgrade mode (stateless for demo)
-    upgradeMode: stateless
+    # Upgrade mode (stateful with checkpointing)
+    upgradeMode: last-state
 
     # Job state
     state: running

--- a/workloads/flink-resources/overlays/flink-demo-rbac/flink-application-shapes.yaml
+++ b/workloads/flink-resources/overlays/flink-demo-rbac/flink-application-shapes.yaml
@@ -114,6 +114,30 @@ spec:
     metrics.reporter.prom.factory.class: org.apache.flink.metrics.prometheus.PrometheusReporterFactory
     metrics.reporter.prom.port: "9249-9250"
 
+    # Checkpointing configuration
+    execution.checkpointing.interval: "10s"
+    execution.checkpointing.mode: EXACTLY_ONCE
+    execution.checkpointing.min-pause: "5s"
+    execution.checkpointing.max-concurrent-checkpoints: "1"
+    execution.checkpointing.timeout: "600000"
+
+    # State backend configuration
+    state.backend: filesystem
+    state.checkpoints.dir: "s3://warehouse/checkpoints/shapes/"
+    state.savepoints.dir: "s3://warehouse/savepoints/shapes/"
+    state.checkpoints.num-retained: "10"
+
+    # S3 configuration (points to s3proxy service)
+    s3.endpoint: "http://s3proxy.flink.svc.cluster.local:8000"
+    s3.path.style.access: "true"
+    s3.connection.ssl.enabled: "false"
+    s3.access-key: "admin"
+    s3.secret-key: "password"
+
+    # High availability configuration
+    high-availability.type: kubernetes
+    high-availability.storageDir: "s3://warehouse/ha/shapes/"
+
   # Job configuration
   job:
     # JAR location (bundled in container image)
@@ -122,8 +146,8 @@ spec:
     # Parallelism
     parallelism: 2
 
-    # Upgrade mode (stateless for demo)
-    upgradeMode: stateless
+    # Upgrade mode (stateful with checkpointing)
+    upgradeMode: last-state
 
     # Job state
     state: running


### PR DESCRIPTION
## Summary

- Adds S3-backed checkpointing configuration to flink-colors and flink-shapes FlinkApplications
- Enables stateful processing with automatic recovery from failures
- Changes upgrade mode from `stateless` to `last-state` for checkpoint-based restarts
- Aligns with checkpointing pattern used in cp-flink-sql-sandbox

## Changes

**Configuration added to both applications:**

- **Checkpointing**: 10s interval, EXACTLY_ONCE mode, 10 retained checkpoints
- **State backend**: Filesystem with S3 storage via s3proxy service
- **Storage paths** (isolated per application):
  - Colors: `s3://warehouse/checkpoints/colors/`, `s3://warehouse/ha/colors/`
  - Shapes: `s3://warehouse/checkpoints/shapes/`, `s3://warehouse/ha/shapes/`
- **High availability**: Kubernetes HA enabled with S3 metadata storage
- **Upgrade mode**: Changed from `stateless` to `last-state`

**Files modified:**
- `workloads/flink-resources/overlays/flink-demo-rbac/flink-application-colors.yaml`
- `workloads/flink-resources/overlays/flink-demo-rbac/flink-application-shapes.yaml`

## Benefits

- Jobs automatically recover from TaskManager failures
- State preserved across pod restarts and upgrades
- Exactly-once processing semantics maintained
- Enables resilient demo behavior for fault tolerance demonstrations

## Test Plan

- [ ] Deploy updated FlinkApplications to flink-demo-rbac cluster
- [ ] Verify jobs start successfully and transition to RUNNING state
- [ ] Check logs for checkpoint creation messages
- [ ] Verify checkpoint files appear in s3proxy storage at `/warehouse/checkpoints/`
- [ ] Test fault tolerance by killing TaskManager pods
- [ ] Verify jobs recover automatically from last checkpoint
- [ ] Confirm no data loss or duplicate processing

## Dependencies

- Requires existing s3proxy deployment (sync-wave 106)
- No changes needed to s3proxy or other infrastructure

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)