### PR TITLE
Enable S3 filesystem plugin for FlinkApplications

### DIFF
--- a/workloads/flink-resources/overlays/flink-demo-rbac/flink-application-colors.yaml
+++ b/workloads/flink-resources/overlays/flink-demo-rbac/flink-application-colors.yaml
@@ -45,6 +45,8 @@ spec:
       containers:
         - name: flink-main-container
           env:
+            - name: ENABLE_BUILT_IN_PLUGINS
+              value: "flink-s3-fs-hadoop-2.1.1-cp1.jar"
             # OAuth client ID from secret
             - name: KAFKA_OAUTH_CLIENT_ID
               valueFrom:

--- a/workloads/flink-resources/overlays/flink-demo-rbac/flink-application-shapes.yaml
+++ b/workloads/flink-resources/overlays/flink-demo-rbac/flink-application-shapes.yaml
@@ -45,6 +45,8 @@ spec:
       containers:
         - name: flink-main-container
           env:
+            - name: ENABLE_BUILT_IN_PLUGINS
+              value: "flink-s3-fs-hadoop-2.1.1-cp1.jar"
             # OAuth client ID from secret
             - name: KAFKA_OAUTH_CLIENT_ID
               valueFrom:


### PR DESCRIPTION
## Summary
- Add `ENABLE_BUILT_IN_PLUGINS` environment variable to enable the built-in S3 filesystem plugin for both shapes and colors FlinkApplications
- Enables S3 checkpointing and high availability storage without Docker image modifications

## Changes
- `workloads/flink-resources/overlays/flink-demo-rbac/flink-application-colors.yaml`: Add ENABLE_BUILT_IN_PLUGINS env var
- `workloads/flink-resources/overlays/flink-demo-rbac/flink-application-shapes.yaml`: Add ENABLE_BUILT_IN_PLUGINS env var

## Technical Details
The `ENABLE_BUILT_IN_PLUGINS` environment variable tells the Confluent Flink image to automatically load the `flink-s3-fs-hadoop` plugin from `/opt/flink/opt/` at runtime. This is cleaner than modifying the Dockerfile to copy the plugin JAR.

With this change, FlinkApplications can now use:
- S3 for checkpointing (`state.checkpoints.dir: s3://...`)
- S3 for savepoints (`state.savepoints.dir: s3://...`)
- S3 for high availability storage (`high-availability.storageDir: s3://...`)

All S3 requests go to the `s3proxy` service running in the flink namespace.

Closes #141