### PR TITLE
feat(flink-agents): Phase 2.1 — parameterize Ollama model and endpoint target

### DIFF
--- a/workloads/flink-agents/base/flink-application.yaml
+++ b/workloads/flink-agents/base/flink-application.yaml
@@ -56,6 +56,8 @@ spec:
           env:
             - name: OLLAMA_ENDPOINT
               value: http://ollama.ollama.svc.cluster.local:11434
+            - name: OLLAMA_MODEL
+              value: qwen3:8b
   cmfRestClassRef:
     name: cmf-rest-class
     namespace: flink

--- a/workloads/flink-agents/components/ollama-host-mode/kustomization.yaml
+++ b/workloads/flink-agents/components/ollama-host-mode/kustomization.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+# Switches the Ollama endpoint from the in-cluster service to the native
+# macOS host. Used when Ollama runs locally via `brew services` rather than
+# as a Kubernetes workload. Applies to both the init container health check
+# and the main Flink container's OLLAMA_ENDPOINT env var.
+patches:
+  - target:
+      kind: FlinkApplication
+      name: flink-agents-workflow
+    patch: |-
+      - op: replace
+        path: /spec/podTemplate/spec/initContainers/0/env/0/value
+        value: http://host.docker.internal:11434
+      - op: replace
+        path: /spec/podTemplate/spec/containers/0/env/0/value
+        value: http://host.docker.internal:11434

--- a/workloads/flink-agents/overlays/flink-demo/kustomization.yaml
+++ b/workloads/flink-agents/overlays/flink-demo/kustomization.yaml
@@ -6,6 +6,11 @@ kind: Kustomization
 resources:
   - ../../base
 
+# Use host-mode Ollama component — routes OLLAMA_ENDPOINT to the native macOS
+# host instead of the in-cluster service. Remove this when running Ollama in-cluster.
+components:
+  - ../../components/ollama-host-mode
+
 # Patch spec.image with the SHA tag from the most recent osowski/flink-agents build.
 # kustomize images: transformer does not apply to FlinkApplication's spec.image (custom CRD field).
 # To update: run scripts/build-image.sh in osowski/flink-agents and replace the value below.
@@ -17,7 +22,7 @@ patches:
     patch: |-
       - op: replace
         path: /spec/image
-        value: quay.io/osowski/flink-agents-demo:b550df9
+        value: quay.io/osowski/flink-agents-demo:dd28128
 
 # Cluster-specific labels
 labels:


### PR DESCRIPTION
## Summary

- Add `OLLAMA_MODEL` env var to `FlinkApplication` base podTemplate (default: `qwen3:8b`), replacing the hardcoded model name in the Java agent image — the model is now configurable per overlay without rebuilding
- Add `components/ollama-host-mode/` Kustomize component that patches both `OLLAMA_ENDPOINT` values (initContainer + flink-main-container) to `http://host.docker.internal:11434` for native macOS Ollama
- Refactor `flink-demo` overlay to use the component instead of inline patches; bump image to `dd28128` (the build that reads `OLLAMA_MODEL` from env)

Companion Java changes in `osowski/flink-agents` (commit `dd28128`): all three example agents (`ReviewAnalysisAgent`, `ProductSuggestionAgent`, `TableReviewAnalysisAgent`) now read `System.getenv().getOrDefault("OLLAMA_MODEL", "qwen3:8b")`, mirroring the existing `OLLAMA_ENDPOINT` pattern.

Closes [#163](https://github.com/osowski/confluent-platform-gitops/issues/163) (Phase 2.1)

## Test plan

- [ ] Sync `flink-agents` in ArgoCD on `flink-demo` and verify pod starts with `OLLAMA_MODEL=qwen3:8b` and `OLLAMA_ENDPOINT=http://host.docker.internal:11434`
- [ ] Confirm init container passes health check against native macOS Ollama
- [ ] Validate end-to-end agent run completes with `qwen3:8b` (and optionally `qwen3:1.7b` by patching the overlay)
- [ ] Verify `kustomize build workloads/flink-agents/overlays/flink-demo/` renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)