### PR TITLE
feat: SSM bastion with 3proxy SOCKS5 (Task 5)

### DIFF
--- a/terraform/eks-demo/bastion.tf
+++ b/terraform/eks-demo/bastion.tf
@@ -1,0 +1,110 @@
+data "aws_ami" "amazon_linux_2023" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["al2023-ami-*-x86_64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+resource "aws_iam_role" "bastion" {
+  name = "${var.cluster_name}-bastion"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "ec2.amazonaws.com" }
+    }]
+  })
+
+  tags = var.common_tags
+}
+
+resource "aws_iam_role_policy_attachment" "bastion_ssm" {
+  role       = aws_iam_role.bastion.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_instance_profile" "bastion" {
+  name = "${var.cluster_name}-bastion"
+  role = aws_iam_role.bastion.name
+  tags = var.common_tags
+}
+
+resource "aws_security_group" "bastion" {
+  name        = "${var.cluster_name}-bastion"
+  description = "Bastion host — no inbound, SSM outbound only"
+  vpc_id      = module.vpc.vpc_id
+
+  # No inbound rules — all access via SSM Session Manager, no SSH
+
+  egress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "SSM agent, ECR, EKS API via VPC endpoints"
+  }
+
+  tags = merge(var.common_tags, { Name = "${var.cluster_name}-bastion" })
+}
+
+resource "aws_instance" "bastion" {
+  ami                         = data.aws_ami.amazon_linux_2023.id
+  instance_type               = "t3.small"
+  subnet_id                   = module.vpc.private_subnets[0]
+  iam_instance_profile        = aws_iam_instance_profile.bastion.name
+  vpc_security_group_ids      = [aws_security_group.bastion.id]
+  associate_public_ip_address = false
+
+  # 3proxy built from source — avoids any repo availability uncertainty on AL2023.
+  # Listens on 127.0.0.1:1080 — exposed to the laptop via SSM port forwarding.
+  user_data_base64 = base64encode(<<-EOF
+    #!/bin/bash
+    set -euo pipefail
+
+    yum install -y git gcc make
+
+    git clone --depth 1 https://github.com/3proxy/3proxy.git /opt/3proxy
+    cd /opt/3proxy && make -f Makefile.Linux
+    install -m 755 bin/3proxy /usr/local/bin/3proxy
+
+    mkdir -p /etc/3proxy /var/log/3proxy
+
+    cat > /etc/3proxy/3proxy.cfg << 'CONF'
+nscache 65536
+log /var/log/3proxy/3proxy.log D
+logformat "- +_L%t.%.  %N.%p %E %U %C:%c %R:%r %O %I %h %T"
+socks -p1080 -i127.0.0.1
+CONF
+
+    cat > /etc/systemd/system/3proxy.service << 'UNIT'
+[Unit]
+Description=3proxy SOCKS5 proxy
+After=network.target
+
+[Service]
+ExecStart=/usr/local/bin/3proxy /etc/3proxy/3proxy.cfg
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+    systemctl daemon-reload
+    systemctl enable 3proxy
+    systemctl start 3proxy
+  EOF
+  )
+
+  tags = merge(var.common_tags, { Name = "${var.cluster_name}-bastion" })
+}

--- a/terraform/eks-demo/bastion.tf
+++ b/terraform/eks-demo/bastion.tf
@@ -11,6 +11,11 @@ data "aws_ami" "amazon_linux_2023" {
     name   = "virtualization-type"
     values = ["hvm"]
   }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
 }
 
 resource "aws_iam_role" "bastion" {
@@ -51,7 +56,7 @@ resource "aws_security_group" "bastion" {
     to_port     = 443
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
-    description = "SSM agent, ECR, EKS API via VPC endpoints"
+    description = "HTTPS only - SSM, EKS API, ECR/S3 via VPC endpoints, and cloning 3proxy from GitHub at boot"
   }
 
   tags = merge(var.common_tags, { Name = "${var.cluster_name}-bastion" })
@@ -65,46 +70,16 @@ resource "aws_instance" "bastion" {
   vpc_security_group_ids      = [aws_security_group.bastion.id]
   associate_public_ip_address = false
 
-  # 3proxy built from source — avoids any repo availability uncertainty on AL2023.
-  # Listens on 127.0.0.1:1080 — exposed to the laptop via SSM port forwarding.
-  user_data_base64 = base64encode(<<-EOF
-    #!/bin/bash
-    set -euo pipefail
+  # The bastion is a dumb SOCKS5 relay — operators tunnel through it via SSM
+  # port-forwarding and authenticate to EKS using their local AWS credentials.
+  # Do not run kubectl or AWS CLI on the bastion itself.
+  user_data_base64 = base64encode(templatefile("${path.module}/scripts/bastion-init.sh", {}))
 
-    yum install -y git gcc make
-
-    git clone --depth 1 https://github.com/3proxy/3proxy.git /opt/3proxy
-    cd /opt/3proxy && make -f Makefile.Linux
-    install -m 755 bin/3proxy /usr/local/bin/3proxy
-
-    mkdir -p /etc/3proxy /var/log/3proxy
-
-    cat > /etc/3proxy/3proxy.cfg << 'CONF'
-nscache 65536
-log /var/log/3proxy/3proxy.log D
-logformat "- +_L%t.%.  %N.%p %E %U %C:%c %R:%r %O %I %h %T"
-socks -p1080 -i127.0.0.1
-CONF
-
-    cat > /etc/systemd/system/3proxy.service << 'UNIT'
-[Unit]
-Description=3proxy SOCKS5 proxy
-After=network.target
-
-[Service]
-ExecStart=/usr/local/bin/3proxy /etc/3proxy/3proxy.cfg
-Restart=always
-RestartSec=5
-
-[Install]
-WantedBy=multi-user.target
-UNIT
-
-    systemctl daemon-reload
-    systemctl enable 3proxy
-    systemctl start 3proxy
-  EOF
-  )
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 1
+  }
 
   tags = merge(var.common_tags, { Name = "${var.cluster_name}-bastion" })
 }

--- a/terraform/eks-demo/outputs.tf
+++ b/terraform/eks-demo/outputs.tf
@@ -42,3 +42,8 @@ output "private_subnets" {
   description = "Private subnet IDs — used by bastion and load balancer controller"
   value       = module.vpc.private_subnets
 }
+
+output "bastion_instance_id" {
+  description = "SSM target ID — use with: aws ssm start-session --target <id>"
+  value       = aws_instance.bastion.id
+}

--- a/terraform/eks-demo/scripts/bastion-init.sh
+++ b/terraform/eks-demo/scripts/bastion-init.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -euo pipefail
+
+# Build 3proxy from source — avoids AL2023 package repo uncertainty.
+# Pinned to a specific release tag for reproducibility.
+PROXY_VERSION="0.9.6"
+
+yum install -y git gcc make
+
+git clone --depth 1 --branch "$PROXY_VERSION" \
+  https://github.com/3proxy/3proxy.git /opt/3proxy
+
+cd /opt/3proxy && make -f Makefile.Linux
+
+# Fail loudly if the build didn't produce the expected binary
+test -f bin/3proxy || { echo "ERROR: 3proxy build failed — binary not found" >&2; exit 1; }
+
+install -m 755 bin/3proxy /usr/local/bin/3proxy
+
+mkdir -p /etc/3proxy /var/log/3proxy
+
+cat > /etc/3proxy/3proxy.cfg << 'CONF'
+nscache 65536
+# Explicit no-auth — proxy is bound to 127.0.0.1 only (SSM port-forward).
+# auth none is required for ACL directives to function correctly.
+auth none
+log /var/log/3proxy/3proxy.log D
+logformat "- +_L%t.%.  %N.%p %E %U %C:%c %R:%r %O %I %h %T"
+socks -p1080 -i127.0.0.1
+CONF
+
+cat > /etc/systemd/system/3proxy.service << 'UNIT'
+[Unit]
+Description=3proxy SOCKS5 proxy
+After=network.target
+
+[Service]
+ExecStart=/usr/local/bin/3proxy /etc/3proxy/3proxy.cfg
+Restart=on-failure
+RestartSec=5
+LimitNOFILE=65536
+LimitNPROC=32768
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+systemctl daemon-reload
+systemctl enable 3proxy
+systemctl start 3proxy

--- a/terraform/eks-demo/terraform.tfvars.example
+++ b/terraform/eks-demo/terraform.tfvars.example
@@ -1,0 +1,10 @@
+aws_region         = "us-east-1"
+cluster_name       = "eks-demo"
+kubernetes_version = "1.32"
+platform_zone_id   = "<output from dns-bootstrap: platform_zone_id>"
+platform_domain    = "platform.dspdemos.com"
+vpc_cidr           = "10.0.0.0/16"
+node_instance_type = "t3.xlarge"
+node_desired_size  = 2
+node_min_size      = 2
+node_max_size      = 5


### PR DESCRIPTION
## Summary

- Adds `terraform/eks-demo/bastion.tf`: AL2023 EC2 in private subnet, no public IP, SSM Session Manager access only
- 3proxy built from source at boot (`github.com/3proxy/3proxy`) — avoids AL2023 package repo uncertainty
- SOCKS5 listener on `127.0.0.1:1080`, exposed to local machine via SSM port forwarding
- Adds `bastion_instance_id` output to `outputs.tf` for use in SSM session commands
- Adds `terraform.tfvars.example` for operator reference

## Usage after apply

```bash
# 1. Start SSM port-forward tunnel (laptop → bastion:1080)
aws ssm start-session \
  --target $(terraform -chdir=terraform/eks-demo output -raw bastion_instance_id) \
  --document-name AWS-StartPortForwardingSession \
  --parameters '{"portNumber":["1080"],"localPortNumber":["1080"]}' \
  --region us-east-1

# 2. In a second terminal — configure kubeconfig and proxy kubectl through the tunnel
aws eks update-kubeconfig --name eks-demo --region us-east-1
export HTTPS_PROXY=socks5://localhost:1080
kubectl get nodes
```

## Test plan

- [ ] `terraform plan` shows bastion instance, IAM role, instance profile, security group
- [ ] `terraform apply` completes successfully
- [ ] Instance appears in SSM Fleet Manager as managed (SSM agent registered)
- [ ] SSM port-forward session starts without error
- [ ] `kubectl get nodes` returns 2 Ready nodes through the SOCKS5 tunnel

Closes #180
Part of #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)