### PR TITLE
feat: add IRSA IAM roles for EKS add-ons and controllers

### DIFF
--- a/terraform/eks-demo/aws-lb-controller-iam-policy.json
+++ b/terraform/eks-demo/aws-lb-controller-iam-policy.json
@@ -1,0 +1,251 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "iam:CreateServiceLinkedRole"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "StringEquals": {
+                    "iam:AWSServiceName": "elasticloadbalancing.amazonaws.com"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DescribeAccountAttributes",
+                "ec2:DescribeAddresses",
+                "ec2:DescribeAvailabilityZones",
+                "ec2:DescribeInternetGateways",
+                "ec2:DescribeVpcs",
+                "ec2:DescribeVpcPeeringConnections",
+                "ec2:DescribeSubnets",
+                "ec2:DescribeSecurityGroups",
+                "ec2:DescribeInstances",
+                "ec2:DescribeNetworkInterfaces",
+                "ec2:DescribeTags",
+                "ec2:GetCoipPoolUsage",
+                "ec2:DescribeCoipPools",
+                "ec2:GetSecurityGroupsForVpc",
+                "ec2:DescribeIpamPools",
+                "ec2:DescribeRouteTables",
+                "elasticloadbalancing:DescribeLoadBalancers",
+                "elasticloadbalancing:DescribeLoadBalancerAttributes",
+                "elasticloadbalancing:DescribeListeners",
+                "elasticloadbalancing:DescribeListenerCertificates",
+                "elasticloadbalancing:DescribeSSLPolicies",
+                "elasticloadbalancing:DescribeRules",
+                "elasticloadbalancing:DescribeTargetGroups",
+                "elasticloadbalancing:DescribeTargetGroupAttributes",
+                "elasticloadbalancing:DescribeTargetHealth",
+                "elasticloadbalancing:DescribeTags",
+                "elasticloadbalancing:DescribeTrustStores",
+                "elasticloadbalancing:DescribeListenerAttributes",
+                "elasticloadbalancing:DescribeCapacityReservation"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "cognito-idp:DescribeUserPoolClient",
+                "acm:ListCertificates",
+                "acm:DescribeCertificate",
+                "iam:ListServerCertificates",
+                "iam:GetServerCertificate",
+                "waf-regional:GetWebACL",
+                "waf-regional:GetWebACLForResource",
+                "waf-regional:AssociateWebACL",
+                "waf-regional:DisassociateWebACL",
+                "wafv2:GetWebACL",
+                "wafv2:GetWebACLForResource",
+                "wafv2:AssociateWebACL",
+                "wafv2:DisassociateWebACL",
+                "shield:GetSubscriptionState",
+                "shield:DescribeProtection",
+                "shield:CreateProtection",
+                "shield:DeleteProtection"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:AuthorizeSecurityGroupIngress",
+                "ec2:RevokeSecurityGroupIngress"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:CreateSecurityGroup"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:CreateTags"
+            ],
+            "Resource": "arn:aws:ec2:*:*:security-group/*",
+            "Condition": {
+                "StringEquals": {
+                    "ec2:CreateAction": "CreateSecurityGroup"
+                },
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:CreateTags",
+                "ec2:DeleteTags"
+            ],
+            "Resource": "arn:aws:ec2:*:*:security-group/*",
+            "Condition": {
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:AuthorizeSecurityGroupIngress",
+                "ec2:RevokeSecurityGroupIngress",
+                "ec2:DeleteSecurityGroup"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "Null": {
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:CreateLoadBalancer",
+                "elasticloadbalancing:CreateTargetGroup"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:CreateListener",
+                "elasticloadbalancing:DeleteListener",
+                "elasticloadbalancing:CreateRule",
+                "elasticloadbalancing:DeleteRule"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:AddTags",
+                "elasticloadbalancing:RemoveTags"
+            ],
+            "Resource": [
+                "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+                "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+                "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+            ],
+            "Condition": {
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:AddTags",
+                "elasticloadbalancing:RemoveTags"
+            ],
+            "Resource": [
+                "arn:aws:elasticloadbalancing:*:*:listener/net/*/*/*",
+                "arn:aws:elasticloadbalancing:*:*:listener/app/*/*/*",
+                "arn:aws:elasticloadbalancing:*:*:listener-rule/net/*/*/*",
+                "arn:aws:elasticloadbalancing:*:*:listener-rule/app/*/*/*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:ModifyLoadBalancerAttributes",
+                "elasticloadbalancing:SetIpAddressType",
+                "elasticloadbalancing:SetSecurityGroups",
+                "elasticloadbalancing:SetSubnets",
+                "elasticloadbalancing:DeleteLoadBalancer",
+                "elasticloadbalancing:ModifyTargetGroup",
+                "elasticloadbalancing:ModifyTargetGroupAttributes",
+                "elasticloadbalancing:DeleteTargetGroup",
+                "elasticloadbalancing:ModifyListenerAttributes",
+                "elasticloadbalancing:ModifyCapacityReservation",
+                "elasticloadbalancing:ModifyIpPools"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "Null": {
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:AddTags"
+            ],
+            "Resource": [
+                "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+                "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+                "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+            ],
+            "Condition": {
+                "StringEquals": {
+                    "elasticloadbalancing:CreateAction": [
+                        "CreateTargetGroup",
+                        "CreateLoadBalancer"
+                    ]
+                },
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:RegisterTargets",
+                "elasticloadbalancing:DeregisterTargets"
+            ],
+            "Resource": "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:SetWebAcl",
+                "elasticloadbalancing:ModifyListener",
+                "elasticloadbalancing:AddListenerCertificates",
+                "elasticloadbalancing:RemoveListenerCertificates",
+                "elasticloadbalancing:ModifyRule",
+                "elasticloadbalancing:SetRulePriorities"
+            ],
+            "Resource": "*"
+        }
+    ]
+}

--- a/terraform/eks-demo/iam.tf
+++ b/terraform/eks-demo/iam.tf
@@ -5,23 +5,19 @@ locals {
 }
 
 # ── EBS CSI Driver ────────────────────────────────────────────────────────────
+# The driver itself is installed via ArgoCD in Task 10 (Issue #185) —
+# infrastructure/aws-ebs-csi-driver with a Kustomize overlay that annotates
+# the ServiceAccount with this role ARN. It is not a managed EKS addon.
 
 resource "aws_iam_role" "ebs_csi_driver" {
-  name = "AmazonEKS_EBS_CSI_DriverRole_${var.cluster_name}"
+  name        = "AmazonEKS_EBS_CSI_DriverRole_${var.cluster_name}"
+  description = "IRSA role for the EBS CSI Driver controller (kube-system/ebs-csi-controller-sa)"
 
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Effect    = "Allow"
-      Action    = "sts:AssumeRoleWithWebIdentity"
-      Principal = { Federated = local.oidc_provider_arn }
-      Condition = {
-        StringEquals = {
-          "${local.oidc_provider}:sub" = "system:serviceaccount:kube-system:ebs-csi-controller-sa"
-          "${local.oidc_provider}:aud" = "sts.amazonaws.com"
-        }
-      }
-    }]
+  assume_role_policy = templatefile("${path.module}/trust-policy.tpl", {
+    oidc_provider_arn = local.oidc_provider_arn
+    oidc_provider     = local.oidc_provider
+    namespace         = "kube-system"
+    sa_name           = "ebs-csi-controller-sa"
   })
 
   tags = var.common_tags
@@ -35,21 +31,14 @@ resource "aws_iam_role_policy_attachment" "ebs_csi_driver" {
 # ── cert-manager (DNS-01 via Route53) ─────────────────────────────────────────
 
 resource "aws_iam_role" "cert_manager" {
-  name = "AmazonEKS_CertManager_${var.cluster_name}"
+  name        = "AmazonEKS_CertManager_${var.cluster_name}"
+  description = "IRSA role for cert-manager DNS-01 Route53 validation (cert-manager/cert-manager)"
 
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Effect    = "Allow"
-      Action    = "sts:AssumeRoleWithWebIdentity"
-      Principal = { Federated = local.oidc_provider_arn }
-      Condition = {
-        StringEquals = {
-          "${local.oidc_provider}:sub" = "system:serviceaccount:cert-manager:cert-manager"
-          "${local.oidc_provider}:aud" = "sts.amazonaws.com"
-        }
-      }
-    }]
+  assume_role_policy = templatefile("${path.module}/trust-policy.tpl", {
+    oidc_provider_arn = local.oidc_provider_arn
+    oidc_provider     = local.oidc_provider
+    namespace         = "cert-manager"
+    sa_name           = "cert-manager"
   })
 
   tags = var.common_tags
@@ -84,21 +73,14 @@ resource "aws_iam_role_policy" "cert_manager" {
 # ── ExternalDNS ───────────────────────────────────────────────────────────────
 
 resource "aws_iam_role" "external_dns" {
-  name = "ExternalDNS_${var.cluster_name}"
+  name        = "ExternalDNS_${var.cluster_name}"
+  description = "IRSA role for ExternalDNS Route53 record management (external-dns/external-dns)"
 
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Effect    = "Allow"
-      Action    = "sts:AssumeRoleWithWebIdentity"
-      Principal = { Federated = local.oidc_provider_arn }
-      Condition = {
-        StringEquals = {
-          "${local.oidc_provider}:sub" = "system:serviceaccount:external-dns:external-dns"
-          "${local.oidc_provider}:aud" = "sts.amazonaws.com"
-        }
-      }
-    }]
+  assume_role_policy = templatefile("${path.module}/trust-policy.tpl", {
+    oidc_provider_arn = local.oidc_provider_arn
+    oidc_provider     = local.oidc_provider
+    namespace         = "external-dns"
+    sa_name           = "external-dns"
   })
 
   tags = var.common_tags
@@ -127,31 +109,18 @@ resource "aws_iam_role_policy" "external_dns" {
 
 # ── AWS Load Balancer Controller ──────────────────────────────────────────────
 
-data "aws_iam_policy_document" "aws_lb_controller_trust" {
-  statement {
-    effect  = "Allow"
-    actions = ["sts:AssumeRoleWithWebIdentity"]
-    principals {
-      type        = "Federated"
-      identifiers = [local.oidc_provider_arn]
-    }
-    condition {
-      test     = "StringEquals"
-      variable = "${local.oidc_provider}:sub"
-      values   = ["system:serviceaccount:kube-system:aws-load-balancer-controller"]
-    }
-    condition {
-      test     = "StringEquals"
-      variable = "${local.oidc_provider}:aud"
-      values   = ["sts.amazonaws.com"]
-    }
-  }
-}
-
 resource "aws_iam_role" "aws_lb_controller" {
-  name               = "AWSLoadBalancerController_${var.cluster_name}"
-  assume_role_policy = data.aws_iam_policy_document.aws_lb_controller_trust.json
-  tags               = var.common_tags
+  name        = "AWSLoadBalancerController_${var.cluster_name}"
+  description = "IRSA role for the AWS Load Balancer Controller (kube-system/aws-load-balancer-controller)"
+
+  assume_role_policy = templatefile("${path.module}/trust-policy.tpl", {
+    oidc_provider_arn = local.oidc_provider_arn
+    oidc_provider     = local.oidc_provider
+    namespace         = "kube-system"
+    sa_name           = "aws-load-balancer-controller"
+  })
+
+  tags = var.common_tags
 }
 
 resource "aws_iam_policy" "aws_lb_controller" {

--- a/terraform/eks-demo/iam.tf
+++ b/terraform/eks-demo/iam.tf
@@ -8,6 +8,9 @@ locals {
 # The driver itself is installed via ArgoCD in Task 10 (Issue #185) —
 # infrastructure/aws-ebs-csi-driver with a Kustomize overlay that annotates
 # the ServiceAccount with this role ARN. It is not a managed EKS addon.
+# sa_name must match controller.serviceAccount.name in the Helm values for
+# infrastructure/aws-ebs-csi-driver/overlays/eks-demo — changing it there
+# without updating this trust policy will silently break IRSA.
 
 resource "aws_iam_role" "ebs_csi_driver" {
   name        = "AmazonEKS_EBS_CSI_DriverRole_${var.cluster_name}"
@@ -100,7 +103,7 @@ resource "aws_iam_role_policy" "external_dns" {
       },
       {
         Effect   = "Allow"
-        Action   = ["route53:ListHostedZones", "route53:ListResourceRecordSets", "route53:ListTagsForResource"]
+        Action   = ["route53:ListHostedZones", "route53:ListHostedZonesByName", "route53:ListResourceRecordSets", "route53:ListTagsForResource"]
         Resource = ["*"]
       }
     ]
@@ -124,7 +127,10 @@ resource "aws_iam_role" "aws_lb_controller" {
 }
 
 resource "aws_iam_policy" "aws_lb_controller" {
-  name   = "AWSLoadBalancerControllerIAMPolicy_${var.cluster_name}"
+  name        = "AWSLoadBalancerControllerIAMPolicy_${var.cluster_name}"
+  description = "IAM permissions for the AWS Load Balancer Controller — sourced from kubernetes-sigs/aws-load-balancer-controller"
+  # Update aws-lb-controller-iam-policy.json when upgrading the controller Helm chart version;
+  # the policy changes across minor releases.
   policy = file("${path.module}/aws-lb-controller-iam-policy.json")
   tags   = var.common_tags
 }

--- a/terraform/eks-demo/iam.tf
+++ b/terraform/eks-demo/iam.tf
@@ -1,0 +1,166 @@
+locals {
+  oidc_provider_arn = module.eks.oidc_provider_arn
+  # Strip https:// prefix — used as the condition key in IRSA trust policies
+  oidc_provider = replace(module.eks.cluster_oidc_issuer_url, "https://", "")
+}
+
+# ── EBS CSI Driver ────────────────────────────────────────────────────────────
+
+resource "aws_iam_role" "ebs_csi_driver" {
+  name = "AmazonEKS_EBS_CSI_DriverRole_${var.cluster_name}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Action    = "sts:AssumeRoleWithWebIdentity"
+      Principal = { Federated = local.oidc_provider_arn }
+      Condition = {
+        StringEquals = {
+          "${local.oidc_provider}:sub" = "system:serviceaccount:kube-system:ebs-csi-controller-sa"
+          "${local.oidc_provider}:aud" = "sts.amazonaws.com"
+        }
+      }
+    }]
+  })
+
+  tags = var.common_tags
+}
+
+resource "aws_iam_role_policy_attachment" "ebs_csi_driver" {
+  role       = aws_iam_role.ebs_csi_driver.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
+}
+
+# ── cert-manager (DNS-01 via Route53) ─────────────────────────────────────────
+
+resource "aws_iam_role" "cert_manager" {
+  name = "AmazonEKS_CertManager_${var.cluster_name}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Action    = "sts:AssumeRoleWithWebIdentity"
+      Principal = { Federated = local.oidc_provider_arn }
+      Condition = {
+        StringEquals = {
+          "${local.oidc_provider}:sub" = "system:serviceaccount:cert-manager:cert-manager"
+          "${local.oidc_provider}:aud" = "sts.amazonaws.com"
+        }
+      }
+    }]
+  })
+
+  tags = var.common_tags
+}
+
+resource "aws_iam_role_policy" "cert_manager" {
+  name = "cert-manager-route53"
+  role = aws_iam_role.cert_manager.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["route53:GetChange"]
+        Resource = ["arn:aws:route53:::change/*"]
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["route53:ChangeResourceRecordSets", "route53:ListResourceRecordSets"]
+        Resource = ["arn:aws:route53:::hostedzone/${var.platform_zone_id}"]
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["route53:ListHostedZonesByName"]
+        Resource = ["*"]
+      }
+    ]
+  })
+}
+
+# ── ExternalDNS ───────────────────────────────────────────────────────────────
+
+resource "aws_iam_role" "external_dns" {
+  name = "ExternalDNS_${var.cluster_name}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Action    = "sts:AssumeRoleWithWebIdentity"
+      Principal = { Federated = local.oidc_provider_arn }
+      Condition = {
+        StringEquals = {
+          "${local.oidc_provider}:sub" = "system:serviceaccount:external-dns:external-dns"
+          "${local.oidc_provider}:aud" = "sts.amazonaws.com"
+        }
+      }
+    }]
+  })
+
+  tags = var.common_tags
+}
+
+resource "aws_iam_role_policy" "external_dns" {
+  name = "external-dns-route53"
+  role = aws_iam_role.external_dns.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["route53:ChangeResourceRecordSets"]
+        Resource = ["arn:aws:route53:::hostedzone/${var.platform_zone_id}"]
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["route53:ListHostedZones", "route53:ListResourceRecordSets", "route53:ListTagsForResource"]
+        Resource = ["*"]
+      }
+    ]
+  })
+}
+
+# ── AWS Load Balancer Controller ──────────────────────────────────────────────
+
+data "aws_iam_policy_document" "aws_lb_controller_trust" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    principals {
+      type        = "Federated"
+      identifiers = [local.oidc_provider_arn]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "${local.oidc_provider}:sub"
+      values   = ["system:serviceaccount:kube-system:aws-load-balancer-controller"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "${local.oidc_provider}:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "aws_lb_controller" {
+  name               = "AWSLoadBalancerController_${var.cluster_name}"
+  assume_role_policy = data.aws_iam_policy_document.aws_lb_controller_trust.json
+  tags               = var.common_tags
+}
+
+resource "aws_iam_policy" "aws_lb_controller" {
+  name   = "AWSLoadBalancerControllerIAMPolicy_${var.cluster_name}"
+  policy = file("${path.module}/aws-lb-controller-iam-policy.json")
+  tags   = var.common_tags
+}
+
+resource "aws_iam_role_policy_attachment" "aws_lb_controller" {
+  role       = aws_iam_role.aws_lb_controller.name
+  policy_arn = aws_iam_policy.aws_lb_controller.arn
+}

--- a/terraform/eks-demo/outputs.tf
+++ b/terraform/eks-demo/outputs.tf
@@ -47,3 +47,23 @@ output "bastion_instance_id" {
   description = "SSM target ID — use with: aws ssm start-session --target <id>"
   value       = aws_instance.bastion.id
 }
+
+output "ebs_csi_driver_role_arn" {
+  description = "IRSA role ARN for the EBS CSI driver"
+  value       = aws_iam_role.ebs_csi_driver.arn
+}
+
+output "cert_manager_role_arn" {
+  description = "IRSA role ARN for cert-manager"
+  value       = aws_iam_role.cert_manager.arn
+}
+
+output "external_dns_role_arn" {
+  description = "IRSA role ARN for ExternalDNS"
+  value       = aws_iam_role.external_dns.arn
+}
+
+output "aws_lb_controller_role_arn" {
+  description = "IRSA role ARN for the AWS Load Balancer Controller"
+  value       = aws_iam_role.aws_lb_controller.arn
+}

--- a/terraform/eks-demo/trust-policy.tpl
+++ b/terraform/eks-demo/trust-policy.tpl
@@ -1,0 +1,16 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": "sts:AssumeRoleWithWebIdentity",
+    "Principal": {
+      "Federated": "${oidc_provider_arn}"
+    },
+    "Condition": {
+      "StringEquals": {
+        "${oidc_provider}:sub": "system:serviceaccount:${namespace}:${sa_name}",
+        "${oidc_provider}:aud": "sts.amazonaws.com"
+      }
+    }
+  }]
+}


### PR DESCRIPTION
## Summary

- Adds `iam.tf` with IRSA IAM roles for EBS CSI Driver, cert-manager, ExternalDNS, and AWS Load Balancer Controller
- Adds `aws-lb-controller-iam-policy.json` (official policy from kubernetes-sigs/aws-load-balancer-controller)
- Extends `outputs.tf` with role ARNs needed for downstream Helm chart ServiceAccount annotations

## Test plan

- [ ] `terraform plan` shows no unexpected changes
- [ ] Role ARNs appear in `terraform output -json`
- [ ] IRSA trust policies correctly scope to the expected namespace/serviceaccount per role

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)