### PR TITLE
feat: add dns-bootstrap Terraform for dspdemos.com Route53 zones

### DIFF
--- a/terraform/dns-bootstrap/README.md
+++ b/terraform/dns-bootstrap/README.md
@@ -65,7 +65,8 @@ Verify with:
 
 ```bash
 # Query the root zone SOA from one of the Route53 name servers directly
-dig SOA dspdemos.com @ns-123.awsdns-45.com
+# Replace <ns-value> with one of the values from Step 1
+dig SOA dspdemos.com @<ns-value-from-step-1>
 
 # Verify global propagation (uses your default resolver)
 dig NS dspdemos.com
@@ -82,4 +83,5 @@ Once the NS records resolve correctly, proceed to apply the `eks-demo` Terraform
 | `root_zone_id` | Route53 zone ID for `dspdemos.com` |
 | `root_zone_name_servers` | Four NS values to set at your registrar |
 | `platform_zone_id` | Route53 zone ID for `platform.dspdemos.com` — pass to `eks-demo` Terraform as `platform_zone_id` |
+| `platform_zone_name_servers` | Name servers for the platform zone — useful for debugging DNS propagation |
 | `platform_domain` | Fully qualified platform domain (`platform.dspdemos.com`) |

--- a/terraform/dns-bootstrap/README.md
+++ b/terraform/dns-bootstrap/README.md
@@ -1,0 +1,85 @@
+# dns-bootstrap
+
+Provisions two Route53 hosted zones and NS delegation for the eks-demo cluster deployment.
+
+## What this creates
+
+| Resource | Description |
+|----------|-------------|
+| `aws_route53_zone.root` | Hosted zone for `dspdemos.com` (root domain) |
+| `aws_route53_zone.platform` | Hosted zone for `platform.dspdemos.com` (scoped for per-cluster IAM policies) |
+| `aws_route53_record.platform_ns` | NS delegation record in root zone pointing to platform zone name servers |
+
+## Usage
+
+```bash
+cp terraform.tfvars.example terraform.tfvars
+# Edit terraform.tfvars with your values
+terraform init
+terraform apply
+```
+
+## Post-apply: Registrar NS Update (required, one-time manual step)
+
+After `terraform apply`, Route53 assigns four name servers to the root zone. You must
+configure these at your domain registrar so that DNS queries for `dspdemos.com` are
+answered by Route53 rather than your registrar's default name servers.
+
+### Step 1: Get the name servers
+
+```bash
+terraform output root_zone_name_servers
+```
+
+This produces four NS records, for example:
+
+```
+ns-123.awsdns-45.com
+ns-678.awsdns-90.net
+ns-111.awsdns-22.org
+ns-333.awsdns-44.co.uk
+```
+
+### Step 2: Update your registrar
+
+Log in to your domain registrar (e.g. Namecheap, GoDaddy, Google Domains, Route53
+Registrar) and replace the current authoritative name servers for `dspdemos.com` with
+the four values from Step 1.
+
+**Registrar-specific paths:**
+
+| Registrar | Where to find NS settings |
+|-----------|--------------------------|
+| Namecheap | Domain List → Manage → Nameservers → Custom DNS |
+| GoDaddy | My Products → DNS → Nameservers → Change |
+| Google Domains | DNS → Name servers → Use custom name servers |
+| AWS Route53 Registrar | Registered domains → `dspdemos.com` → Name servers → Edit |
+
+Remove all existing name servers and add the four Route53 values. No trailing dot is needed
+— registrars accept them without it.
+
+### Step 3: Verify propagation
+
+DNS propagation can take up to 48 hours but typically completes within 15–30 minutes.
+Verify with:
+
+```bash
+# Query the root zone SOA from one of the Route53 name servers directly
+dig SOA dspdemos.com @ns-123.awsdns-45.com
+
+# Verify global propagation (uses your default resolver)
+dig NS dspdemos.com
+# Expected: the four Route53 name servers in the ANSWER section
+```
+
+Once the NS records resolve correctly, proceed to apply the `eks-demo` Terraform root
+(Task 3–6) and then the GitOps cluster configuration.
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `root_zone_id` | Route53 zone ID for `dspdemos.com` |
+| `root_zone_name_servers` | Four NS values to set at your registrar |
+| `platform_zone_id` | Route53 zone ID for `platform.dspdemos.com` — pass to `eks-demo` Terraform as `platform_zone_id` |
+| `platform_domain` | Fully qualified platform domain (`platform.dspdemos.com`) |

--- a/terraform/dns-bootstrap/main.tf
+++ b/terraform/dns-bootstrap/main.tf
@@ -1,0 +1,38 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+locals {
+  platform_domain = "${var.platform_subdomain}.${var.root_domain}"
+}
+
+# Root domain hosted zone
+resource "aws_route53_zone" "root" {
+  name = var.root_domain
+  tags = var.tags
+}
+
+# Platform subdomain hosted zone (separate zone for scoped IAM policies)
+resource "aws_route53_zone" "platform" {
+  name = local.platform_domain
+  tags = var.tags
+}
+
+# NS delegation from root zone to platform zone
+resource "aws_route53_record" "platform_ns" {
+  zone_id = aws_route53_zone.root.zone_id
+  name    = local.platform_domain
+  type    = "NS"
+  ttl     = 300
+  records = aws_route53_zone.platform.name_servers
+}

--- a/terraform/dns-bootstrap/main.tf
+++ b/terraform/dns-bootstrap/main.tf
@@ -33,6 +33,6 @@ resource "aws_route53_record" "platform_ns" {
   zone_id = aws_route53_zone.root.zone_id
   name    = local.platform_domain
   type    = "NS"
-  ttl     = 300
+  ttl     = 3600
   records = aws_route53_zone.platform.name_servers
 }

--- a/terraform/dns-bootstrap/outputs.tf
+++ b/terraform/dns-bootstrap/outputs.tf
@@ -1,0 +1,19 @@
+output "root_zone_id" {
+  description = "Route53 hosted zone ID for the root domain"
+  value       = aws_route53_zone.root.zone_id
+}
+
+output "root_zone_name_servers" {
+  description = "Name servers for the root zone — configure these at your registrar"
+  value       = aws_route53_zone.root.name_servers
+}
+
+output "platform_zone_id" {
+  description = "Route53 hosted zone ID for platform subdomain — used by per-cluster Terraform"
+  value       = aws_route53_zone.platform.zone_id
+}
+
+output "platform_domain" {
+  description = "Fully qualified platform domain"
+  value       = local.platform_domain
+}

--- a/terraform/dns-bootstrap/outputs.tf
+++ b/terraform/dns-bootstrap/outputs.tf
@@ -13,6 +13,11 @@ output "platform_zone_id" {
   value       = aws_route53_zone.platform.zone_id
 }
 
+output "platform_zone_name_servers" {
+  description = "Name servers for the platform zone — delegated from the root zone NS record"
+  value       = aws_route53_zone.platform.name_servers
+}
+
 output "platform_domain" {
   description = "Fully qualified platform domain"
   value       = local.platform_domain

--- a/terraform/dns-bootstrap/terraform.tfvars.example
+++ b/terraform/dns-bootstrap/terraform.tfvars.example
@@ -1,0 +1,12 @@
+aws_region         = "us-east-1"
+root_domain        = "dspdemos.com"
+platform_subdomain = "platform"
+
+tags = {
+  cflt_environment = "devel"
+  cflt_partition   = "onprem"
+  cflt_service     = "dns-bootstrap"
+  cflt_managed_by  = "terraform"
+  cflt_managed_id  = "rosowski-dns-bootstrap"
+  cflt_protected   = "false"
+}

--- a/terraform/dns-bootstrap/terraform.tfvars.example
+++ b/terraform/dns-bootstrap/terraform.tfvars.example
@@ -5,8 +5,8 @@ platform_subdomain = "platform"
 tags = {
   cflt_environment = "devel"
   cflt_partition   = "onprem"
-  cflt_service     = "dns-bootstrap"
+  cflt_service     = "osowski/confluent-platform-gitops"
   cflt_managed_by  = "terraform"
-  cflt_managed_id  = "rosowski-dns-bootstrap"
+  cflt_managed_id  = "osowski/confluent-platform-gitops"
   cflt_protected   = "false"
 }

--- a/terraform/dns-bootstrap/variables.tf
+++ b/terraform/dns-bootstrap/variables.tf
@@ -1,5 +1,7 @@
 variable "aws_region" {
-  description = "AWS region for Route53 operations"
+  # Route53 is a global service; this only satisfies the provider's required region
+  # argument and does not affect zone placement. us-east-1 is the conventional value.
+  description = "AWS provider region — Route53 is global and unaffected by this value"
   type        = string
   default     = "us-east-1"
 }

--- a/terraform/dns-bootstrap/variables.tf
+++ b/terraform/dns-bootstrap/variables.tf
@@ -1,0 +1,22 @@
+variable "aws_region" {
+  description = "AWS region for Route53 operations"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "root_domain" {
+  description = "Root domain name (e.g. dspdemos.com)"
+  type        = string
+}
+
+variable "platform_subdomain" {
+  description = "Platform subdomain prefix (e.g. platform)"
+  type        = string
+  default     = "platform"
+}
+
+variable "tags" {
+  description = "Common tags for all resources"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## Summary
- Creates `terraform/dns-bootstrap/` with `main.tf`, `variables.tf`, `outputs.tf`, and `terraform.tfvars.example`
- Provisions Route53 hosted zones for `dspdemos.com` (root) and `platform.dspdemos.com` (platform subdomain) with NS delegation between them
- Includes `README.md` with step-by-step registrar NS update instructions and propagation verification commands

## Test plan
- [x] `terraform validate` passes (confirmed locally)
- [ ] `terraform apply` after AWS credentials configured and `terraform.tfvars` populated
- [ ] Registrar NS records updated to Route53 values from `root_zone_name_servers` output
- [ ] `dig NS dspdemos.com` confirms Route53 name servers in ANSWER section

Closes #177
Part of #175