### PR TITLE
feat: EKS cluster Terraform — private-only endpoint, IRSA, EKS module v21

### DIFF
--- a/terraform/eks-demo/eks.tf
+++ b/terraform/eks-demo/eks.tf
@@ -12,6 +12,24 @@ module "eks" {
   endpoint_public_access  = false
   endpoint_private_access = true
 
+  # KMS encryption disabled — demo cluster is destroyed and recreated frequently;
+  # a pending-deletion KMS key blocks re-provisioning within the default 10-day window.
+  # Enable create_kms_key = true and set encryption_config for production clusters.
+  create_kms_key    = false
+  encryption_config = null
+
+  # Control plane log types — explicit to document the monitoring posture.
+  # Critical for a private cluster where CloudWatch is the primary debug path.
+  enabled_log_types = ["audit", "api", "authenticator", "controllerManager", "scheduler"]
+
+  # Core add-ons — vpc-cni and kube-proxy must be installed before nodes join
+  # (before_compute = true) or nodes will have no CNI and pods will never schedule.
+  addons = {
+    vpc-cni    = { before_compute = true }
+    kube-proxy = {}
+    coredns    = {}
+  }
+
   # IRSA — required for pod IAM (external-dns, cert-manager, aws-load-balancer-controller)
   enable_irsa = true
 
@@ -24,6 +42,21 @@ module "eks" {
       min_size       = var.node_min_size
       max_size       = var.node_max_size
       desired_size   = var.node_desired_size
+
+      ami_type = "AL2023_x86_64_STANDARD"
+
+      # 20 GiB default fills rapidly under Confluent Platform image pulls + ephemeral storage.
+      block_device_mappings = {
+        xvda = {
+          device_name = "/dev/xvda"
+          ebs = {
+            volume_size           = 100
+            volume_type           = "gp3"
+            delete_on_termination = true
+            encrypted             = true
+          }
+        }
+      }
     }
   }
 

--- a/terraform/eks-demo/eks.tf
+++ b/terraform/eks-demo/eks.tf
@@ -1,0 +1,31 @@
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "~> 21.0"
+
+  name               = var.cluster_name
+  kubernetes_version = var.kubernetes_version
+
+  vpc_id     = module.vpc.vpc_id
+  subnet_ids = module.vpc.private_subnets
+
+  # Private-only API — no public endpoint; access is via SSM+SOCKS5 bastion
+  endpoint_public_access  = false
+  endpoint_private_access = true
+
+  # IRSA — required for pod IAM (external-dns, cert-manager, aws-load-balancer-controller)
+  enable_irsa = true
+
+  # Grant the Terraform caller cluster-admin via access entry so post-apply kubectl works
+  enable_cluster_creator_admin_permissions = true
+
+  eks_managed_node_groups = {
+    default = {
+      instance_types = [var.node_instance_type]
+      min_size       = var.node_min_size
+      max_size       = var.node_max_size
+      desired_size   = var.node_desired_size
+    }
+  }
+
+  tags = var.common_tags
+}

--- a/terraform/eks-demo/main.tf
+++ b/terraform/eks-demo/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/terraform/eks-demo/main.tf
+++ b/terraform/eks-demo/main.tf
@@ -5,10 +5,6 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 6.0"
     }
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = "~> 2.0"
-    }
   }
 }
 

--- a/terraform/eks-demo/outputs.tf
+++ b/terraform/eks-demo/outputs.tf
@@ -1,0 +1,44 @@
+output "cluster_name" {
+  description = "EKS cluster name"
+  value       = module.eks.cluster_name
+}
+
+output "cluster_endpoint" {
+  description = "EKS API server endpoint (private only)"
+  value       = module.eks.cluster_endpoint
+}
+
+output "cluster_certificate_authority_data" {
+  description = "Base64-encoded cluster CA certificate — used in kubeconfig"
+  value       = module.eks.cluster_certificate_authority_data
+}
+
+output "cluster_oidc_issuer_url" {
+  description = "OIDC issuer URL for IRSA trust policies"
+  value       = module.eks.cluster_oidc_issuer_url
+}
+
+output "oidc_provider_arn" {
+  description = "ARN of the OIDC provider — used in IRSA IAM role trust policies"
+  value       = module.eks.oidc_provider_arn
+}
+
+output "cluster_security_group_id" {
+  description = "Security group attached to the EKS control plane"
+  value       = module.eks.cluster_security_group_id
+}
+
+output "node_security_group_id" {
+  description = "Security group shared by all managed node group nodes"
+  value       = module.eks.node_security_group_id
+}
+
+output "vpc_id" {
+  description = "VPC ID — convenience output for dependent modules"
+  value       = module.vpc.vpc_id
+}
+
+output "private_subnets" {
+  description = "Private subnet IDs — used by bastion and load balancer controller"
+  value       = module.vpc.private_subnets
+}


### PR DESCRIPTION
## Summary

- Adds `terraform/eks-demo/eks.tf` using `terraform-aws-modules/eks/aws ~> 21.0`
- Kubernetes 1.32, private-only API endpoint (no public access), IRSA via OIDC enabled
- Bumps AWS provider from `~> 5.0` to `~> 6.0` to satisfy EKS module v21 minimum requirement (`>= 6.28.0`)
- Adds `terraform/eks-demo/outputs.tf` exposing cluster endpoint, CA, OIDC issuer URL, OIDC provider ARN, and security group IDs for use by Tasks 5 (bastion) and 6 (IAM IRSA)
- Carries forward AZ filtering fix (`data.aws_vpc_endpoint_service.ssm`) to ensure branch is current with main

## Test plan

- [ ] `terraform init` completes without error
- [ ] `terraform validate` passes (deprecation warning in VPC module is benign and upstream)
- [ ] `terraform plan` shows EKS cluster, node group, and OIDC provider resources
- [ ] `terraform apply` provisions cluster successfully

Closes #179
Part of #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)