### PR TITLE
feat: Traefik EKS overlay with internal NLB and ExternalDNS wildcard (Task 12)

### DIFF
--- a/clusters/eks-demo/infrastructure/traefik.yaml
+++ b/clusters/eks-demo/infrastructure/traefik.yaml
@@ -7,12 +7,12 @@ metadata:
   finalizers:
     - resources-finalizer.argocd.argoproj.io
   annotations:
-    argocd.argoproj.io/sync-wave: "10"  # Deploy after cert-manager and storage
+    argocd.argoproj.io/sync-wave: "10"
 spec:
   project: infrastructure
   sources:
   - repoURL: oci://ghcr.io/traefik/helm/traefik
-    targetRevision: 38.0.2  # Pin to specific version
+    targetRevision: 38.0.2
     chart: traefik
     helm:
       ignoreMissingValueFiles: true
@@ -24,18 +24,17 @@ spec:
     ref: values
   destination:
     server: https://kubernetes.default.svc
-    namespace: ingress
+    namespace: traefik
   syncPolicy:
     automated:
       prune: true
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
-      - ServerSideApply=true  # Required for CRDs
+      - ServerSideApply=true
     retry:
       limit: 5
       backoff:
         duration: 5s
         factor: 2
         maxDuration: 3m
-  ignoreDifferences: []

--- a/infrastructure/traefik/overlays/eks-demo/values.yaml
+++ b/infrastructure/traefik/overlays/eks-demo/values.yaml
@@ -27,12 +27,19 @@ ports:
   websecure:
     port: 443
 
+# Override base publishedService path — namespace changed from ingress to traefik
+providers:
+  kubernetesIngress:
+    publishedService:
+      pathOverride: "traefik/traefik"
+
 ingressRoute:
   dashboard:
     enabled: true
     matchRule: Host(`traefik.eks-demo.platform.dspdemos.com`)
     entryPoints:
       - websecure
+    tls: {}
 
 logs:
   general:

--- a/infrastructure/traefik/overlays/eks-demo/values.yaml
+++ b/infrastructure/traefik/overlays/eks-demo/values.yaml
@@ -1,0 +1,41 @@
+---
+# EKS overlay: Deployment (not DaemonSet), LoadBalancer service (not NodePort)
+deployment:
+  kind: Deployment
+  replicas: 2
+
+# Remove Kind-specific node selection from base
+nodeSelector: ~
+tolerations: []
+
+service:
+  type: LoadBalancer
+  annotations:
+    # Internal NLB via AWS Load Balancer Controller
+    service.beta.kubernetes.io/aws-load-balancer-type: "nlb-ip"
+    service.beta.kubernetes.io/aws-load-balancer-scheme: "internal"
+    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
+    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
+    # Confluent mandatory tags for NLB resource
+    service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: "cflt_environment=devel,cflt_partition=onprem,cflt_service=eks-demo,cflt_managed_by=kubernetes,cflt_managed_id=traefik-nlb,cflt_protected=false"
+    # ExternalDNS wildcard: creates *.eks-demo.platform.dspdemos.com → NLB
+    external-dns.alpha.kubernetes.io/hostname: "*.eks-demo.platform.dspdemos.com"
+
+ports:
+  web:
+    port: 80
+  websecure:
+    port: 443
+
+ingressRoute:
+  dashboard:
+    enabled: true
+    matchRule: Host(`traefik.eks-demo.platform.dspdemos.com`)
+    entryPoints:
+      - websecure
+
+logs:
+  general:
+    level: INFO
+  access:
+    enabled: true


### PR DESCRIPTION
## Summary

- Adds `infrastructure/traefik/overlays/eks-demo/values.yaml` — switches from DaemonSet/NodePort (Kind) to Deployment/LoadBalancer (EKS), internal NLB via AWS Load Balancer Controller annotations, ExternalDNS wildcard for `*.eks-demo.platform.dspdemos.com`, and enables the Traefik dashboard at `traefik.eks-demo.platform.dspdemos.com`
- Updates `clusters/eks-demo/infrastructure/traefik.yaml` — fixes destination namespace from `ingress` to `traefik`

## Test plan

- [ ] Verify Kustomize renders cleanly: `kubectl kustomize clusters/eks-demo/infrastructure/`
- [ ] After Phase 1 bootstrap (Task 18), confirm ArgoCD syncs Traefik and an internal NLB is provisioned in AWS
- [ ] Confirm ExternalDNS creates the `*.eks-demo.platform.dspdemos.com` wildcard record in Route53
- [ ] Verify Traefik dashboard is reachable at `traefik.eks-demo.platform.dspdemos.com` via SOCKS5 proxy

Closes #187
Part of #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)