### PR TITLE
fix: allow bastion SG to reach private EKS API endpoint

### DIFF
--- a/terraform/eks-demo/eks.tf
+++ b/terraform/eks-demo/eks.tf
@@ -62,3 +62,16 @@ module "eks" {
 
   tags = var.common_tags
 }
+
+# Allow the bastion's SOCKS5 proxy to reach the private EKS API endpoint.
+# Without this rule the cluster security group silently drops the traffic,
+# and kubectl through the tunnel gets "connection refused" from 3proxy.
+resource "aws_security_group_rule" "bastion_to_eks_api" {
+  type                     = "ingress"
+  from_port                = 443
+  to_port                  = 443
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.bastion.id
+  security_group_id        = module.eks.cluster_security_group_id
+  description              = "Bastion SOCKS5 proxy to EKS API"
+}


### PR DESCRIPTION
## Summary

Adds an ingress rule to the EKS cluster security group allowing TCP/443 from the bastion security group.

Without this rule, 3proxy on the bastion cannot make outbound connections to the private EKS API endpoint. kubectl through the SOCKS5 tunnel returns `socks connect ... connection refused` even when the SSM port-forward is working correctly.

## Root cause

The EKS cluster security group controls access to the private API endpoint ENIs. The module's default rules allow node-to-API traffic but not arbitrary VPC instances. The bastion needs an explicit ingress grant.

## Test plan

- [ ] `terraform apply` adds one security group rule
- [ ] `kubectl get nodes` succeeds through SOCKS5 tunnel after apply

Part of #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)