### PR TITLE
fix: replace em dash in bastion security group description

### DIFF
--- a/terraform/eks-demo/bastion.tf
+++ b/terraform/eks-demo/bastion.tf
@@ -46,7 +46,7 @@ resource "aws_iam_instance_profile" "bastion" {
 
 resource "aws_security_group" "bastion" {
   name        = "${var.cluster_name}-bastion"
-  description = "Bastion host — no inbound, SSM outbound only"
+  description = "Bastion host - no inbound, SSM outbound only"
   vpc_id      = module.vpc.vpc_id
 
   # No inbound rules — all access via SSM Session Manager, no SSH


### PR DESCRIPTION
## Summary

- Replaces em dash (`—`) with ASCII dash (`-`) in `aws_security_group.bastion` description
- AWS EC2 rejects non-ASCII characters in security group `GroupDescription` with `InvalidParameterValue`

Part of #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)