### PR TITLE
feat: scaffold eks-demo cluster directory

### DIFF
--- a/clusters/eks-demo/README.md
+++ b/clusters/eks-demo/README.md
@@ -1,0 +1,290 @@
+# eks-demo Cluster
+
+
+
+## Overview
+
+The `eks-demo` cluster provides:
+
+- **Kafka Cluster**: 
+- **Flink Integration**: 
+- **Monitoring**: Prometheus, Grafana, and Alertmanager with pre-configured dashboards
+- **Security**: 
+- **Networking**: Traefik ingress controller with local DNS resolution
+
+**Domain**: `*.eks-demo.platform.dspdemos.com`
+
+## Getting Started
+
+> [!TIP]
+> **New to this repository?** Start with the [Getting Started for the Uninitiated](../../docs/getting-started-for-the-uninitiated.md) guide for complete step-by-step setup instructions including:
+> - Prerequisites and tool installation
+> - DNS configuration (`/etc/hosts` setup with IPv6 timeout workaround)
+> - Cluster creation and ArgoCD installation
+> - Bootstrap and initial deployment
+> - Accessing ArgoCD UI
+
+### Deploy Bootstrap
+
+```bash
+kubectl apply -f clusters/eks-demo/bootstrap.yaml
+```
+
+### Verify Deployment
+
+```bash
+# Check bootstrap application
+kubectl get application bootstrap -n argocd
+
+# Check all applications
+kubectl get applications -n argocd
+
+# Watch sync progress
+kubectl get applications -n argocd -w
+```
+
+### Manual Sync Applications
+
+<!-- Customize this section for applications that require manual sync in this cluster -->
+
+Some applications require manual sync to ensure operators and namespaces are fully ready.
+
+**Wait for operators to be healthy:**
+
+```bash
+# Check CFK operator
+kubectl wait --namespace operator --for=condition=Ready pods -l app=confluent-operator --timeout=300s
+
+# Check CMF operator
+kubectl wait --namespace operator --for=condition=Ready pods -l app.kubernetes.io/name=confluent-for-apache-flink --timeout=300s
+
+# Check Flink Kubernetes Operator
+kubectl wait --namespace operator --for=condition=Ready pods -l app.kubernetes.io/name=flink-kubernetes-operator --timeout=300s
+```
+
+**Sync confluent-resources:**
+
+In the ArgoCD UI:
+1. Click on `confluent-resources` Application
+2. Click **Sync** → **Synchronize**
+3. Wait for `Healthy` status (~5-10 minutes)
+
+**Sync flink-resources:**
+
+In the ArgoCD UI:
+1. Click on `flink-resources` Application
+2. Click **Sync** → **Synchronize**
+3. Wait for `Healthy` status (~2-3 minutes)
+
+<!-- Add any additional manual sync steps specific to this cluster -->
+
+## Applications
+
+### Infrastructure Applications
+
+Infrastructure applications are defined in `infrastructure/kustomization.yaml`:
+
+<!-- Update this list to match the actual applications in this cluster -->
+
+- **kube-prometheus-stack-crds** (wave 2) - Prometheus Operator CRDs
+- **metrics-server** (wave 5) - Kubernetes Metrics Server
+- **traefik** (wave 10) - Ingress controller
+- **cert-manager** (wave 20) - TLS certificate management
+- **kube-prometheus-stack** (wave 20) - Monitoring stack (Prometheus, Grafana, Alertmanager)
+- **trust-manager** (wave 30) - CA certificate distribution
+- **vault** (wave 40) - HashiCorp Vault (dev mode)
+- **vault-config** (wave 50) - Vault transit engine configuration
+- **cert-manager-resources** (wave 75) - ClusterIssuer and certificates
+- **argocd-ingress** (wave 80) - Traefik IngressRoute for ArgoCD UI
+- **argocd-config** (wave 85) - ArgoCD ConfigMap patches for custom health checks
+
+### Workload Applications
+
+Workload applications are defined in `workloads/kustomization.yaml`:
+
+<!-- Update this list to match the actual applications in this cluster -->
+
+- **namespaces** (wave 100) - Namespace definitions
+- **cfk-operator** (wave 105) - Confluent for Kubernetes operator
+- **confluent-resources** (wave 110) - Confluent Platform (KRaft, Kafka, Schema Registry, etc.)
+- **controlcenter-ingress** (wave 115) - Traefik IngressRoute for Control Center UI
+- **flink-kubernetes-operator** (wave 116) - Flink Kubernetes Operator
+- **observability-resources** (wave 117) - PodMonitors and Grafana dashboards
+- **cmf-operator** (wave 118) - Confluent Manager for Apache Flink
+- **flink-resources** (wave 120) - Flink integration resources
+
+## Environment Access
+
+### DNS Configuration
+
+Add these entries to `/etc/hosts`:
+
+```
+127.0.0.1  alertmanager.eks-demo.platform.dspdemos.com
+127.0.0.1  argocd.eks-demo.platform.dspdemos.com
+127.0.0.1  cmf.eks-demo.platform.dspdemos.com
+127.0.0.1  controlcenter.eks-demo.platform.dspdemos.com
+127.0.0.1  grafana.eks-demo.platform.dspdemos.com
+127.0.0.1  kafka.eks-demo.platform.dspdemos.com
+127.0.0.1  prometheus.eks-demo.platform.dspdemos.com
+127.0.0.1  schemaregistry.eks-demo.platform.dspdemos.com
+127.0.0.1  vault.eks-demo.platform.dspdemos.com
+```
+
+> [!WARNING]
+> If you experience ~5-second timeouts when accessing services, add IPv6 entries as well:
+> ```
+> ::1  alertmanager.eks-demo.platform.dspdemos.com
+> ::1  argocd.eks-demo.platform.dspdemos.com
+> ::1  cmf.eks-demo.platform.dspdemos.com
+> ::1  controlcenter.eks-demo.platform.dspdemos.com
+> ::1  grafana.eks-demo.platform.dspdemos.com
+> ::1  kafka.eks-demo.platform.dspdemos.com
+> ::1  prometheus.eks-demo.platform.dspdemos.com
+> ::1  schemaregistry.eks-demo.platform.dspdemos.com
+> ::1  vault.eks-demo.platform.dspdemos.com
+> ```
+
+### Services
+
+<!-- Customize URLs and credentials for this cluster's services -->
+
+**ArgoCD UI:**
+- **URL**: https://argocd.eks-demo.platform.dspdemos.com
+- **Username**: `admin`
+- **Password**: `kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath="{.data.password}" | base64 -d`
+
+**Control Center:**
+- **URL**: https://controlcenter.eks-demo.platform.dspdemos.com
+
+**Grafana:**
+- **URL**: http://grafana.eks-demo.platform.dspdemos.com
+- **Username**: `admin`
+- **Password**: `prom-operator`
+
+**Prometheus:**
+- **URL**: http://prometheus.eks-demo.platform.dspdemos.com
+
+**Alertmanager:**
+- **URL**: http://alertmanager.eks-demo.platform.dspdemos.com
+
+**Vault** (dev mode):
+- **URL**: http://vault.eks-demo.platform.dspdemos.com
+- **Token**: `root`
+- **Warning**: Dev mode - data is not persisted across restarts
+
+**CMF API:**
+- **URL**: http://cmf.eks-demo.platform.dspdemos.com
+
+<!-- Add any additional services or port-forwarding fallbacks specific to this cluster -->
+
+## Cluster Specific Use Cases
+
+<!--
+Document anything unique to this cluster that doesn't fit the standard template.
+Examples:
+- RBAC naming conventions and permission model
+- Pre-created topics, schemas, or Flink resources
+- Special authentication flows (e.g., Keycloak SSO, MDS device-grant)
+- Token lifecycle management
+- Demo/sandbox environments (e.g., CP Flink SQL Sandbox)
+
+Remove this comment block and replace with cluster-specific content.
+If this cluster has no unique use cases, remove this section entirely.
+-->
+
+## Troubleshooting
+
+### ArgoCD Applications Not Syncing
+
+Check parent Application health:
+
+```bash
+kubectl get application infrastructure-apps --namespace argocd -o yaml
+kubectl get application workloads-apps --namespace argocd -o yaml
+```
+
+Verify Application manifests exist:
+
+```bash
+ls -la ./clusters/eks-demo/infrastructure/
+ls -la ./clusters/eks-demo/workloads/
+```
+
+### Pods Not Starting
+
+Check pod status and events:
+
+```bash
+kubectl get pods --namespace <namespace> --output wide
+kubectl describe pod <pod-name> --namespace <namespace>
+```
+
+Check resource availability:
+
+```bash
+kubectl top nodes
+kubectl top pods --all-namespaces
+```
+
+### Ingress Not Accessible
+
+Verify kind port mappings:
+
+```bash
+docker ps | grep eks-demo
+```
+
+Should show port mappings: `0.0.0.0:80->30080/tcp, 0.0.0.0:443->30443/tcp`
+
+Check Traefik IngressRoutes:
+
+```bash
+kubectl get ingressroute --all-namespaces
+```
+
+### Certificate Issues
+
+Check cert-manager resources:
+
+```bash
+kubectl get certificates --all-namespaces
+kubectl get certificaterequests --all-namespaces
+kubectl get clusterissuers
+```
+
+### CFK Components Not Deploying
+
+Check operator logs:
+
+```bash
+kubectl logs --namespace operator deployment/confluent-operator --tail=100
+```
+
+Verify CRDs installed:
+
+```bash
+kubectl get crd | grep platform.confluent.io
+```
+
+### Validation Script
+
+Run the comprehensive validation script:
+
+```bash
+./scripts/validate-cluster.sh eks-demo --verbose
+```
+
+## Cleanup
+
+Remove the kind cluster:
+
+```bash
+kind delete cluster --name eks-demo
+```
+
+Stop the container runtime (if using Colima):
+
+```bash
+colima stop
+```

--- a/clusters/eks-demo/README.md
+++ b/clusters/eks-demo/README.md
@@ -39,25 +39,34 @@ terraform init && terraform apply
 
 See [`terraform/eks-demo/README.md`](../../terraform/eks-demo/README.md) for full variable reference and outputs.
 
-### Step 3: Configure kubectl via bastion
+### Step 3: Configure kubectl (run locally)
+
+The EKS Kubernetes API is private — not reachable from the internet. All kubectl traffic must route through the SOCKS5 bastion tunnel. Run these commands on your local machine, not on the bastion.
 
 ```bash
-# Get the bastion instance ID
-terraform -chdir=terraform/eks-demo output bastion_instance_id
-
-# Open SSM shell on the bastion
-aws ssm start-session --region us-east-1 --target <bastion_instance_id>
-
-# On the bastion:
+# Update local kubeconfig (calls the public EKS management API — no tunnel needed)
 aws eks update-kubeconfig --region us-east-1 --name eks-demo
+
+# Start the SOCKS5 tunnel (keep this running in a separate terminal)
+aws ssm start-session \
+  --region us-east-1 \
+  --target $(terraform -chdir=terraform/eks-demo output -raw bastion_instance_id) \
+  --document-name AWS-StartPortForwardingSession \
+  --parameters '{"portNumber":["1080"],"localPortNumber":["1080"]}'
+
+# Route kubectl through the tunnel (in your working terminal)
+export HTTPS_PROXY=socks5://localhost:1080
 kubectl get nodes  # Expected: 2+ nodes in Ready state
 ```
+
+> [!TIP]
+> Add `HTTPS_PROXY=socks5://localhost:1080` to your shell profile or a `.envrc` file in this repo so it's set automatically whenever the tunnel is active.
 
 ## Getting Started
 
 ### Deploy Bootstrap
 
-From the bastion (or any host with kubectl access to the private cluster API):
+With the SOCKS5 tunnel running and `HTTPS_PROXY` set (see Prerequisites Step 3):
 
 ```bash
 kubectl apply -f clusters/eks-demo/bootstrap.yaml
@@ -139,17 +148,7 @@ All services are private — exposed only within the VPC. Access from your lapto
 
 ### SOCKS5 Proxy Setup
 
-Start an SSM port-forward session from your laptop:
-
-```bash
-aws ssm start-session \
-  --region us-east-1 \
-  --target $(terraform -chdir=terraform/eks-demo output -raw bastion_instance_id) \
-  --document-name AWS-StartPortForwardingSession \
-  --parameters '{"portNumber":["1080"],"localPortNumber":["1080"]}'
-```
-
-Configure **FoxyProxy** (or your browser proxy settings) to route `*.platform.dspdemos.com` through `socks5://localhost:1080`.
+The same SSM tunnel used for kubectl (Prerequisites Step 3) also proxies browser traffic. Once the tunnel is running on `localhost:1080`, configure **FoxyProxy** (or your browser proxy settings) to route `*.platform.dspdemos.com` through `socks5://localhost:1080`.
 
 DNS is managed automatically by ExternalDNS — no `/etc/hosts` entries are needed.
 

--- a/clusters/eks-demo/README.md
+++ b/clusters/eks-demo/README.md
@@ -1,30 +1,63 @@
 # eks-demo Cluster
 
-
-
 ## Overview
 
-The `eks-demo` cluster provides:
+The `eks-demo` cluster is a fully operational Confluent Platform + Flink deployment on AWS EKS with private-only access.
 
-- **Kafka Cluster**: 
-- **Flink Integration**: 
+- **Kafka Cluster**: KRaft-based Kafka with Schema Registry, managed by Confluent for Kubernetes (CFK)
+- **Flink Integration**: Apache Flink via Confluent Manager for Apache Flink (CMF) and Flink Kubernetes Operator
 - **Monitoring**: Prometheus, Grafana, and Alertmanager with pre-configured dashboards
-- **Security**: 
-- **Networking**: Traefik ingress controller with local DNS resolution
+- **Security**: OIDC-based RBAC via Keycloak, Let's Encrypt TLS via cert-manager (DNS-01/Route53 IRSA)
+- **Networking**: Traefik on an internal AWS NLB; wildcard DNS via ExternalDNS → Route53; private-only access via SSM+SOCKS5 bastion
 
 **Domain**: `*.eks-demo.platform.dspdemos.com`
 
+## Prerequisites
+
+All AWS infrastructure must be provisioned before deploying this cluster.
+
+### Step 1: DNS Bootstrap
+
+```bash
+cd terraform/dns-bootstrap
+cp terraform.tfvars.example terraform.tfvars
+# Edit terraform.tfvars with your root_domain and tags
+terraform init && terraform apply
+# Note the output: platform_zone_id and root_zone_name_servers
+```
+
+Set the `root_zone_name_servers` values at your domain registrar for `dspdemos.com`. This is a one-time step.
+
+### Step 2: EKS Cluster
+
+```bash
+cd terraform/eks-demo
+cp terraform.tfvars.example terraform.tfvars
+# Edit terraform.tfvars — set platform_zone_id from dns-bootstrap output
+terraform init && terraform apply
+```
+
+See [`terraform/eks-demo/README.md`](../../terraform/eks-demo/README.md) for full variable reference and outputs.
+
+### Step 3: Configure kubectl via bastion
+
+```bash
+# Get the bastion instance ID
+terraform -chdir=terraform/eks-demo output bastion_instance_id
+
+# Open SSM shell on the bastion
+aws ssm start-session --target <bastion_instance_id>
+
+# On the bastion:
+aws eks update-kubeconfig --region us-east-1 --name eks-demo
+kubectl get nodes  # Expected: 2+ nodes in Ready state
+```
+
 ## Getting Started
 
-> [!TIP]
-> **New to this repository?** Start with the [Getting Started for the Uninitiated](../../docs/getting-started-for-the-uninitiated.md) guide for complete step-by-step setup instructions including:
-> - Prerequisites and tool installation
-> - DNS configuration (`/etc/hosts` setup with IPv6 timeout workaround)
-> - Cluster creation and ArgoCD installation
-> - Bootstrap and initial deployment
-> - Accessing ArgoCD UI
-
 ### Deploy Bootstrap
+
+From the bastion (or any host with kubectl access to the private cluster API):
 
 ```bash
 kubectl apply -f clusters/eks-demo/bootstrap.yaml
@@ -33,121 +66,93 @@ kubectl apply -f clusters/eks-demo/bootstrap.yaml
 ### Verify Deployment
 
 ```bash
-# Check bootstrap application
 kubectl get application bootstrap -n argocd
-
-# Check all applications
 kubectl get applications -n argocd
-
-# Watch sync progress
 kubectl get applications -n argocd -w
 ```
 
 ### Manual Sync Applications
-
-<!-- Customize this section for applications that require manual sync in this cluster -->
 
 Some applications require manual sync to ensure operators and namespaces are fully ready.
 
 **Wait for operators to be healthy:**
 
 ```bash
-# Check CFK operator
 kubectl wait --namespace operator --for=condition=Ready pods -l app=confluent-operator --timeout=300s
-
-# Check CMF operator
 kubectl wait --namespace operator --for=condition=Ready pods -l app.kubernetes.io/name=confluent-for-apache-flink --timeout=300s
-
-# Check Flink Kubernetes Operator
 kubectl wait --namespace operator --for=condition=Ready pods -l app.kubernetes.io/name=flink-kubernetes-operator --timeout=300s
 ```
 
-**Sync confluent-resources:**
+**Sync confluent-resources** (after CFK operator is healthy):
 
 In the ArgoCD UI:
-1. Click on `confluent-resources` Application
-2. Click **Sync** → **Synchronize**
-3. Wait for `Healthy` status (~5-10 minutes)
+1. Click on `confluent-resources` → **Sync** → **Synchronize**
+2. Wait for `Healthy` status (~5-10 minutes)
 
-**Sync flink-resources:**
+**Sync flink-resources** (after CMF operator is healthy):
 
 In the ArgoCD UI:
-1. Click on `flink-resources` Application
-2. Click **Sync** → **Synchronize**
-3. Wait for `Healthy` status (~2-3 minutes)
-
-<!-- Add any additional manual sync steps specific to this cluster -->
+1. Click on `flink-resources` → **Sync** → **Synchronize**
+2. Wait for `Healthy` status (~2-3 minutes)
 
 ## Applications
 
 ### Infrastructure Applications
 
-Infrastructure applications are defined in `infrastructure/kustomization.yaml`:
-
-<!-- Update this list to match the actual applications in this cluster -->
+Defined in `clusters/eks-demo/infrastructure/kustomization.yaml`:
 
 - **kube-prometheus-stack-crds** (wave 2) - Prometheus Operator CRDs
+- **aws-ebs-csi-driver** (wave 3) - EBS CSI driver and gp3 StorageClass *(added in Task 10)*
 - **metrics-server** (wave 5) - Kubernetes Metrics Server
-- **traefik** (wave 10) - Ingress controller
-- **cert-manager** (wave 20) - TLS certificate management
+- **aws-load-balancer-controller** (wave 8) - AWS Load Balancer Controller for NLB provisioning *(added in Task 11)*
+- **external-dns** (wave 8) - Route53 DNS record management via ExternalDNS *(added in Task N)*
+- **traefik** (wave 10) - Ingress controller deployed on internal AWS NLB
+- **cert-manager** (wave 20) - TLS certificate management (Let's Encrypt DNS-01 via Route53 IRSA)
 - **kube-prometheus-stack** (wave 20) - Monitoring stack (Prometheus, Grafana, Alertmanager)
 - **trust-manager** (wave 30) - CA certificate distribution
-- **vault** (wave 40) - HashiCorp Vault (dev mode)
-- **vault-config** (wave 50) - Vault transit engine configuration
-- **cert-manager-resources** (wave 75) - ClusterIssuer and certificates
-- **argocd-ingress** (wave 80) - Traefik IngressRoute for ArgoCD UI
+- **reflector** (wave 40) - Secret/ConfigMap replication across namespaces
+- **cert-manager-resources** (wave 75) - ClusterIssuers for Let's Encrypt staging and production
+- **infra-ingresses** (wave 80) - Traefik IngressRoute for ArgoCD UI
+- **minio** (wave 85) - Object storage for Flink checkpoints and savepoints
 - **argocd-config** (wave 85) - ArgoCD ConfigMap patches for custom health checks
 
 ### Workload Applications
 
-Workload applications are defined in `workloads/kustomization.yaml`:
-
-<!-- Update this list to match the actual applications in this cluster -->
+Defined in `clusters/eks-demo/workloads/kustomization.yaml`:
 
 - **namespaces** (wave 100) - Namespace definitions
+- **keycloak** (wave 102) - Keycloak OIDC provider for MDS RBAC *(added in Task N)*
 - **cfk-operator** (wave 105) - Confluent for Kubernetes operator
+- **mds-keygen** (wave 107) - MDS token key generation job *(added in Task N)*
 - **confluent-resources** (wave 110) - Confluent Platform (KRaft, Kafka, Schema Registry, etc.)
-- **controlcenter-ingress** (wave 115) - Traefik IngressRoute for Control Center UI
+- **workload-ingresses** (wave 110) - Traefik IngressRoutes for workload UIs
 - **flink-kubernetes-operator** (wave 116) - Flink Kubernetes Operator
 - **observability-resources** (wave 117) - PodMonitors and Grafana dashboards
 - **cmf-operator** (wave 118) - Confluent Manager for Apache Flink
+- **cmf-operator-secrets** (wave 119) - CMF operator secrets *(added in Task N)*
+- **flink-rbac** (wave 119) - Flink RBAC ConfluentRoleBindings *(added in Task N)*
 - **flink-resources** (wave 120) - Flink integration resources
 
 ## Environment Access
 
-### DNS Configuration
+All services are private — exposed only within the VPC. Access from your laptop requires the SOCKS5 proxy tunnel.
 
-Add these entries to `/etc/hosts`:
+### SOCKS5 Proxy Setup
 
-```
-127.0.0.1  alertmanager.eks-demo.platform.dspdemos.com
-127.0.0.1  argocd.eks-demo.platform.dspdemos.com
-127.0.0.1  cmf.eks-demo.platform.dspdemos.com
-127.0.0.1  controlcenter.eks-demo.platform.dspdemos.com
-127.0.0.1  grafana.eks-demo.platform.dspdemos.com
-127.0.0.1  kafka.eks-demo.platform.dspdemos.com
-127.0.0.1  prometheus.eks-demo.platform.dspdemos.com
-127.0.0.1  schemaregistry.eks-demo.platform.dspdemos.com
-127.0.0.1  vault.eks-demo.platform.dspdemos.com
+Start an SSM port-forward session from your laptop:
+
+```bash
+aws ssm start-session \
+  --target $(terraform -chdir=terraform/eks-demo output -raw bastion_instance_id) \
+  --document-name AWS-StartPortForwardingSession \
+  --parameters '{"portNumber":["1080"],"localPortNumber":["1080"]}'
 ```
 
-> [!WARNING]
-> If you experience ~5-second timeouts when accessing services, add IPv6 entries as well:
-> ```
-> ::1  alertmanager.eks-demo.platform.dspdemos.com
-> ::1  argocd.eks-demo.platform.dspdemos.com
-> ::1  cmf.eks-demo.platform.dspdemos.com
-> ::1  controlcenter.eks-demo.platform.dspdemos.com
-> ::1  grafana.eks-demo.platform.dspdemos.com
-> ::1  kafka.eks-demo.platform.dspdemos.com
-> ::1  prometheus.eks-demo.platform.dspdemos.com
-> ::1  schemaregistry.eks-demo.platform.dspdemos.com
-> ::1  vault.eks-demo.platform.dspdemos.com
-> ```
+Configure **FoxyProxy** (or your browser proxy settings) to route `*.platform.dspdemos.com` through `socks5://localhost:1080`.
+
+DNS is managed automatically by ExternalDNS — no `/etc/hosts` entries are needed.
 
 ### Services
-
-<!-- Customize URLs and credentials for this cluster's services -->
 
 **ArgoCD UI:**
 - **URL**: https://argocd.eks-demo.platform.dspdemos.com
@@ -158,39 +163,34 @@ Add these entries to `/etc/hosts`:
 - **URL**: https://controlcenter.eks-demo.platform.dspdemos.com
 
 **Grafana:**
-- **URL**: http://grafana.eks-demo.platform.dspdemos.com
+- **URL**: https://grafana.eks-demo.platform.dspdemos.com
 - **Username**: `admin`
 - **Password**: `prom-operator`
 
 **Prometheus:**
-- **URL**: http://prometheus.eks-demo.platform.dspdemos.com
+- **URL**: https://prometheus.eks-demo.platform.dspdemos.com
 
 **Alertmanager:**
-- **URL**: http://alertmanager.eks-demo.platform.dspdemos.com
-
-**Vault** (dev mode):
-- **URL**: http://vault.eks-demo.platform.dspdemos.com
-- **Token**: `root`
-- **Warning**: Dev mode - data is not persisted across restarts
+- **URL**: https://alertmanager.eks-demo.platform.dspdemos.com
 
 **CMF API:**
-- **URL**: http://cmf.eks-demo.platform.dspdemos.com
+- **URL**: https://cmf.eks-demo.platform.dspdemos.com
 
-<!-- Add any additional services or port-forwarding fallbacks specific to this cluster -->
+**MinIO Console:**
+- **URL**: https://s3-console.eks-demo.platform.dspdemos.com
+
+**Keycloak** *(added in Task N)*:
+- **URL**: https://keycloak.eks-demo.platform.dspdemos.com
 
 ## Cluster Specific Use Cases
 
 <!--
-Document anything unique to this cluster that doesn't fit the standard template.
-Examples:
-- RBAC naming conventions and permission model
-- Pre-created topics, schemas, or Flink resources
-- Special authentication flows (e.g., Keycloak SSO, MDS device-grant)
-- Token lifecycle management
-- Demo/sandbox environments (e.g., CP Flink SQL Sandbox)
-
-Remove this comment block and replace with cluster-specific content.
-If this cluster has no unique use cases, remove this section entirely.
+Document anything unique to this cluster:
+- OIDC/Keycloak SSO flow and realm configuration
+- RBAC model for MDS + Flink ConfluentRoleBindings
+- Flink checkpoint/savepoint storage layout in MinIO
+- Let's Encrypt certificate lifecycle and renewal
+- SSM+SOCKS5 bastion access patterns
 -->
 
 ## Troubleshooting
@@ -213,29 +213,29 @@ ls -la ./clusters/eks-demo/workloads/
 
 ### Pods Not Starting
 
-Check pod status and events:
-
 ```bash
 kubectl get pods --namespace <namespace> --output wide
 kubectl describe pod <pod-name> --namespace <namespace>
-```
-
-Check resource availability:
-
-```bash
 kubectl top nodes
 kubectl top pods --all-namespaces
 ```
 
 ### Ingress Not Accessible
 
-Verify kind port mappings:
+Verify the SOCKS5 proxy is running and your browser proxy is routing `*.platform.dspdemos.com` through `localhost:1080`.
+
+Check the Traefik NLB is provisioned:
 
 ```bash
-docker ps | grep eks-demo
+kubectl get svc -n traefik
+# EXTERNAL-IP should show an AWS NLB hostname (*.elb.amazonaws.com)
 ```
 
-Should show port mappings: `0.0.0.0:80->30080/tcp, 0.0.0.0:443->30443/tcp`
+Check ExternalDNS has written Route53 records:
+
+```bash
+kubectl logs -n external-dns -l app.kubernetes.io/name=external-dns --tail=50
+```
 
 Check Traefik IngressRoutes:
 
@@ -245,31 +245,27 @@ kubectl get ingressroute --all-namespaces
 
 ### Certificate Issues
 
-Check cert-manager resources:
-
 ```bash
 kubectl get certificates --all-namespaces
 kubectl get certificaterequests --all-namespaces
 kubectl get clusterissuers
+kubectl logs -n cert-manager -l app=cert-manager --tail=100
+```
+
+Let's Encrypt DNS-01 challenges write TXT records to Route53 via IRSA — check the cert-manager IAM role ARN is correctly annotated on the `cert-manager` ServiceAccount:
+
+```bash
+kubectl get sa cert-manager -n cert-manager -o jsonpath='{.metadata.annotations}'
 ```
 
 ### CFK Components Not Deploying
 
-Check operator logs:
-
 ```bash
 kubectl logs --namespace operator deployment/confluent-operator --tail=100
-```
-
-Verify CRDs installed:
-
-```bash
 kubectl get crd | grep platform.confluent.io
 ```
 
 ### Validation Script
-
-Run the comprehensive validation script:
 
 ```bash
 ./scripts/validate-cluster.sh eks-demo --verbose
@@ -277,14 +273,12 @@ Run the comprehensive validation script:
 
 ## Cleanup
 
-Remove the kind cluster:
+Destroy Terraform resources in reverse order:
 
 ```bash
-kind delete cluster --name eks-demo
+terraform -chdir=terraform/eks-demo destroy
+terraform -chdir=terraform/dns-bootstrap destroy
 ```
 
-Stop the container runtime (if using Colima):
-
-```bash
-colima stop
-```
+> [!WARNING]
+> `terraform destroy` on `eks-demo` deletes the EKS cluster, all node groups, the VPC, bastion, and IRSA roles. Back up or snapshot any persistent data (EBS volumes from PVCs) before destroying.

--- a/clusters/eks-demo/README.md
+++ b/clusters/eks-demo/README.md
@@ -46,7 +46,7 @@ See [`terraform/eks-demo/README.md`](../../terraform/eks-demo/README.md) for ful
 terraform -chdir=terraform/eks-demo output bastion_instance_id
 
 # Open SSM shell on the bastion
-aws ssm start-session --target <bastion_instance_id>
+aws ssm start-session --region us-east-1 --target <bastion_instance_id>
 
 # On the bastion:
 aws eks update-kubeconfig --region us-east-1 --name eks-demo
@@ -143,6 +143,7 @@ Start an SSM port-forward session from your laptop:
 
 ```bash
 aws ssm start-session \
+  --region us-east-1 \
   --target $(terraform -chdir=terraform/eks-demo output -raw bastion_instance_id) \
   --document-name AWS-StartPortForwardingSession \
   --parameters '{"portNumber":["1080"],"localPortNumber":["1080"]}'

--- a/clusters/eks-demo/bootstrap.yaml
+++ b/clusters/eks-demo/bootstrap.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: bootstrap
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/osowski/confluent-platform-gitops.git
+    targetRevision: HEAD
+    path: bootstrap
+    helm:
+      valuesObject:
+        cluster:
+          name: eks-demo
+          domain: platform.dspdemos.com
+        git:
+          targetRevision: "HEAD"
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/clusters/eks-demo/infrastructure/argocd-config.yaml
+++ b/clusters/eks-demo/infrastructure/argocd-config.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argocd-config
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "85"  # After argocd-ingress (80), before workloads (100)
+spec:
+  project: infrastructure
+  source:
+    repoURL: https://github.com/osowski/confluent-platform-gitops.git
+    targetRevision: HEAD
+    path: infrastructure/argocd-config/overlays/eks-demo
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/clusters/eks-demo/infrastructure/cert-manager-resources.yaml
+++ b/clusters/eks-demo/infrastructure/cert-manager-resources.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cert-manager-resources
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "75"
+spec:
+  project: infrastructure
+  source:
+    repoURL: https://github.com/osowski/confluent-platform-gitops.git
+    targetRevision: HEAD
+    path: infrastructure/cert-manager-resources/overlays/eks-demo
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: cert-manager
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/clusters/eks-demo/infrastructure/cert-manager.yaml
+++ b/clusters/eks-demo/infrastructure/cert-manager.yaml
@@ -17,8 +17,8 @@ spec:
     helm:
       ignoreMissingValueFiles: true
       valueFiles:
-        - /infrastructure/cert-manager/base/values.yaml
-        - /infrastructure/cert-manager/overlays/eks-demo/values.yaml
+        - $values/infrastructure/cert-manager/base/values.yaml
+        - $values/infrastructure/cert-manager/overlays/eks-demo/values.yaml
   - repoURL: https://github.com/osowski/confluent-platform-gitops.git
     targetRevision: HEAD
     ref: values

--- a/clusters/eks-demo/infrastructure/cert-manager.yaml
+++ b/clusters/eks-demo/infrastructure/cert-manager.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cert-manager
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "20"  # Deploy after cert-manager and storage
+spec:
+  project: infrastructure
+  sources:
+  - repoURL: oci://quay.io/jetstack/charts/cert-manager
+    targetRevision: v1.19.2  # Pin to specific version
+    chart: cert-manager
+    helm:
+      ignoreMissingValueFiles: true
+      valueFiles:
+        - /infrastructure/cert-manager/base/values.yaml
+        - /infrastructure/cert-manager/overlays/eks-demo/values.yaml
+  - repoURL: https://github.com/osowski/confluent-platform-gitops.git
+    targetRevision: HEAD
+    ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: cert-manager
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true  # Required for CRDs
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/clusters/eks-demo/infrastructure/infra-ingresses.yaml
+++ b/clusters/eks-demo/infrastructure/infra-ingresses.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: infra-ingresses
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "80"
+spec:
+  project: infrastructure
+  source:
+    repoURL: https://github.com/osowski/confluent-platform-gitops.git
+    targetRevision: HEAD
+    path: infrastructure/ingresses/overlays/eks-demo
+  destination:
+    server: https://kubernetes.default.svc
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=false
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/clusters/eks-demo/infrastructure/kube-prometheus-stack-crds.yaml
+++ b/clusters/eks-demo/infrastructure/kube-prometheus-stack-crds.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kube-prometheus-stack-crds
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"  # Deploy as early as possible so all others have access to CRDs
+spec:
+  project: infrastructure
+  sources:
+  - repoURL: https://prometheus-community.github.io/helm-charts
+    targetRevision: 81.6.1  # Pin to specific version
+    chart: kube-prometheus-stack
+    helm:
+      valueFiles:
+        - $values/infrastructure/kube-prometheus-stack-crds/base/values.yaml
+  - repoURL: https://github.com/osowski/confluent-platform-gitops.git
+    targetRevision: HEAD
+    ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: monitoring
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true  # Required for CRDs
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m
+  ignoreDifferences:
+    # Ignore differences in webhook CA bundles (auto-generated)
+    - group: admissionregistration.k8s.io
+      kind: MutatingWebhookConfiguration
+      jsonPointers:
+        - /webhooks/0/clientConfig/caBundle
+    - group: admissionregistration.k8s.io
+      kind: ValidatingWebhookConfiguration
+      jsonPointers:
+        - /webhooks/0/clientConfig/caBundle

--- a/clusters/eks-demo/infrastructure/kube-prometheus-stack.yaml
+++ b/clusters/eks-demo/infrastructure/kube-prometheus-stack.yaml
@@ -16,8 +16,8 @@ spec:
     chart: kube-prometheus-stack
     helm:
       valueFiles:
-        - /infrastructure/kube-prometheus-stack/base/values.yaml
-        - /infrastructure/kube-prometheus-stack/overlays/eks-demo/values.yaml
+        - $values/infrastructure/kube-prometheus-stack/base/values.yaml
+        - $values/infrastructure/kube-prometheus-stack/overlays/eks-demo/values.yaml
       ignoreMissingValueFiles: true
   - repoURL: https://github.com/osowski/confluent-platform-gitops.git
     targetRevision: HEAD

--- a/clusters/eks-demo/infrastructure/kube-prometheus-stack.yaml
+++ b/clusters/eks-demo/infrastructure/kube-prometheus-stack.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kube-prometheus-stack
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "20"  # Deploy after cert-manager and storage
+spec:
+  project: infrastructure
+  sources:
+  - repoURL: https://prometheus-community.github.io/helm-charts
+    targetRevision: 81.6.1  # Pin to specific version
+    chart: kube-prometheus-stack
+    helm:
+      valueFiles:
+        - /infrastructure/kube-prometheus-stack/base/values.yaml
+        - /infrastructure/kube-prometheus-stack/overlays/eks-demo/values.yaml
+      ignoreMissingValueFiles: true
+  - repoURL: https://github.com/osowski/confluent-platform-gitops.git
+    targetRevision: HEAD
+    ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: monitoring
+  syncPolicy:
+    # automated: disabled # Explicitly NOT auto-sync while under development
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true  # Required for CRDs
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m
+  ignoreDifferences:
+    # Ignore differences in webhook CA bundles (auto-generated)
+    - group: admissionregistration.k8s.io
+      kind: MutatingWebhookConfiguration
+      jsonPointers:
+        - /webhooks/0/clientConfig/caBundle
+    - group: admissionregistration.k8s.io
+      kind: ValidatingWebhookConfiguration
+      jsonPointers:
+        - /webhooks/0/clientConfig/caBundle
+    # Ignore differences in auto-generated secrets
+    - group: ""
+      kind: Secret
+      name: alertmanager-kube-prometheus-stack-alertmanager
+      jsonPointers:
+        - /data
+    # Ignore Ingress loadBalancer status for NodePort environments (KIND clusters)
+    # NodePort services don't populate status.loadBalancer, causing ArgoCD to stay in Progressing
+    - group: networking.k8s.io
+      kind: Ingress
+      jsonPointers:
+        - /status/loadBalancer

--- a/clusters/eks-demo/infrastructure/kustomization.yaml
+++ b/clusters/eks-demo/infrastructure/kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- argocd-config.yaml
+- infra-ingresses.yaml
+- cert-manager.yaml
+- cert-manager-resources.yaml
+- trust-manager.yaml
+- kube-prometheus-stack-crds.yaml
+- kube-prometheus-stack.yaml
+- metrics-server.yaml
+- reflector.yaml
+- traefik.yaml
+- minio.yaml
+
+# Infrastructure applications are deployed in sync wave order (10-85)
+# Remove any applications you don't need for your cluster

--- a/clusters/eks-demo/infrastructure/metrics-server.yaml
+++ b/clusters/eks-demo/infrastructure/metrics-server.yaml
@@ -17,8 +17,8 @@ spec:
     helm:
       ignoreMissingValueFiles: true
       valueFiles:
-        - /infrastructure/metrics-server/base/values.yaml
-        - /infrastructure/metrics-server/overlays/eks-demo/values.yaml
+        - $values/infrastructure/metrics-server/base/values.yaml
+        - $values/infrastructure/metrics-server/overlays/eks-demo/values.yaml
   - repoURL: https://github.com/osowski/confluent-platform-gitops.git
     targetRevision: HEAD
     ref: values

--- a/clusters/eks-demo/infrastructure/metrics-server.yaml
+++ b/clusters/eks-demo/infrastructure/metrics-server.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: metrics-server
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "5"  # After CRDs (2), before infrastructure (10+)
+spec:
+  project: infrastructure
+  sources:
+  - repoURL: https://kubernetes-sigs.github.io/metrics-server/
+    targetRevision: 3.12.2  # Pin to specific version
+    chart: metrics-server
+    helm:
+      ignoreMissingValueFiles: true
+      valueFiles:
+        - /infrastructure/metrics-server/base/values.yaml
+        - /infrastructure/metrics-server/overlays/eks-demo/values.yaml
+  - repoURL: https://github.com/osowski/confluent-platform-gitops.git
+    targetRevision: HEAD
+    ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kube-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=false  # kube-system already exists
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m
+  ignoreDifferences: []

--- a/clusters/eks-demo/infrastructure/minio.yaml
+++ b/clusters/eks-demo/infrastructure/minio.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: minio
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "85" # After traefik/ingress (80), before workloads (100+)
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: infrastructure
+  source:
+    repoURL: https://github.com/osowski/confluent-platform-gitops.git
+    targetRevision: HEAD
+    path: infrastructure/minio/overlays/eks-demo
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: storage
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: false
+    syncOptions:
+      - CreateNamespace=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/clusters/eks-demo/infrastructure/reflector.yaml
+++ b/clusters/eks-demo/infrastructure/reflector.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: reflector
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "40"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: infrastructure
+  sources:
+    - repoURL: https://emberstack.github.io/helm-charts
+      chart: reflector
+      targetRevision: 10.0.21  # Pin to specific chart version
+      helm:
+        valueFiles:
+          - $values/infrastructure/reflector/base/values.yaml
+    - repoURL: https://github.com/osowski/confluent-platform-gitops.git
+      targetRevision: HEAD
+      ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: reflector-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/clusters/eks-demo/infrastructure/traefik.yaml
+++ b/clusters/eks-demo/infrastructure/traefik.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: traefik
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"  # Deploy after cert-manager and storage
+spec:
+  project: infrastructure
+  sources:
+  - repoURL: oci://ghcr.io/traefik/helm/traefik
+    targetRevision: 38.0.2  # Pin to specific version
+    chart: traefik
+    helm:
+      ignoreMissingValueFiles: true
+      valueFiles:
+        - /infrastructure/traefik/base/values.yaml
+        - /infrastructure/traefik/overlays/eks-demo/values.yaml
+  - repoURL: https://github.com/osowski/confluent-platform-gitops.git
+    targetRevision: HEAD
+    ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: ingress
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true  # Required for CRDs
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m
+  ignoreDifferences: []

--- a/clusters/eks-demo/infrastructure/traefik.yaml
+++ b/clusters/eks-demo/infrastructure/traefik.yaml
@@ -17,8 +17,8 @@ spec:
     helm:
       ignoreMissingValueFiles: true
       valueFiles:
-        - /infrastructure/traefik/base/values.yaml
-        - /infrastructure/traefik/overlays/eks-demo/values.yaml
+        - $values/infrastructure/traefik/base/values.yaml
+        - $values/infrastructure/traefik/overlays/eks-demo/values.yaml
   - repoURL: https://github.com/osowski/confluent-platform-gitops.git
     targetRevision: HEAD
     ref: values

--- a/clusters/eks-demo/infrastructure/trust-manager.yaml
+++ b/clusters/eks-demo/infrastructure/trust-manager.yaml
@@ -17,8 +17,8 @@ spec:
     helm:
       ignoreMissingValueFiles: true
       valueFiles:
-        - /infrastructure/trust-manager/base/values.yaml
-        - /infrastructure/trust-manager/overlays/eks-demo/values.yaml
+        - $values/infrastructure/trust-manager/base/values.yaml
+        - $values/infrastructure/trust-manager/overlays/eks-demo/values.yaml
   - repoURL: https://github.com/osowski/confluent-platform-gitops.git
     targetRevision: HEAD
     ref: values

--- a/clusters/eks-demo/infrastructure/trust-manager.yaml
+++ b/clusters/eks-demo/infrastructure/trust-manager.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: trust-manager
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "30"  # Deploy after cert-manager (wave 20)
+spec:
+  project: infrastructure
+  sources:
+  - repoURL: oci://quay.io/jetstack/charts/trust-manager
+    targetRevision: v0.20.3  # Pin to specific version
+    chart: trust-manager
+    helm:
+      ignoreMissingValueFiles: true
+      valueFiles:
+        - /infrastructure/trust-manager/base/values.yaml
+        - /infrastructure/trust-manager/overlays/eks-demo/values.yaml
+  - repoURL: https://github.com/osowski/confluent-platform-gitops.git
+    targetRevision: HEAD
+    ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: cert-manager
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=false  # cert-manager namespace already created by cert-manager app
+      - ServerSideApply=true  # Required for CRDs
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/clusters/eks-demo/workloads/cfk-operator.yaml
+++ b/clusters/eks-demo/workloads/cfk-operator.yaml
@@ -12,11 +12,11 @@ spec:
   sources:
     - repoURL: https://packages.confluent.io/helm
       chart: confluent-for-kubernetes
-      targetRevision: 0.1351.59
+      targetRevision: 0.1514.19
       helm:
         valueFiles:
-          - /workloads/cfk-operator/base/values.yaml
-          - /workloads/cfk-operator/overlays/eks-demo/values.yaml
+          - $values/workloads/cfk-operator/base/values.yaml
+          - $values/workloads/cfk-operator/overlays/eks-demo/values.yaml
         ignoreMissingValueFiles: true
     - repoURL: https://github.com/osowski/confluent-platform-gitops.git
       targetRevision: HEAD

--- a/clusters/eks-demo/workloads/cfk-operator.yaml
+++ b/clusters/eks-demo/workloads/cfk-operator.yaml
@@ -1,0 +1,38 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cfk-operator
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "105"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: workloads
+  sources:
+    - repoURL: https://packages.confluent.io/helm
+      chart: confluent-for-kubernetes
+      targetRevision: 0.1351.59
+      helm:
+        valueFiles:
+          - /workloads/cfk-operator/base/values.yaml
+          - /workloads/cfk-operator/overlays/eks-demo/values.yaml
+        ignoreMissingValueFiles: true
+    - repoURL: https://github.com/osowski/confluent-platform-gitops.git
+      targetRevision: HEAD
+      ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: operator
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: false
+    syncOptions:
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/clusters/eks-demo/workloads/cmf-operator.yaml
+++ b/clusters/eks-demo/workloads/cmf-operator.yaml
@@ -1,0 +1,44 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cmf-operator
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "118"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: workloads
+  sources:
+    - repoURL: https://packages.confluent.io/helm
+      chart: confluent-manager-for-apache-flink
+      targetRevision: 2.2.0
+      helm:
+        valueFiles:
+          - /workloads/cmf-operator/base/values.yaml
+          - /workloads/cmf-operator/overlays/eks-demo/values.yaml
+        ignoreMissingValueFiles: true
+    - repoURL: https://github.com/osowski/confluent-platform-gitops.git
+      targetRevision: HEAD
+      ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: operator
+  ignoreDifferences:
+    - group: apps
+      kind: Deployment
+      name: confluent-manager-for-apache-flink
+      jsonPointers:
+        - /spec/template/metadata/annotations/rollme
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: false
+    syncOptions:
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/clusters/eks-demo/workloads/cmf-operator.yaml
+++ b/clusters/eks-demo/workloads/cmf-operator.yaml
@@ -12,11 +12,11 @@ spec:
   sources:
     - repoURL: https://packages.confluent.io/helm
       chart: confluent-manager-for-apache-flink
-      targetRevision: 2.2.0
+      targetRevision: 2.3.0
       helm:
         valueFiles:
-          - /workloads/cmf-operator/base/values.yaml
-          - /workloads/cmf-operator/overlays/eks-demo/values.yaml
+          - $values/workloads/cmf-operator/base/values.yaml
+          - $values/workloads/cmf-operator/overlays/eks-demo/values.yaml
         ignoreMissingValueFiles: true
     - repoURL: https://github.com/osowski/confluent-platform-gitops.git
       targetRevision: HEAD

--- a/clusters/eks-demo/workloads/confluent-resources.yaml
+++ b/clusters/eks-demo/workloads/confluent-resources.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: confluent-resources
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "110"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: workloads
+  source:
+    repoURL: https://github.com/osowski/confluent-platform-gitops.git
+    targetRevision: HEAD
+    path: workloads/confluent-resources/overlays/eks-demo
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kafka
+  syncPolicy:
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/clusters/eks-demo/workloads/flink-kubernetes-operator.yaml
+++ b/clusters/eks-demo/workloads/flink-kubernetes-operator.yaml
@@ -12,11 +12,11 @@ spec:
   sources:
     - repoURL: https://packages.confluent.io/helm
       chart: flink-kubernetes-operator
-      targetRevision: 1.130.2
+      targetRevision: 1.140.1
       helm:
         valueFiles:
-          - /workloads/flink-kubernetes-operator/base/values.yaml
-          - /workloads/flink-kubernetes-operator/overlays/eks-demo/values.yaml
+          - $values/workloads/flink-kubernetes-operator/base/values.yaml
+          - $values/workloads/flink-kubernetes-operator/overlays/eks-demo/values.yaml
         ignoreMissingValueFiles: true
     - repoURL: https://github.com/osowski/confluent-platform-gitops.git
       targetRevision: HEAD

--- a/clusters/eks-demo/workloads/flink-kubernetes-operator.yaml
+++ b/clusters/eks-demo/workloads/flink-kubernetes-operator.yaml
@@ -1,0 +1,43 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: flink-kubernetes-operator
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "116"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: workloads
+  sources:
+    - repoURL: https://packages.confluent.io/helm
+      chart: flink-kubernetes-operator
+      targetRevision: 1.130.2
+      helm:
+        valueFiles:
+          - /workloads/flink-kubernetes-operator/base/values.yaml
+          - /workloads/flink-kubernetes-operator/overlays/eks-demo/values.yaml
+        ignoreMissingValueFiles: true
+    - repoURL: https://github.com/osowski/confluent-platform-gitops.git
+      targetRevision: HEAD
+      ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: operator
+  ignoreDifferences:
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      jqPathExpressions:
+        - .spec.versions[].additionalPrinterColumns[].priority
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: false
+    syncOptions:
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/clusters/eks-demo/workloads/flink-resources.yaml
+++ b/clusters/eks-demo/workloads/flink-resources.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: flink-resources
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "120"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: workloads
+  source:
+    repoURL: https://github.com/osowski/confluent-platform-gitops.git
+    targetRevision: HEAD
+    path: workloads/flink-resources/overlays/eks-demo
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: flink

--- a/clusters/eks-demo/workloads/kustomization.yaml
+++ b/clusters/eks-demo/workloads/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespaces.yaml
+  - cfk-operator.yaml
+  - confluent-resources.yaml
+  - workload-ingresses.yaml
+  - flink-kubernetes-operator.yaml
+  - observability-resources.yaml
+  - cmf-operator.yaml
+  - flink-resources.yaml
+
+# Workload applications are deployed in sync wave order (100-120)
+# Remove any applications you don't need for your cluster

--- a/clusters/eks-demo/workloads/namespaces.yaml
+++ b/clusters/eks-demo/workloads/namespaces.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: namespaces
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "100"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: workloads
+  source:
+    repoURL: https://github.com/osowski/confluent-platform-gitops.git
+    targetRevision: HEAD
+    path: workloads/namespaces/base
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/clusters/eks-demo/workloads/observability-resources.yaml
+++ b/clusters/eks-demo/workloads/observability-resources.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: observability-resources
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "117"  # After Flink operator (wave 116)
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: workloads
+  source:
+    repoURL: https://github.com/osowski/confluent-platform-gitops.git
+    targetRevision: HEAD
+    path: workloads/observability-resources/base
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: operator
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: false
+    syncOptions:
+      - CreateNamespace=false  # Namespace should already exist from wave 100

--- a/clusters/eks-demo/workloads/workload-ingresses.yaml
+++ b/clusters/eks-demo/workloads/workload-ingresses.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: workload-ingresses
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "110"
+spec:
+  project: workloads
+  source:
+    repoURL: https://github.com/osowski/confluent-platform-gitops.git
+    targetRevision: HEAD
+    path: workloads/ingresses/overlays/eks-demo
+  destination:
+    server: https://kubernetes.default.svc
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=false
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/clusters/flink-demo/workloads/cfk-operator.yaml
+++ b/clusters/flink-demo/workloads/cfk-operator.yaml
@@ -12,7 +12,7 @@ spec:
   sources:
     - repoURL: https://packages.confluent.io/helm
       chart: confluent-for-kubernetes
-      targetRevision: 0.1351.59
+      targetRevision: 0.1514.19
       helm:
         valueFiles:
           - $values/workloads/cfk-operator/base/values.yaml

--- a/clusters/flink-demo/workloads/cmf-operator.yaml
+++ b/clusters/flink-demo/workloads/cmf-operator.yaml
@@ -12,7 +12,7 @@ spec:
   sources:
     - repoURL: https://packages.confluent.io/helm
       chart: confluent-manager-for-apache-flink
-      targetRevision: 2.2.0
+      targetRevision: 2.3.0
       helm:
         valueFiles:
           - $values/workloads/cmf-operator/base/values.yaml

--- a/clusters/flink-demo/workloads/flink-kubernetes-operator.yaml
+++ b/clusters/flink-demo/workloads/flink-kubernetes-operator.yaml
@@ -12,7 +12,7 @@ spec:
   sources:
     - repoURL: https://packages.confluent.io/helm
       chart: flink-kubernetes-operator
-      targetRevision: 1.130.2
+      targetRevision: 1.140.1
       helm:
         valueFiles:
           - $values/workloads/flink-kubernetes-operator/base/values.yaml

--- a/infrastructure/argocd-config/overlays/eks-demo/kustomization.yaml
+++ b/infrastructure/argocd-config/overlays/eks-demo/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+# No cluster-specific patches needed
+# Health check configuration applies to all clusters

--- a/infrastructure/ingresses/overlays/eks-demo/argocd-certificate-patch.yaml
+++ b/infrastructure/ingresses/overlays/eks-demo/argocd-certificate-patch.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: argocd-server-tls
+  namespace: argocd
+spec:
+  dnsNames:
+    - argocd.eks-demo.platform.dspdemos.com

--- a/infrastructure/ingresses/overlays/eks-demo/argocd-ingressroute-patch.yaml
+++ b/infrastructure/ingresses/overlays/eks-demo/argocd-ingressroute-patch.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: argocd-server
+  namespace: argocd
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`argocd.eks-demo.platform.dspdemos.com`)
+      kind: Rule
+      services:
+        - name: argocd-server
+          port: 443
+          scheme: https
+          serversTransport: argocd-server-insecure-transport
+  tls:
+    secretName: argocd-server-tls

--- a/infrastructure/ingresses/overlays/eks-demo/kustomization.yaml
+++ b/infrastructure/ingresses/overlays/eks-demo/kustomization.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+patches:
+  - path: argocd-ingressroute-patch.yaml
+    target:
+      kind: IngressRoute
+      name: argocd-server
+
+  - path: argocd-certificate-patch.yaml
+    target:
+      kind: Certificate
+      name: argocd-server-tls
+
+# Cluster-specific labels
+labels:
+- includeSelectors: false
+  includeTemplates: true
+  pairs:
+    cluster: eks-demo

--- a/infrastructure/minio/overlays/eks-demo/ingressroute-patch.yaml
+++ b/infrastructure/minio/overlays/eks-demo/ingressroute-patch.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: minio
+  namespace: storage
+spec:
+  routes:
+    - match: Host(`s3.eks-demo.platform.dspdemos.com`)
+      kind: Rule
+      services:
+        - name: minio
+          port: 9000
+          scheme: http
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: minio-console
+  namespace: storage
+spec:
+  routes:
+    - match: Host(`s3-console.eks-demo.platform.dspdemos.com`)
+      kind: Rule
+      services:
+        - name: minio
+          port: 9001
+          scheme: http

--- a/infrastructure/minio/overlays/eks-demo/kustomization.yaml
+++ b/infrastructure/minio/overlays/eks-demo/kustomization.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+patches:
+  - path: ingressroute-patch.yaml
+  - path: secret-patch.yaml
+
+labels:
+- includeSelectors: false
+  includeTemplates: true
+  pairs:
+    cluster: eks-demo

--- a/infrastructure/minio/overlays/eks-demo/secret-patch.yaml
+++ b/infrastructure/minio/overlays/eks-demo/secret-patch.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-credentials
+  namespace: storage
+  annotations:
+    reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+    reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "flink"
+    reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"

--- a/scripts/new-cluster.sh
+++ b/scripts/new-cluster.sh
@@ -132,7 +132,7 @@ replace_placeholders() {
     # Create temp file, replace placeholders, then move to original
     local temp_file="${file}.tmp"
     CLUSTER_NAME="$cluster_name" DOMAIN="$domain" REPO_URL="$repo_url" \
-        envsubst < "$file" > "$temp_file"
+        envsubst '$CLUSTER_NAME $DOMAIN $REPO_URL' < "$file" > "$temp_file"
     mv "$temp_file" "$file"
 }
 

--- a/templates/new-cluster/workloads/cfk-operator.yaml.template
+++ b/templates/new-cluster/workloads/cfk-operator.yaml.template
@@ -12,7 +12,7 @@ spec:
   sources:
     - repoURL: https://packages.confluent.io/helm
       chart: confluent-for-kubernetes
-      targetRevision: 0.1351.59
+      targetRevision: 0.1514.19
       helm:
         valueFiles:
           - $values/workloads/cfk-operator/base/values.yaml

--- a/templates/new-cluster/workloads/cmf-operator.yaml.template
+++ b/templates/new-cluster/workloads/cmf-operator.yaml.template
@@ -12,7 +12,7 @@ spec:
   sources:
     - repoURL: https://packages.confluent.io/helm
       chart: confluent-manager-for-apache-flink
-      targetRevision: 2.2.0
+      targetRevision: 2.3.0
       helm:
         valueFiles:
           - $values/workloads/cmf-operator/base/values.yaml

--- a/templates/new-cluster/workloads/flink-kubernetes-operator.yaml.template
+++ b/templates/new-cluster/workloads/flink-kubernetes-operator.yaml.template
@@ -12,7 +12,7 @@ spec:
   sources:
     - repoURL: https://packages.confluent.io/helm
       chart: flink-kubernetes-operator
-      targetRevision: 1.130.2
+      targetRevision: 1.140.1
       helm:
         valueFiles:
           - $values/workloads/flink-kubernetes-operator/base/values.yaml

--- a/workloads/flink-resources/base/flink-application.yaml
+++ b/workloads/flink-resources/base/flink-application.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: flink
 spec:
   flinkEnvironment: env1
-  image: confluentinc/cp-flink:1.20.3-cp1
+  image: confluentinc/cp-flink:1.20.3-cp2-java17
   flinkVersion: v1_20
   flinkConfiguration:
     "taskmanager.numberOfTaskSlots": "2"

--- a/workloads/ingresses/overlays/eks-demo/cmf-ingressroute-patch.yaml
+++ b/workloads/ingresses/overlays/eks-demo/cmf-ingressroute-patch.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: cmf
+  namespace: operator
+spec:
+  routes:
+    - match: Host(`cmf.eks-demo.platform.dspdemos.com`)
+      kind: Rule
+      services:
+        - name: cmf-service
+          port: 80
+          scheme: http

--- a/workloads/ingresses/overlays/eks-demo/controlcenter-certificate-patch.yaml
+++ b/workloads/ingresses/overlays/eks-demo/controlcenter-certificate-patch.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: controlcenter-tls
+  namespace: kafka
+spec:
+  dnsNames:
+    - controlcenter.eks-demo.platform.dspdemos.com

--- a/workloads/ingresses/overlays/eks-demo/controlcenter-ingressroute-patch.yaml
+++ b/workloads/ingresses/overlays/eks-demo/controlcenter-ingressroute-patch.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: controlcenter
+  namespace: kafka
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`controlcenter.eks-demo.platform.dspdemos.com`)
+      kind: Rule
+      services:
+        - name: controlcenter
+          port: 9021
+          scheme: http
+  tls:
+    secretName: controlcenter-tls

--- a/workloads/ingresses/overlays/eks-demo/kustomization.yaml
+++ b/workloads/ingresses/overlays/eks-demo/kustomization.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+patches:
+  - path: cmf-ingressroute-patch.yaml
+    target:
+      kind: IngressRoute
+      name: cmf
+
+  - path: controlcenter-ingressroute-patch.yaml
+    target:
+      kind: IngressRoute
+      name: controlcenter
+
+  - path: controlcenter-certificate-patch.yaml
+    target:
+      kind: Certificate
+      name: controlcenter-tls
+
+  - path: schema-registry-ingressroute-patch.yaml
+    target:
+      kind: IngressRoute
+      name: schema-registry
+
+# Cluster-specific labels
+labels:
+- includeSelectors: false
+  includeTemplates: true
+  pairs:
+    cluster: eks-demo

--- a/workloads/ingresses/overlays/eks-demo/schema-registry-ingressroute-patch.yaml
+++ b/workloads/ingresses/overlays/eks-demo/schema-registry-ingressroute-patch.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: schema-registry
+  namespace: kafka
+spec:
+  routes:
+    - kind: Rule
+      match: Host(`schema-registry.eks-demo.platform.dspdemos.com`)
+      services:
+        - name: schemaregistry
+          port: 8081
+          scheme: http


### PR DESCRIPTION
## Summary

- Runs `new-cluster.sh eks-demo platform.dspdemos.com` to generate the full cluster directory structure
- Removes vault infrastructure apps (`vault.yaml`, `vault-config.yaml`) — not needed on EKS
- Removes vault entries from `clusters/eks-demo/infrastructure/kustomization.yaml`
- Includes stub overlays for infrastructure and workload ingresses generated by the script

## What's included

**Infrastructure (12 apps):** argocd-config, cert-manager, cert-manager-resources, trust-manager, infra-ingresses, kube-prometheus-stack-crds, kube-prometheus-stack, metrics-server, reflector, traefik, minio

**Workloads (8 apps):** namespaces, cfk-operator, cmf-operator, confluent-resources, flink-kubernetes-operator, flink-resources, observability-resources, workload-ingresses

## What comes in later tasks

AWS-specific infrastructure (EBS CSI driver, Load Balancer Controller, ExternalDNS) and RBAC workloads (Keycloak, MDS keygen, CMF operator secrets, Flink RBAC) are added in subsequent tasks per the eks-demo v3 plan.

Gap analysis against `flink-demo` and `flink-demo-rbac` was performed; flink-demo-only extras (`cp-flink-sql-sandbox`, `flink-agents`, `ollama`) are tracked for future cleanup in #215.

Closes #183 (Task 9)

## Test plan

- [ ] Verify `clusters/eks-demo/bootstrap.yaml` has correct cluster name and domain
- [ ] Verify vault apps are absent from infrastructure kustomization
- [ ] Confirm kustomize renders cleanly for generated overlay stubs

🤖 Generated with [Claude Code](https://claude.com/claude-code)