### PR TITLE
docs: add ArgoCD manual install step to eks-demo README

### DIFF
--- a/clusters/eks-demo/README.md
+++ b/clusters/eks-demo/README.md
@@ -66,7 +66,7 @@ kubectl get nodes  # Expected: 2+ nodes in Ready state
 
 ### Install ArgoCD
 
-ArgoCD must be installed manually before the bootstrap Application can be applied (chicken-and-egg: ArgoCD manages itself, but it needs to exist first).
+ArgoCD must be installed manually before the bootstrap Application can be applied.
 
 With the SOCKS5 tunnel running and `HTTPS_PROXY` set (see Prerequisites Step 3):
 

--- a/clusters/eks-demo/README.md
+++ b/clusters/eks-demo/README.md
@@ -64,9 +64,24 @@ kubectl get nodes  # Expected: 2+ nodes in Ready state
 
 ## Getting Started
 
-### Deploy Bootstrap
+### Install ArgoCD
+
+ArgoCD must be installed manually before the bootstrap Application can be applied (chicken-and-egg: ArgoCD manages itself, but it needs to exist first).
 
 With the SOCKS5 tunnel running and `HTTPS_PROXY` set (see Prerequisites Step 3):
+
+```bash
+kubectl create namespace argocd
+kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
+
+# Wait for ArgoCD to be ready
+kubectl wait --namespace argocd \
+  --for=condition=Ready pods \
+  --selector=app.kubernetes.io/name=argocd-application-controller \
+  --timeout=300s
+```
+
+### Deploy Bootstrap
 
 ```bash
 kubectl apply -f clusters/eks-demo/bootstrap.yaml


### PR DESCRIPTION
## Summary

- Adds a **Install ArgoCD** section between Prerequisites and Deploy Bootstrap
- Includes a `kubectl wait` for the application-controller to be ready before proceeding
- References the same install approach documented in `docs/cluster-onboarding.md`

The bootstrap.yaml defines an ArgoCD Application, so ArgoCD must be running before it can be applied.

Part of #183

## Test plan

- [ ] Verify the install commands work against a fresh EKS cluster with no ArgoCD present
- [ ] Confirm ArgoCD is healthy before `kubectl apply -f clusters/eks-demo/bootstrap.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)