### PR TITLE
fix: ignore Divvy compliance tags in eks-demo Terraform provider

### DIFF
--- a/terraform/eks-demo/main.tf
+++ b/terraform/eks-demo/main.tf
@@ -28,6 +28,10 @@ provider "aws" {
   default_tags {
     tags = local.mandatory_tags
   }
+  # Ignore tags added by Confluent's Divvy compliance scanner — managed externally
+  ignore_tags {
+    key_prefixes = ["divvy"]
+  }
 }
 
 data "aws_availability_zones" "available" {


### PR DESCRIPTION
## Summary

- Adds `ignore_tags { key_prefixes = ["divvy"] }` to the AWS provider in `terraform/eks-demo/main.tf`
- Confluent's Divvy compliance scanner adds `divvy_owner` and `divvy_last_modified_by` tags to resources out-of-band (outside Terraform)
- Without this, every `terraform plan` shows spurious tag removals across all EKS, VPC, subnet, security group, and IAM resources — 15 unwanted changes per plan

## Why provider-level vs resource-level

Provider-level `ignore_tags` covers all AWS resources in this root module with a single directive. Resource-level `lifecycle { ignore_changes }` would require duplicating the block across every resource and every module call, which is unmanageable.

## Test plan

- [ ] `terraform plan` no longer shows `divvy_*` tag removals on existing resources
- [ ] New resources created by this plan do not have `divvy_*` tags added by Terraform (Divvy adds them independently)

Part of #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)