### PR TITLE
feat: add cert-manager and trust-manager overlays for eks-demo (Task 13)

### DIFF
--- a/infrastructure/cert-manager/overlays/eks-demo/values.yaml
+++ b/infrastructure/cert-manager/overlays/eks-demo/values.yaml
@@ -1,4 +1,4 @@
 serviceAccount:
   annotations:
     # Obtain from: terraform -chdir=terraform/eks-demo output -raw cert_manager_role_arn
-    eks.amazonaws.com/role-arn: REPLACE_WITH_CERT_MANAGER_ROLE_ARN
+    eks.amazonaws.com/role-arn: arn:aws:iam::829250931565:role/AmazonEKS_CertManager_eks-demo

--- a/infrastructure/cert-manager/overlays/eks-demo/values.yaml
+++ b/infrastructure/cert-manager/overlays/eks-demo/values.yaml
@@ -1,0 +1,4 @@
+serviceAccount:
+  annotations:
+    # Obtain from: terraform -chdir=terraform/eks-demo output -raw cert_manager_role_arn
+    eks.amazonaws.com/role-arn: REPLACE_WITH_CERT_MANAGER_ROLE_ARN

--- a/infrastructure/trust-manager/overlays/eks-demo/values.yaml
+++ b/infrastructure/trust-manager/overlays/eks-demo/values.yaml
@@ -1,0 +1,1 @@
+# No cluster-specific overrides needed for trust-manager on eks-demo


### PR DESCRIPTION
## Summary

- Creates `infrastructure/cert-manager/overlays/eks-demo/values.yaml` — annotates the cert-manager ServiceAccount with the IRSA role ARN so cert-manager can write DNS-01 TXT records to Route53 for Let's Encrypt validation
- Creates `infrastructure/trust-manager/overlays/eks-demo/values.yaml` — no-op passthrough (base config is sufficient for eks-demo)

Both cluster Application manifests (`cert-manager.yaml`, `trust-manager.yaml`) already exist and reference these overlay paths — they were previously silently skipped due to `ignoreMissingValueFiles: true`.

**Before merging — fill the cert-manager IRSA ARN:**
```bash
terraform -chdir=terraform/eks-demo output -raw cert_manager_role_arn
```
Replace `REPLACE_WITH_CERT_MANAGER_ROLE_ARN` in `infrastructure/cert-manager/overlays/eks-demo/values.yaml`.

Closes #188
Part of #183

## Test plan

- [ ] ArgoCD `cert-manager` app resyncs and cert-manager SA has the `eks.amazonaws.com/role-arn` annotation
- [ ] `kubectl get sa cert-manager -n cert-manager -o jsonpath='{.metadata.annotations}'` shows the role ARN
- [ ] After Let's Encrypt issuers are configured (Task 14), DNS-01 challenge succeeds via Route53

🤖 Generated with [Claude Code](https://claude.com/claude-code)