### PR TITLE
feat: AWS Load Balancer Controller overlay for eks-demo (Task 11)

### DIFF
--- a/clusters/eks-demo/infrastructure/aws-load-balancer-controller.yaml
+++ b/clusters/eks-demo/infrastructure/aws-load-balancer-controller.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: aws-load-balancer-controller
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "8"
+spec:
+  project: infrastructure
+  sources:
+  - repoURL: https://aws.github.io/eks-charts
+    targetRevision: 1.11.0
+    chart: aws-load-balancer-controller
+    helm:
+      ignoreMissingValueFiles: true
+      valueFiles:
+        - $values/infrastructure/aws-load-balancer-controller/base/values.yaml
+        - $values/infrastructure/aws-load-balancer-controller/overlays/eks-demo/values.yaml
+  - repoURL: https://github.com/osowski/confluent-platform-gitops.git
+    targetRevision: HEAD
+    ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kube-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=false
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/clusters/eks-demo/infrastructure/kustomization.yaml
+++ b/clusters/eks-demo/infrastructure/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
 - kube-prometheus-stack.yaml
 - metrics-server.yaml
 - aws-ebs-csi-driver.yaml
+- aws-load-balancer-controller.yaml
 - reflector.yaml
 - traefik.yaml
 - minio.yaml

--- a/infrastructure/aws-load-balancer-controller/base/values.yaml
+++ b/infrastructure/aws-load-balancer-controller/base/values.yaml
@@ -1,0 +1,18 @@
+---
+clusterName: ""  # Override in overlay
+
+serviceAccount:
+  create: true
+  name: aws-load-balancer-controller
+  annotations:
+    eks.amazonaws.com/role-arn: ""  # Override in overlay
+
+replicaCount: 2
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 200m
+    memory: 256Mi

--- a/infrastructure/aws-load-balancer-controller/overlays/eks-demo/values.yaml
+++ b/infrastructure/aws-load-balancer-controller/overlays/eks-demo/values.yaml
@@ -1,0 +1,6 @@
+---
+clusterName: eks-demo
+
+serviceAccount:
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::829250931565:role/AWSLoadBalancerController_eks-demo


### PR DESCRIPTION
## Summary

- Adds `infrastructure/aws-load-balancer-controller/base/values.yaml` with base Helm values (replica count, resources, service account template)
- Adds `infrastructure/aws-load-balancer-controller/overlays/eks-demo/values.yaml` with cluster name and IRSA role ARN for account `829250931565`
- Adds `clusters/eks-demo/infrastructure/aws-load-balancer-controller.yaml` ArgoCD Application manifest at sync-wave 8, deploying from the `eks-charts` Helm repo
- Registers the app in `clusters/eks-demo/infrastructure/kustomization.yaml`

## Test plan

- [ ] Verify Kustomize renders cleanly: `kubectl kustomize clusters/eks-demo/infrastructure/`
- [ ] After cluster bootstrap (Task 18), confirm ArgoCD syncs the app and pods reach `Running` state in `kube-system`
- [ ] Confirm IRSA annotation is correctly applied to the `aws-load-balancer-controller` service account

Closes #186
Part of #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)