### PR TITLE
Add Ollama workload for Flink Agents demo (Phase 1)

### DIFF
--- a/clusters/flink-demo/workloads/kustomization.yaml
+++ b/clusters/flink-demo/workloads/kustomization.yaml
@@ -13,3 +13,4 @@ resources:
   - s3proxy.yaml
   - cmf-ingress.yaml
   - cp-flink-sql-sandbox.yaml
+  - ollama.yaml

--- a/clusters/flink-demo/workloads/ollama.yaml
+++ b/clusters/flink-demo/workloads/ollama.yaml
@@ -16,7 +16,7 @@ spec:
     path: workloads/ollama/overlays/flink-demo
   destination:
     server: https://kubernetes.default.svc
-    namespace: flink
+    namespace: ollama
   syncPolicy:
     syncOptions:
       - CreateNamespace=false

--- a/clusters/flink-demo/workloads/ollama.yaml
+++ b/clusters/flink-demo/workloads/ollama.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ollama
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "106"
+spec:
+  project: workloads
+  source:
+    repoURL: https://github.com/osowski/confluent-platform-gitops.git
+    targetRevision: HEAD
+    path: workloads/ollama/overlays/flink-demo
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: flink
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=false
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/workloads/namespaces/base/kustomization.yaml
+++ b/workloads/namespaces/base/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - operator.yaml
   - kafka.yaml
   - flink.yaml
+  - ollama.yaml

--- a/workloads/namespaces/base/ollama.yaml
+++ b/workloads/namespaces/base/ollama.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ollama
+  labels:
+    app.kubernetes.io/name: ollama
+    app.kubernetes.io/component: platform

--- a/workloads/ollama/base/deployment.yaml
+++ b/workloads/ollama/base/deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ollama
-  namespace: flink
+  namespace: ollama
   annotations:
     argocd.argoproj.io/sync-wave: "15"
   labels:

--- a/workloads/ollama/base/deployment.yaml
+++ b/workloads/ollama/base/deployment.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ollama
+  namespace: flink
+  annotations:
+    argocd.argoproj.io/sync-wave: "15"
+  labels:
+    app: ollama
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ollama
+  template:
+    metadata:
+      labels:
+        app: ollama
+    spec:
+      containers:
+      - name: ollama
+        image: ollama/ollama:0.6.5
+        ports:
+        - name: api
+          containerPort: 11434
+          protocol: TCP
+        env:
+        - name: OLLAMA_HOST
+          value: "0.0.0.0"
+        volumeMounts:
+        - name: data
+          mountPath: /root/.ollama
+        resources:
+          requests:
+            cpu: 500m
+            memory: 2Gi
+          limits:
+            cpu: 4000m
+            memory: 8Gi
+        livenessProbe:
+          httpGet:
+            path: /api/tags
+            port: 11434
+          initialDelaySeconds: 30
+          periodSeconds: 15
+          failureThreshold: 5
+        readinessProbe:
+          httpGet:
+            path: /api/tags
+            port: 11434
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          failureThreshold: 3
+      volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: ollama-data

--- a/workloads/ollama/base/deployment.yaml
+++ b/workloads/ollama/base/deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: ollama
-        image: ollama/ollama:0.6.5
+        image: ollama/ollama:0.20.6
         ports:
         - name: api
           containerPort: 11434

--- a/workloads/ollama/base/kustomization.yaml
+++ b/workloads/ollama/base/kustomization.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - pvc.yaml
+  - deployment.yaml
+  - service.yaml
+  - model-config.yaml
+  - model-pull-job.yaml
+
+labels:
+- includeSelectors: false
+  includeTemplates: true
+  pairs:
+    app: ollama

--- a/workloads/ollama/base/model-config.yaml
+++ b/workloads/ollama/base/model-config.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: ollama-model-config
-  namespace: flink
+  namespace: ollama
   annotations:
     argocd.argoproj.io/sync-wave: "15"
   labels:

--- a/workloads/ollama/base/model-config.yaml
+++ b/workloads/ollama/base/model-config.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ollama-model-config
+  namespace: flink
+  annotations:
+    argocd.argoproj.io/sync-wave: "15"
+  labels:
+    app: ollama
+data:
+  model: "qwen3:8b"

--- a/workloads/ollama/base/model-config.yaml
+++ b/workloads/ollama/base/model-config.yaml
@@ -9,4 +9,5 @@ metadata:
   labels:
     app: ollama
 data:
-  model: "qwen3:8b"
+  models: |
+    qwen3:8b

--- a/workloads/ollama/base/model-pull-job.yaml
+++ b/workloads/ollama/base/model-pull-job.yaml
@@ -34,10 +34,16 @@ spec:
         - /bin/sh
         - -c
         - |
-          MODEL=$(cat /config/model)
-          echo "Pulling model: ${MODEL}"
-          OLLAMA_HOST=http://ollama:11434 ollama pull ${MODEL}
-          echo "Model pull complete!"
+          export OLLAMA_HOST=http://ollama:11434
+          echo "Starting model pulls..."
+          while IFS= read -r MODEL || [ -n "${MODEL}" ]; do
+            MODEL=$(echo "${MODEL}" | tr -d '[:space:]')
+            [ -z "${MODEL}" ] && continue
+            echo "Pulling model: ${MODEL}"
+            ollama pull "${MODEL}"
+            echo "Done pulling: ${MODEL}"
+          done < /config/models
+          echo "All models pulled successfully!"
         volumeMounts:
         - name: model-config
           mountPath: /config
@@ -46,5 +52,5 @@ spec:
         configMap:
           name: ollama-model-config
           items:
-          - key: model
-            path: model
+          - key: models
+            path: models

--- a/workloads/ollama/base/model-pull-job.yaml
+++ b/workloads/ollama/base/model-pull-job.yaml
@@ -29,7 +29,7 @@ spec:
           echo "Ollama is ready!"
       containers:
       - name: pull-model
-        image: ollama/ollama:0.6.5
+        image: ollama/ollama:0.20.6
         command:
         - /bin/sh
         - -c

--- a/workloads/ollama/base/model-pull-job.yaml
+++ b/workloads/ollama/base/model-pull-job.yaml
@@ -3,7 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: ollama-model-pull
-  namespace: flink
+  namespace: ollama
   annotations:
     argocd.argoproj.io/hook: PostSync
     argocd.argoproj.io/hook-delete-policy: BeforeHookCreation

--- a/workloads/ollama/base/model-pull-job.yaml
+++ b/workloads/ollama/base/model-pull-job.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ollama-model-pull
+  namespace: flink
+  annotations:
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      name: ollama-model-pull
+    spec:
+      restartPolicy: OnFailure
+      initContainers:
+      - name: wait-for-ollama
+        image: busybox:1.36
+        command:
+        - /bin/sh
+        - -c
+        - |
+          echo "Waiting for Ollama API to be ready..."
+          until wget -q -O /dev/null http://ollama:11434/; do
+            echo "Ollama not ready yet, retrying in 5s..."
+            sleep 5
+          done
+          echo "Ollama is ready!"
+      containers:
+      - name: pull-model
+        image: ollama/ollama:0.6.5
+        command:
+        - /bin/sh
+        - -c
+        - |
+          MODEL=$(cat /config/model)
+          echo "Pulling model: ${MODEL}"
+          OLLAMA_HOST=http://ollama:11434 ollama pull ${MODEL}
+          echo "Model pull complete!"
+        volumeMounts:
+        - name: model-config
+          mountPath: /config
+      volumes:
+      - name: model-config
+        configMap:
+          name: ollama-model-config
+          items:
+          - key: model
+            path: model

--- a/workloads/ollama/base/pvc.yaml
+++ b/workloads/ollama/base/pvc.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ollama-data
+  namespace: flink
+  annotations:
+    argocd.argoproj.io/sync-wave: "15"
+  labels:
+    app: ollama
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: standard
+  resources:
+    requests:
+      storage: 30Gi

--- a/workloads/ollama/base/pvc.yaml
+++ b/workloads/ollama/base/pvc.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: ollama-data
-  namespace: flink
+  namespace: ollama
   annotations:
     argocd.argoproj.io/sync-wave: "15"
   labels:

--- a/workloads/ollama/base/service.yaml
+++ b/workloads/ollama/base/service.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ollama
+  namespace: flink
+  annotations:
+    argocd.argoproj.io/sync-wave: "15"
+  labels:
+    app: ollama
+spec:
+  type: ClusterIP
+  ports:
+  - name: api
+    port: 11434
+    targetPort: api
+    protocol: TCP
+  selector:
+    app: ollama

--- a/workloads/ollama/base/service.yaml
+++ b/workloads/ollama/base/service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ollama
-  namespace: flink
+  namespace: ollama
   annotations:
     argocd.argoproj.io/sync-wave: "15"
   labels:

--- a/workloads/ollama/overlays/flink-demo/kustomization.yaml
+++ b/workloads/ollama/overlays/flink-demo/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+labels:
+- includeSelectors: false
+  includeTemplates: true
+  pairs:
+    cluster: flink-demo


### PR DESCRIPTION
## Summary

- Adds Ollama as a manually-synced GitOps workload (under `workloads/ollama/`) with a dedicated `ollama` namespace — not co-located in `flink` and not classified as infrastructure
- Adds a PostSync Job that pulls a configurable list of models (default: `qwen3:8b`) on each sync; additional models can be appended per cluster overlay
- Adds the `ollama` Namespace to `workloads/namespaces/base/` so it is provisioned before Ollama deploys (wave 100 vs 106)

## Test plan

- [ ] Sync `namespaces` Application in ArgoCD and confirm `ollama` namespace created
- [ ] Manually sync `ollama` Application in ArgoCD on flink-demo cluster
- [ ] Confirm Deployment reaches Ready state
- [ ] Confirm PostSync `ollama-model-pull` Job completes and `qwen3:8b` is available
- [ ] Validate API from within cluster: `kubectl exec -n ollama deploy/ollama -- ollama list`
- [ ] Validate cross-namespace reachability: `curl http://ollama.ollama.svc.cluster.local:11434/api/tags` from the `flink` namespace

Part of #163 (Phase 1 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)