### PR TITLE
feat: add Prometheus metrics reporter to env1 ComputePool

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- Add Prometheus metrics reporter to `env1` ComputePool, consistent with Flink Application defaults and flink-demo-rbac compute pools.
 - Replaced s3proxy with MinIO in flink-demo cluster; adds reflector for secret distribution and MinIO console UI
 - Consolidated all standalone ingress ArgoCD Applications into `infra-ingresses` and `workload-ingresses` per cluster; updated `new-cluster.sh` to scaffold ingress overlays automatically.
 

--- a/workloads/cp-flink-sql-sandbox/base/cmf-config-configmap.yaml
+++ b/workloads/cp-flink-sql-sandbox/base/cmf-config-configmap.yaml
@@ -62,6 +62,8 @@ data:
             "pipeline.operator-chaining.enabled": "false",
             "execution.checkpointing.interval": "10s",
             "taskmanager.numberOfTaskSlots": "4",
+            "metrics.reporter.prom.factory.class": "org.apache.flink.metrics.prometheus.PrometheusReporterFactory",
+            "metrics.reporter.prom.port": "9249-9250",
             "state.checkpoints.dir": "s3://warehouse/checkpoints/",
             "state.savepoints.dir": "s3://warehouse/savepoints/",
             "s3.endpoint": "http://minio.storage.svc.cluster.local:9000",


### PR DESCRIPTION
## Summary

- Adds `metrics.reporter.prom.factory.class` and `metrics.reporter.prom.port` to the `pool` ComputePool `flinkConfiguration` in `cp-flink-sql-sandbox/base/cmf-config-configmap.yaml`
- Closes the observability gap between Flink Applications (which inherit these via `flinkApplicationDefaults`) and the `env1` compute pool on `flink-demo`
- `flink-demo-rbac` pools (`shapes-pool`, `colors-pool`) were already correct — no change needed there

## Why not FlinkEnvironment computePoolDefaults?

`computePoolDefaults` exists in the CMF REST API spec but is not exposed in the `FlinkEnvironment` CRD (`platform.confluent.io/v1beta1`) in CMF 2.2. The fix must be applied per-pool.

## Test plan

- [ ] Sync `cp-flink-sql-sandbox` on `flink-demo` and verify the PostSync Job re-creates or updates the compute pool with the new config
- [ ] Confirm Prometheus scraping of compute pool pods succeeds (port 9249-9250 visible)
- [ ] Confirm no regression on `flink-demo-rbac` (shapes/colors pools unchanged)

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)