### PR TITLE
feat: add ExternalDNS and AWS LB Controller Helm repos to infrastructure AppProject

### DIFF
--- a/bootstrap/templates/argocd-projects.yaml
+++ b/bootstrap/templates/argocd-projects.yaml
@@ -21,6 +21,8 @@ spec:
     - oci://ghcr.io/traefik/helm/traefik
     - oci://quay.io/jetstack/charts/cert-manager
     - oci://quay.io/jetstack/charts/trust-manager
+    - https://kubernetes-sigs.github.io/external-dns/
+    - https://aws.github.io/eks-charts
 
   # Allow deploying to all namespaces
   destinations:


### PR DESCRIPTION
## Summary

- Adds `https://kubernetes-sigs.github.io/external-dns/` to the `infrastructure` AppProject `sourceRepos` list
- Adds `https://aws.github.io/eks-charts` to the `infrastructure` AppProject `sourceRepos` list

These repos are required for the ExternalDNS and AWS Load Balancer Controller ArgoCD Applications being added as part of the eks-demo cluster build-out.

Closes #183

## Test plan

- [ ] Verify `bootstrap/templates/argocd-projects.yaml` renders correctly via Helm template
- [ ] Confirm ArgoCD can source ExternalDNS and AWS LB Controller charts after bootstrap is applied to eks-demo cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)