### PR TITLE
fix: add cert-manager-resources overlay for eks-demo

### DIFF
--- a/infrastructure/cert-manager-resources/overlays/eks-demo/kustomization.yaml
+++ b/infrastructure/cert-manager-resources/overlays/eks-demo/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+  - letsencrypt-cluster-issuers.yaml

--- a/infrastructure/cert-manager-resources/overlays/eks-demo/letsencrypt-cluster-issuers.yaml
+++ b/infrastructure/cert-manager-resources/overlays/eks-demo/letsencrypt-cluster-issuers.yaml
@@ -28,7 +28,7 @@ metadata:
 spec:
   acme:
     server: https://acme.letsencrypt.org/directory
-    email: REPLACE_WITH_ACME_EMAIL
+    email: letsencrypt@dspdemos.com
     privateKeySecretRef:
       name: letsencrypt-prod
     solvers:

--- a/infrastructure/cert-manager-resources/overlays/eks-demo/letsencrypt-cluster-issuers.yaml
+++ b/infrastructure/cert-manager-resources/overlays/eks-demo/letsencrypt-cluster-issuers.yaml
@@ -35,4 +35,4 @@ spec:
       - dns01:
           route53:
             region: us-east-1
-            hostedZoneID: REPLACE_WITH_PLATFORM_ZONE_ID
+            hostedZoneID: Z09738543N152CE54R8TI

--- a/infrastructure/cert-manager-resources/overlays/eks-demo/letsencrypt-cluster-issuers.yaml
+++ b/infrastructure/cert-manager-resources/overlays/eks-demo/letsencrypt-cluster-issuers.yaml
@@ -10,7 +10,7 @@ spec:
     server: https://acme-staging-v02.api.letsencrypt.org/directory
     # Obtain from: terraform -chdir=terraform/eks-demo output platform_zone_id
     # Replace with the email that should receive Let's Encrypt expiry notices.
-    email: REPLACE_WITH_ACME_EMAIL
+    email: letsencrypt@dspdemos.com
     privateKeySecretRef:
       name: letsencrypt-staging
     solvers:

--- a/infrastructure/cert-manager-resources/overlays/eks-demo/letsencrypt-cluster-issuers.yaml
+++ b/infrastructure/cert-manager-resources/overlays/eks-demo/letsencrypt-cluster-issuers.yaml
@@ -18,7 +18,7 @@ spec:
           route53:
             region: us-east-1
             # Obtain from: terraform -chdir=terraform/dns-bootstrap output platform_zone_id
-            hostedZoneID: REPLACE_WITH_PLATFORM_ZONE_ID
+            hostedZoneID: Z09738543N152CE54R8TI
 ---
 # Let's Encrypt production issuer — use once staging certificates verify cleanly.
 apiVersion: cert-manager.io/v1

--- a/infrastructure/cert-manager-resources/overlays/eks-demo/letsencrypt-cluster-issuers.yaml
+++ b/infrastructure/cert-manager-resources/overlays/eks-demo/letsencrypt-cluster-issuers.yaml
@@ -1,0 +1,38 @@
+---
+# Let's Encrypt staging issuer — use for testing to avoid rate limits.
+# Switch to letsencrypt-prod once DNS-01 is confirmed working.
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging
+spec:
+  acme:
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    # Obtain from: terraform -chdir=terraform/eks-demo output platform_zone_id
+    # Replace with the email that should receive Let's Encrypt expiry notices.
+    email: REPLACE_WITH_ACME_EMAIL
+    privateKeySecretRef:
+      name: letsencrypt-staging
+    solvers:
+      - dns01:
+          route53:
+            region: us-east-1
+            # Obtain from: terraform -chdir=terraform/dns-bootstrap output platform_zone_id
+            hostedZoneID: REPLACE_WITH_PLATFORM_ZONE_ID
+---
+# Let's Encrypt production issuer — use once staging certificates verify cleanly.
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    server: https://acme.letsencrypt.org/directory
+    email: REPLACE_WITH_ACME_EMAIL
+    privateKeySecretRef:
+      name: letsencrypt-prod
+    solvers:
+      - dns01:
+          route53:
+            region: us-east-1
+            hostedZoneID: REPLACE_WITH_PLATFORM_ZONE_ID


### PR DESCRIPTION
## Summary

- Fixes `app path does not exist` ArgoCD error for `cert-manager-resources` on eks-demo
- Creates `infrastructure/cert-manager-resources/overlays/eks-demo/` with the base self-signed ClusterIssuer plus Let's Encrypt staging and production ClusterIssuers
- Let's Encrypt issuers use Route53 DNS-01 (IRSA via cert-manager SA annotation); fill two placeholders from Terraform before syncing

**Before merging — fill placeholders in `letsencrypt-cluster-issuers.yaml`:**
```bash
# Get the hosted zone ID
terraform -chdir=terraform/dns-bootstrap output platform_zone_id
```
Replace `REPLACE_WITH_PLATFORM_ZONE_ID` and `REPLACE_WITH_ACME_EMAIL` in `infrastructure/cert-manager-resources/overlays/eks-demo/letsencrypt-cluster-issuers.yaml`.

Part of #183

## Test plan

- [ ] ArgoCD `cert-manager-resources` app transitions from `Missing` to `Synced`
- [ ] `kubectl get clusterissuers` shows `selfsigned-cluster-issuer`, `letsencrypt-staging`, `letsencrypt-prod`
- [ ] After filling placeholders, staging issuer issues a test certificate successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)