### PR TITLE
docs: add FoxyProxy configuration steps to eks-demo README

### DIFF
--- a/clusters/eks-demo/README.md
+++ b/clusters/eks-demo/README.md
@@ -163,7 +163,19 @@ All services are private — exposed only within the VPC. Access from your lapto
 
 ### SOCKS5 Proxy Setup
 
-The same SSM tunnel used for kubectl (Prerequisites Step 3) also proxies browser traffic. Once the tunnel is running on `localhost:1080`, configure **FoxyProxy** (or your browser proxy settings) to route `*.platform.dspdemos.com` through `socks5://localhost:1080`.
+The same SSM tunnel used for kubectl (Prerequisites Step 3) also proxies browser traffic. Once the tunnel is running on `localhost:1080`, configure **FoxyProxy** to route `*.platform.dspdemos.com` through the SOCKS5 proxy:
+
+1. Install the [FoxyProxy browser extension](https://getfoxyproxy.org/) if not already installed.
+2. Open FoxyProxy → **Options** → **Proxies** → **Add**.
+3. Fill in the proxy entry fields:
+   - **Title**: `eks-demo SOCKS5`
+   - **Type**: `SOCKS5`
+   - **Hostname**: `localhost`
+   - **Port**: `1080`
+   - Leave **Username** and **Password** blank.
+4. Click **Proxy by Patterns** → **Add Pattern**, and set the pattern to `*.platform.dspdemos.com`.
+5. Save the proxy entry.
+6. In the FoxyProxy toolbar icon, select **Proxy by Patterns** (or enable the `eks-demo SOCKS5` proxy directly).
 
 DNS is managed automatically by ExternalDNS — no `/etc/hosts` entries are needed.
 


### PR DESCRIPTION
## Summary

- Replaces the vague one-liner FoxyProxy mention in the SOCKS5 Proxy Setup section with concrete, numbered setup instructions
- Documents the exact proxy configuration: Title (`eks-demo SOCKS5`), Type (`SOCKS5`), Hostname (`localhost`), Port (`1080`), no credentials required
- Includes step to add `*.platform.dspdemos.com` URL pattern via FoxyProxy's Proxy by Patterns feature

Part of #183

## Test plan

- [ ] Verify the rendered Markdown displays correctly on GitHub
- [ ] Follow the documented steps end-to-end with FoxyProxy installed to confirm accuracy
- [ ] Confirm `*.platform.dspdemos.com` services are accessible through the proxy after configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)