### PR TITLE
feat: add EBS CSI driver with gp3 default StorageClass for eks-demo

### DIFF
--- a/bootstrap/templates/argocd-projects.yaml
+++ b/bootstrap/templates/argocd-projects.yaml
@@ -23,6 +23,7 @@ spec:
     - oci://quay.io/jetstack/charts/trust-manager
     - https://kubernetes-sigs.github.io/external-dns/
     - https://aws.github.io/eks-charts
+    - https://kubernetes-sigs.github.io/aws-ebs-csi-driver
 
   # Allow deploying to all namespaces
   destinations:

--- a/clusters/eks-demo/README.md
+++ b/clusters/eks-demo/README.md
@@ -81,6 +81,27 @@ kubectl wait --namespace argocd \
   --timeout=300s
 ```
 
+### Configure IRSA Role ARNs
+
+Several infrastructure components use IRSA (IAM Roles for Service Accounts) for AWS API access. Fill in the role ARNs from Terraform before deploying:
+
+```bash
+# Get all IRSA role ARNs from Terraform output
+terraform -chdir=terraform/eks-demo output ebs_csi_driver_role_arn
+terraform -chdir=terraform/eks-demo output cert_manager_role_arn
+terraform -chdir=terraform/eks-demo output external_dns_role_arn
+terraform -chdir=terraform/eks-demo output aws_lb_controller_role_arn
+```
+
+Update the placeholder in `infrastructure/aws-ebs-csi-driver/overlays/eks-demo/values.yaml`:
+
+```yaml
+controller:
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: <paste ebs_csi_driver_role_arn output here>
+```
+
 ### Deploy Bootstrap
 
 ```bash

--- a/clusters/eks-demo/infrastructure/aws-ebs-csi-driver.yaml
+++ b/clusters/eks-demo/infrastructure/aws-ebs-csi-driver.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: aws-ebs-csi-driver
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "3"  # After Prometheus CRDs (2), before workloads (5+)
+spec:
+  project: infrastructure
+  sources:
+  - repoURL: https://kubernetes-sigs.github.io/aws-ebs-csi-driver
+    targetRevision: 2.37.0
+    chart: aws-ebs-csi-driver
+    helm:
+      ignoreMissingValueFiles: true
+      valueFiles:
+        - $values/infrastructure/aws-ebs-csi-driver/base/values.yaml
+        - $values/infrastructure/aws-ebs-csi-driver/overlays/eks-demo/values.yaml
+  - repoURL: https://github.com/osowski/confluent-platform-gitops.git
+    targetRevision: HEAD
+    ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kube-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=false  # kube-system already exists
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m
+  ignoreDifferences: []

--- a/clusters/eks-demo/infrastructure/kustomization.yaml
+++ b/clusters/eks-demo/infrastructure/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
 - kube-prometheus-stack-crds.yaml
 - kube-prometheus-stack.yaml
 - metrics-server.yaml
+- aws-ebs-csi-driver.yaml
 - reflector.yaml
 - traefik.yaml
 - minio.yaml

--- a/infrastructure/aws-ebs-csi-driver/base/values.yaml
+++ b/infrastructure/aws-ebs-csi-driver/base/values.yaml
@@ -1,0 +1,24 @@
+controller:
+  serviceAccount:
+    create: true
+    name: ebs-csi-controller-sa
+
+node:
+  serviceAccount:
+    create: true
+    name: ebs-csi-node-sa
+
+# Create the gp3 StorageClass as part of the driver installation.
+# Marked as the cluster default so PVCs without storageClassName use it automatically.
+# WaitForFirstConsumer defers provisioning until a pod is scheduled, which is required
+# in multi-AZ clusters to co-locate the EBS volume in the same AZ as the pod.
+storageClasses:
+  - name: gp3
+    annotations:
+      storageclass.kubernetes.io/is-default-class: "true"
+    provisioner: ebs.csi.aws.com
+    volumeBindingMode: WaitForFirstConsumer
+    reclaimPolicy: Delete
+    parameters:
+      type: gp3
+      encrypted: "true"

--- a/infrastructure/aws-ebs-csi-driver/overlays/eks-demo/values.yaml
+++ b/infrastructure/aws-ebs-csi-driver/overlays/eks-demo/values.yaml
@@ -1,0 +1,5 @@
+controller:
+  serviceAccount:
+    annotations:
+      # Obtain from: terraform -chdir=terraform/eks-demo output -raw ebs_csi_driver_role_arn
+      eks.amazonaws.com/role-arn: REPLACE_WITH_EBS_CSI_DRIVER_ROLE_ARN

--- a/infrastructure/aws-ebs-csi-driver/overlays/eks-demo/values.yaml
+++ b/infrastructure/aws-ebs-csi-driver/overlays/eks-demo/values.yaml
@@ -2,4 +2,4 @@ controller:
   serviceAccount:
     annotations:
       # Obtain from: terraform -chdir=terraform/eks-demo output -raw ebs_csi_driver_role_arn
-      eks.amazonaws.com/role-arn: REPLACE_WITH_EBS_CSI_DRIVER_ROLE_ARN
+      eks.amazonaws.com/role-arn: arn:aws:iam::829250931565:role/AmazonEKS_EBS_CSI_DriverRole_eks-demo


### PR DESCRIPTION
## Summary

- Adds `aws-ebs-csi-driver` ArgoCD Application (sync wave 3) deploying the Helm chart with IRSA support
- Defines a gp3 StorageClass marked as the cluster default, unblocking PVCs with no explicit `storageClassName` (CMF and MinIO)
- Documents the IRSA role ARN substitution step in the cluster README
- Adds `https://kubernetes-sigs.github.io/aws-ebs-csi-driver` to the infrastructure AppProject `sourceRepos`

Closes #185
Part of #183

## Test plan

- [ ] Fill `REPLACE_WITH_EBS_CSI_DRIVER_ROLE_ARN` in `infrastructure/aws-ebs-csi-driver/overlays/eks-demo/values.yaml` from `terraform output ebs_csi_driver_role_arn`
- [ ] ArgoCD syncs `aws-ebs-csi-driver` app at wave 3 and reports Healthy
- [ ] `kubectl get storageclass` shows `gp3` as the default (`(default)` suffix)
- [ ] Previously Pending PVCs (`confluent-manager-for-apache-flink-pvc`, `minio-data`) bind successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)