### PR TITLE
feat(flink-demo): Phase 2 — Flink Agents workflow agent GitOps deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ charts/*.tgz
 # IDE AI assistant files
 .claude/
 .cursor/
+
+# Local-only working documents (design specs, brainstorming outputs)
+docs/superpowers/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,10 @@ Refer to these documentation files for details. Claude may read them as needed:
 
 These rules apply *in every session*:
 
+### Design Specs — Local Only
+
+Design specs (brainstorming outputs, implementation specs) written to `docs/superpowers/specs/` are **local working documents only** and must NEVER be committed to git. They are gitignored. Do not stage or commit any file under `docs/superpowers/`.
+
 ### Progressive Disclosure Policy
 Only load task-specific docs when needed. This file is intentionally concise — do not dump entire workflows here; instead, link to the named doc files above.
 

--- a/clusters/flink-demo/workloads/flink-agents.yaml
+++ b/clusters/flink-demo/workloads/flink-agents.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: flink-agents
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "111"
+spec:
+  project: workloads
+  source:
+    repoURL: https://github.com/osowski/confluent-platform-gitops.git
+    targetRevision: HEAD
+    path: workloads/flink-agents/overlays/flink-demo
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: flink
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=false
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/clusters/flink-demo/workloads/kustomization.yaml
+++ b/clusters/flink-demo/workloads/kustomization.yaml
@@ -11,5 +11,6 @@ resources:
   - cmf-operator.yaml
   - flink-resources.yaml
   - s3proxy.yaml
+  - flink-agents.yaml
   - cmf-ingress.yaml
   - cp-flink-sql-sandbox.yaml

--- a/workloads/flink-agents/README.md
+++ b/workloads/flink-agents/README.md
@@ -1,0 +1,151 @@
+# Flink Agents — Deployment & Performance Guide
+
+This workload deploys the [Flink Agents workflow agent quickstart](https://nightlies.apache.org/flink/flink-agents-docs-release-0.2/docs/get-started/quickstart/workflow_agent/) as a CMF-managed `FlinkApplication` on the `flink-demo` cluster, using Ollama as the local LLM backend.
+
+---
+
+## Architecture
+
+```
+FlinkApplication (flink ns)
+  └─ ReviewAnalysisAgent
+       └─ OLLAMA_ENDPOINT ──► Ollama service (ollama ns)
+                                  └─ qwen3:8b (or configured model)
+```
+
+The `OLLAMA_ENDPOINT` env var on the Flink pod controls where inference requests are sent. By default it points to the in-cluster Ollama service. For native macOS Ollama, it is overridden in the cluster overlay.
+
+---
+
+## Option 1: In-Cluster Ollama (default)
+
+Ollama runs as a Kubernetes Deployment in the `ollama` namespace, managed by ArgoCD at sync-wave 110 (before flink-agents at 111).
+
+**Endpoint (default):** `http://ollama.ollama.svc.cluster.local:11434`
+
+### The performance constraint on macOS
+
+When running on Kind (Docker Desktop), Ollama runs inside a Linux VM. **Apple Silicon's GPU and Neural Engine are not accessible from inside the VM.** Inference is CPU-only regardless of the host hardware. This caps throughput significantly.
+
+### Performance knobs (in-cluster)
+
+| Setting | Where | Recommended value | Notes |
+|---|---|---|---|
+| CPU limits | `workloads/ollama/overlays/<cluster>/` | `8` | Match available cores on the node |
+| `OLLAMA_NUM_THREADS` | Ollama Deployment env | `8` | Set to the number of physical CPU cores allocated |
+| `OLLAMA_NUM_PARALLEL` | Ollama Deployment env | `1` | Keep at 1 for CPU-only; parallelism degrades CPU throughput |
+| Model | `ollama-model-config` ConfigMap | `qwen3:1.7b` | Smaller model = dramatically faster on CPU (see Model section) |
+| `requestTimeout` | `CustomTypesAndResources.java` | `300` | Allow 5 min per request for slow CPU inference |
+| `NUM_ASYNC_THREADS` | `WorkflowSingleAgentExample.java` | `1` | Match Ollama's effective parallelism (1 for CPU-only) |
+
+To add `OLLAMA_NUM_THREADS` and `OLLAMA_NUM_PARALLEL` to the running deployment, patch the Ollama Deployment in the overlay:
+
+```yaml
+# workloads/ollama/overlays/flink-demo/kustomization.yaml
+patches:
+  - target:
+      kind: Deployment
+      name: ollama
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: OLLAMA_NUM_THREADS
+          value: "8"
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: OLLAMA_NUM_PARALLEL
+          value: "1"
+```
+
+---
+
+## Option 2: Ollama on the Native macOS Host
+
+Running Ollama natively on macOS gives access to Apple Silicon's GPU via Metal. This is the recommended approach for demo performance — expect 10–50x faster inference compared to CPU-only in-cluster.
+
+### Install and start
+
+```bash
+brew install ollama
+ollama serve          # starts on :11434, uses Metal automatically on Apple Silicon
+ollama pull qwen3:8b  # or whichever model is configured (see Model section)
+```
+
+### Performance knobs (native macOS)
+
+| Setting | How to set | Notes |
+|---|---|---|
+| `OLLAMA_NUM_PARALLEL` | `launchctl setenv OLLAMA_NUM_PARALLEL 2` or env before `ollama serve` | GPU handles concurrency well; start at 2 |
+| `OLLAMA_FLASH_ATTENTION` | `OLLAMA_FLASH_ATTENTION=1 ollama serve` | Enables Flash Attention — significant speedup on Apple Silicon |
+| Model | `ollama pull <model>` | Larger models are viable with GPU; see Model section |
+| `NUM_ASYNC_THREADS` | `WorkflowSingleAgentExample.java` | Can increase to 2 when `OLLAMA_NUM_PARALLEL=2` |
+| `requestTimeout` | `CustomTypesAndResources.java` | Can reduce to 60s with GPU-accelerated inference |
+
+### Pointing Flink at the native host
+
+Kind pods reach the macOS host via the DNS name `host.docker.internal` (provided by Docker Desktop). Override `OLLAMA_ENDPOINT` in the `flink-demo` overlay:
+
+```yaml
+# workloads/flink-agents/overlays/flink-demo/kustomization.yaml
+patches:
+  - target:
+      kind: FlinkApplication
+      name: flink-agents-workflow
+      namespace: flink
+    patch: |-
+      - op: replace
+        path: /spec/image
+        value: quay.io/osowski/flink-agents-demo:<sha>
+      - op: replace
+        path: /spec/podTemplate/spec/initContainers/0/env/0/value
+        value: http://host.docker.internal:11434
+      - op: replace
+        path: /spec/podTemplate/spec/containers/0/env/0/value
+        value: http://host.docker.internal:11434
+```
+
+> **Note:** Both the `wait-for-ollama` initContainer and the `flink-main-container` carry the `OLLAMA_ENDPOINT` env var and must both be updated. The base manifest sets the default in-cluster endpoint; the overlay patches override it.
+
+After syncing, verify the initContainer can reach the host:
+
+```bash
+kubectl run -it --rm debug --image=curlimages/curl --restart=Never -n flink -- \
+  curl -sf http://host.docker.internal:11434
+# Expected: "Ollama is running"
+```
+
+---
+
+## Model Selection and Flink Agent Impact
+
+The model name is specified in **two places that must stay in sync**:
+
+| Location | File | Value |
+|---|---|---|
+| What Ollama pulls | `workloads/ollama/base/ollama-model-config.yaml` (ConfigMap) | `qwen3:8b` |
+| What the agent requests | `ReviewAnalysisAgent.java` `@ChatModelSetup` | `.addInitialArgument("model", "qwen3:8b")` |
+
+If the model names do not match, Ollama will attempt to pull the requested model on-demand (slow) or fail if there is no internet access.
+
+### Changing the model
+
+1. Update the `ollama-model-config` ConfigMap in the Ollama overlay to pull the new model.
+2. Update `ReviewAnalysisAgent.java` to request the same model name, then rebuild and push the image:
+   ```bash
+   # in osowski/flink-agents, branch k8s-main
+   # edit: .addInitialArgument("model", "qwen3:1.7b")
+   bash scripts/build-image.sh
+   ```
+3. Update the image SHA tag in `workloads/flink-agents/overlays/flink-demo/kustomization.yaml`.
+
+### Model tradeoffs
+
+| Model | Size (q4) | Inference speed (CPU) | JSON reliability | Recommended for |
+|---|---|---|---|---|
+| `qwen3:1.7b` | ~1.5 GB | Fast | Good | CPU-only, high-throughput demos |
+| `qwen3:4b` | ~2.5 GB | Moderate | Very good | Balanced CPU performance |
+| `qwen3:8b` | ~5 GB | Slow on CPU | Excellent | Native GPU, quality-first |
+
+> The agent prompt instructs the model to return strict JSON with `id`, `score`, and `reasons` fields. Smaller models occasionally produce malformed JSON, causing the agent to throw `IllegalStateException` on parse failure. If this occurs, either switch to a larger model or add retry logic in `ReviewAnalysisAgent.processChatResponse`.

--- a/workloads/flink-agents/base/flink-application.yaml
+++ b/workloads/flink-agents/base/flink-application.yaml
@@ -7,6 +7,9 @@ metadata:
   namespace: flink
 spec:
   flinkEnvironment: env1
+  # No tag here — each cluster overlay must patch spec.image with the specific
+  # version tag for that deployment (kustomize images: transformer does not apply
+  # to custom CRD fields; use a JSON patch in the overlay instead).
   image: quay.io/osowski/flink-agents-demo
   flinkVersion: v2_1
   flinkConfiguration:

--- a/workloads/flink-agents/base/flink-application.yaml
+++ b/workloads/flink-agents/base/flink-application.yaml
@@ -40,7 +40,7 @@ spec:
             - sh
             - -c
             - |
-              until curl -sf "${OLLAMA_ENDPOINT}/api/health"; do
+              until curl -sf "${OLLAMA_ENDPOINT}"; do
                 echo "waiting for ollama at ${OLLAMA_ENDPOINT}...";
                 sleep 5;
               done

--- a/workloads/flink-agents/base/flink-application.yaml
+++ b/workloads/flink-agents/base/flink-application.yaml
@@ -15,8 +15,9 @@ spec:
   flinkConfiguration:
     "taskmanager.numberOfTaskSlots": "2"
     # flink-agents uses jdk.internal.vm.ContinuationScope for Loom-based async execution.
-    # Java 21 requires explicit --add-opens to grant access to this JDK internal package.
-    "env.java.opts": "--add-opens java.base/jdk.internal.vm=ALL-UNNAMED"
+    # Java 21 requires explicit --add-exports to grant access to this JDK internal package.
+    # ref: https://nightlies.apache.org/flink/flink-docs-stable/docs/deployment/config/#env-java-opts-all
+    "env.java.opts.all": "--add-exports java.base/jdk.internal.vm=ALL-UNNAMED"
   serviceAccount: flink
   jobManager:
     resource:

--- a/workloads/flink-agents/base/flink-application.yaml
+++ b/workloads/flink-agents/base/flink-application.yaml
@@ -14,6 +14,9 @@ spec:
   flinkVersion: v2_1
   flinkConfiguration:
     "taskmanager.numberOfTaskSlots": "2"
+    # flink-agents uses jdk.internal.vm.ContinuationScope for Loom-based async execution.
+    # Java 21 requires explicit --add-opens to grant access to this JDK internal package.
+    "env.java.opts": "--add-opens java.base/jdk.internal.vm=ALL-UNNAMED"
   serviceAccount: flink
   jobManager:
     resource:

--- a/workloads/flink-agents/base/flink-application.yaml
+++ b/workloads/flink-agents/base/flink-application.yaml
@@ -31,6 +31,22 @@ spec:
     upgradeMode: stateless
   podTemplate:
     spec:
+      initContainers:
+        # Wait for Ollama to be reachable before starting Flink containers.
+        # Prevents the job from failing immediately if Ollama is slow to start.
+        - name: wait-for-ollama
+          image: curlimages/curl:latest
+          command:
+            - sh
+            - -c
+            - |
+              until curl -sf "${OLLAMA_ENDPOINT}/api/health"; do
+                echo "waiting for ollama at ${OLLAMA_ENDPOINT}...";
+                sleep 5;
+              done
+          env:
+            - name: OLLAMA_ENDPOINT
+              value: http://ollama.ollama.svc.cluster.local:11434
       containers:
         - name: flink-main-container
           env:

--- a/workloads/flink-agents/base/flink-application.yaml
+++ b/workloads/flink-agents/base/flink-application.yaml
@@ -1,0 +1,38 @@
+---
+# Reference: https://docs.confluent.io/operator/current/co-manage-flink.html#create-a-af-application
+apiVersion: platform.confluent.io/v1beta1
+kind: FlinkApplication
+metadata:
+  name: flink-agents-workflow
+  namespace: flink
+spec:
+  flinkEnvironment: env1
+  image: quay.io/osowski/flink-agents-demo
+  flinkVersion: v2_1
+  flinkConfiguration:
+    "taskmanager.numberOfTaskSlots": "2"
+  serviceAccount: flink
+  jobManager:
+    resource:
+      memory: 1048m
+      cpu: 1
+  taskManager:
+    resource:
+      memory: 1048m
+      cpu: 1
+  job:
+    jarURI: local:///opt/flink/usrlib/flink-agents-examples.jar
+    entryClass: org.apache.flink.agents.examples.WorkflowSingleAgentExample
+    state: running
+    parallelism: 1
+    upgradeMode: stateless
+  podTemplate:
+    spec:
+      containers:
+        - name: flink-main-container
+          env:
+            - name: OLLAMA_ENDPOINT
+              value: http://ollama.ollama.svc.cluster.local:11434
+  cmfRestClassRef:
+    name: cmf-rest-class
+    namespace: flink

--- a/workloads/flink-agents/base/kustomization.yaml
+++ b/workloads/flink-agents/base/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - flink-application.yaml

--- a/workloads/flink-agents/overlays/flink-demo/kustomization.yaml
+++ b/workloads/flink-agents/overlays/flink-demo/kustomization.yaml
@@ -17,7 +17,7 @@ patches:
     patch: |-
       - op: replace
         path: /spec/image
-        value: quay.io/osowski/flink-agents-demo:4c0fe4f
+        value: quay.io/osowski/flink-agents-demo:6f41a0a
 
 # Cluster-specific labels
 labels:

--- a/workloads/flink-agents/overlays/flink-demo/kustomization.yaml
+++ b/workloads/flink-agents/overlays/flink-demo/kustomization.yaml
@@ -17,7 +17,7 @@ patches:
     patch: |-
       - op: replace
         path: /spec/image
-        value: quay.io/osowski/flink-agents-demo:00e3992
+        value: quay.io/osowski/flink-agents-demo:4c0fe4f
 
 # Cluster-specific labels
 labels:

--- a/workloads/flink-agents/overlays/flink-demo/kustomization.yaml
+++ b/workloads/flink-agents/overlays/flink-demo/kustomization.yaml
@@ -17,7 +17,7 @@ patches:
     patch: |-
       - op: replace
         path: /spec/image
-        value: quay.io/osowski/flink-agents-demo:6f41a0a
+        value: quay.io/osowski/flink-agents-demo:b550df9
 
 # Cluster-specific labels
 labels:

--- a/workloads/flink-agents/overlays/flink-demo/kustomization.yaml
+++ b/workloads/flink-agents/overlays/flink-demo/kustomization.yaml
@@ -6,8 +6,9 @@ kind: Kustomization
 resources:
   - ../../base
 
-# Patch to inject the image tag from the most recent osowski/flink-agents build.
-# Update the value with the SHA from scripts/build-image.sh in the osowski/flink-agents repo.
+# Patch spec.image with the SHA tag from the most recent osowski/flink-agents build.
+# kustomize images: transformer does not apply to FlinkApplication's spec.image (custom CRD field).
+# To update: run scripts/build-image.sh in osowski/flink-agents and replace the value below.
 patches:
   - target:
       kind: FlinkApplication

--- a/workloads/flink-agents/overlays/flink-demo/kustomization.yaml
+++ b/workloads/flink-agents/overlays/flink-demo/kustomization.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Reference base configuration
+resources:
+  - ../../base
+
+# Patch to inject the image tag from the most recent osowski/flink-agents build.
+# Update the value with the SHA from scripts/build-image.sh in the osowski/flink-agents repo.
+patches:
+  - target:
+      kind: FlinkApplication
+      name: flink-agents-workflow
+      namespace: flink
+    patch: |-
+      - op: replace
+        path: /spec/image
+        value: quay.io/osowski/flink-agents-demo:00e3992
+
+# Cluster-specific labels
+labels:
+  - includeSelectors: false
+    includeTemplates: true
+    pairs:
+      cluster: flink-demo


### PR DESCRIPTION
## Summary

- Adds `workloads/flink-agents/` base and `flink-demo` overlay deploying the [workflow agent quickstart](https://nightlies.apache.org/flink/flink-agents-docs-release-0.2/docs/get-started/quickstart/workflow_agent/) as a CMF-managed `FlinkApplication`
- Adds ArgoCD Application at sync-wave 111 (after Ollama at 110) with manual sync only
- Enforces gitignore + CLAUDE.md rule that design specs under `docs/superpowers/` are never committed

Closes [#163](https://github.com/osowski/confluent-platform-gitops/issues/163) Phase 2

## What changed

**`workloads/flink-agents/base/`**
- `FlinkApplication` CRD targeting `env1`, `flinkVersion: v2_1`, Java entrypoint `WorkflowSingleAgentExample`
- Stable `jarURI` (`flink-agents-examples.jar`) — decoupled from Maven version string
- `OLLAMA_ENDPOINT` env var on the main container; `--add-exports java.base/jdk.internal.vm=ALL-UNNAMED` in `flinkConfiguration` for Loom runtime access
- `wait-for-ollama` initContainer polls Ollama root endpoint before Flink containers start

**`workloads/flink-agents/overlays/flink-demo/`**
- JSON patch injects SHA-tagged image (`quay.io/osowski/flink-agents-demo:6f41a0a`) — required because `kustomize images:` transformer does not apply to custom CRD fields
- Cluster label `cluster: flink-demo`

**`clusters/flink-demo/workloads/`**
- `flink-agents.yaml` ArgoCD Application, sync-wave 111, no automated sync
- `kustomization.yaml` updated to include `flink-agents.yaml`

**`.gitignore` / `CLAUDE.md`**
- `docs/superpowers/` gitignored; CLAUDE.md documents the rule

## Test plan

- [ ] ArgoCD syncs `flink-agents` Application without error
- [ ] `FlinkApplication flink-agents-workflow` reaches `RUNNING` state in CMF
- [ ] TaskManager logs show `ProductReviewAnalysisRes` records with `id`, `score`, `reasons` fields
- [ ] No Ollama connection errors in TaskManager logs
- [ ] `kustomize build workloads/flink-agents/overlays/flink-demo` renders cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)