### PR TITLE
feat(flink-agents): add ReAct agent quickstart support

### DIFF
--- a/workloads/flink-agents/README.md
+++ b/workloads/flink-agents/README.md
@@ -21,7 +21,13 @@ The `OLLAMA_ENDPOINT` env var on the Flink pod controls where inference requests
 
 **1. Sync in ArgoCD:**
 
-In the ArgoCD UI, click `flink-agents` → **Sync** → **Synchronize**. The `wait-for-ollama` initContainer will block until Ollama is reachable before the Flink job starts.
+The `flink-agents` Application manages two FlinkApplications (`flink-agents-workflow` and `flink-agents-react`). **Only sync one at a time** — running both concurrently will contend for the same Ollama instance and degrade inference throughput for both.
+
+In the ArgoCD UI, click `flink-agents` → **Sync**, then select only the resource you want to run:
+- `FlinkApplication/flink-agents-workflow` — Workflow agent quickstart
+- `FlinkApplication/flink-agents-react` — ReAct agent quickstart
+
+The `wait-for-ollama` initContainer will block until Ollama is reachable before the Flink job starts. To stop a running agent, set `spec.job.state: suspended` in the overlay patch or delete the FlinkApplication resource in ArgoCD before syncing the other.
 
 **2. Tail Flink agent output:**
 

--- a/workloads/flink-agents/base/flink-application-react.yaml
+++ b/workloads/flink-agents/base/flink-application-react.yaml
@@ -1,0 +1,63 @@
+---
+# Reference: https://docs.confluent.io/operator/current/co-manage-flink.html#create-a-af-application
+apiVersion: platform.confluent.io/v1beta1
+kind: FlinkApplication
+metadata:
+  name: flink-agents-react
+  namespace: flink
+spec:
+  flinkEnvironment: env1
+  # No tag here — each cluster overlay must patch spec.image with the specific
+  # version tag for that deployment (kustomize images: transformer does not apply
+  # to custom CRD fields; use a JSON patch in the overlay instead).
+  image: quay.io/osowski/flink-agents-demo
+  flinkVersion: v2_1
+  flinkConfiguration:
+    "taskmanager.numberOfTaskSlots": "2"
+    # flink-agents uses jdk.internal.vm.ContinuationScope for Loom-based async execution.
+    # Java 21 requires explicit --add-exports to grant access to this JDK internal package.
+    # ref: https://nightlies.apache.org/flink/flink-docs-stable/docs/deployment/config/#env-java-opts-all
+    "env.java.opts.all": "--add-exports java.base/jdk.internal.vm=ALL-UNNAMED"
+  serviceAccount: flink
+  jobManager:
+    resource:
+      memory: 1048m
+      cpu: 1
+  taskManager:
+    resource:
+      memory: 1048m
+      cpu: 2
+  job:
+    jarURI: local:///opt/flink/usrlib/flink-agents-examples.jar
+    entryClass: org.apache.flink.agents.examples.ReActAgentExample
+    state: running
+    parallelism: 1
+    upgradeMode: stateless
+  podTemplate:
+    spec:
+      initContainers:
+        # Wait for Ollama to be reachable before starting Flink containers.
+        # Prevents the job from failing immediately if Ollama is slow to start.
+        - name: wait-for-ollama
+          image: curlimages/curl:latest
+          command:
+            - sh
+            - -c
+            - |
+              until curl -sf "${OLLAMA_ENDPOINT}"; do
+                echo "waiting for ollama at ${OLLAMA_ENDPOINT}...";
+                sleep 5;
+              done
+          env:
+            - name: OLLAMA_ENDPOINT
+              value: http://ollama.ollama.svc.cluster.local:11434
+      containers:
+        - name: flink-main-container
+          env:
+            - name: OLLAMA_ENDPOINT
+              value: http://ollama.ollama.svc.cluster.local:11434
+            - name: OLLAMA_MODEL
+              value: qwen3:8b
+  cmfRestClassRef:
+    name: cmf-rest-class
+    namespace: flink

--- a/workloads/flink-agents/base/kustomization.yaml
+++ b/workloads/flink-agents/base/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 
 resources:
   - flink-application-workflow.yaml
+  - flink-application-react.yaml

--- a/workloads/flink-agents/components/ollama-host-mode/kustomization.yaml
+++ b/workloads/flink-agents/components/ollama-host-mode/kustomization.yaml
@@ -9,7 +9,6 @@ kind: Component
 patches:
   - target:
       kind: FlinkApplication
-      name: flink-agents-workflow
     patch: |-
       - op: replace
         path: /spec/podTemplate/spec/initContainers/0/env/0/value

--- a/workloads/flink-agents/overlays/flink-demo/kustomization.yaml
+++ b/workloads/flink-agents/overlays/flink-demo/kustomization.yaml
@@ -23,6 +23,14 @@ patches:
       - op: replace
         path: /spec/image
         value: quay.io/osowski/flink-agents-demo:dd28128
+  - target:
+      kind: FlinkApplication
+      name: flink-agents-react
+      namespace: flink
+    patch: |-
+      - op: replace
+        path: /spec/image
+        value: quay.io/osowski/flink-agents-demo:dd28128
 
 # Cluster-specific labels
 labels:

--- a/workloads/flink-agents/overlays/flink-demo/kustomization.yaml
+++ b/workloads/flink-agents/overlays/flink-demo/kustomization.yaml
@@ -22,7 +22,7 @@ patches:
     patch: |-
       - op: replace
         path: /spec/image
-        value: quay.io/osowski/flink-agents-demo:dd28128
+        value: quay.io/osowski/flink-agents-demo:dea72db
   - target:
       kind: FlinkApplication
       name: flink-agents-react
@@ -30,7 +30,7 @@ patches:
     patch: |-
       - op: replace
         path: /spec/image
-        value: quay.io/osowski/flink-agents-demo:dd28128
+        value: quay.io/osowski/flink-agents-demo:dea72db
 
 # Cluster-specific labels
 labels:


### PR DESCRIPTION
## Summary

- Add `flink-application-react.yaml` base manifest (`flink-agents-react`) with `entryClass: ReActAgentExample` — same image, resources, and Ollama config as the workflow agent
- Update `ollama-host-mode` component to target all `FlinkApplication` resources (removes `name:` filter), so host-mode applies to both workflow and react agents automatically
- Add `spec.image` patch for `flink-agents-react` in the flink-demo overlay
- Bump both image patches to `dea72db` (picks up K8s fixes for `ReActAgentExample`: K8s-aware input file path, `NUM_ASYNC_THREADS` 1, `OLLAMA_MODEL` from env var)

Companion Java changes in `osowski/flink-agents` (commit `dea72db`): `ReActAgentExample` now mirrors the fixes previously applied to `WorkflowSingleAgentExample`.

Part of [#163](https://github.com/osowski/confluent-platform-gitops/issues/163)

## Test plan

- [ ] Sync `flink-agents` in ArgoCD — both `flink-agents-workflow` and `flink-agents-react` Applications should appear
- [ ] Verify `flink-agents-react` init container passes health check against native macOS Ollama
- [ ] Tail TaskManager logs for `flink-agents-react` and confirm ReAct agent completes review analysis
- [ ] Confirm `flink-agents-workflow` still functions correctly with the new image

🤖 Generated with [Claude Code](https://claude.com/claude-code)