### PR TITLE
feat: cert-manager-resources overlay with Let's Encrypt issuers for eks-demo (Task 14)

### DIFF
--- a/clusters/eks-demo/infrastructure/cert-manager-resources.yaml
+++ b/clusters/eks-demo/infrastructure/cert-manager-resources.yaml
@@ -21,3 +21,11 @@ spec:
     automated:
       prune: true
       selfHeal: true
+    syncOptions:
+      - CreateNamespace=false
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m


### PR DESCRIPTION
## Summary

Task 14 was substantially completed by PR #220 which created the overlay with real zone ID and email already filled in. This PR completes the task by adding `syncOptions` and `retry` to the `cert-manager-resources` ArgoCD Application to match the standard cluster app pattern.

**Overlay renders (validated):**
- `selfsigned-cluster-issuer` — from base
- `letsencrypt-staging` — DNS-01 via Route53, zone `Z09738543N152CE54R8TI`
- `letsencrypt-prod` — DNS-01 via Route53, same zone

Closes #189
Part of #183

## Test plan

- [ ] `kubectl kustomize infrastructure/cert-manager-resources/overlays/eks-demo` renders all three ClusterIssuers
- [ ] After cert-manager IRSA SA is active (Task 13), `letsencrypt-staging` ClusterIssuer reaches `Ready` state
- [ ] DNS-01 challenge creates TXT records in Route53 hosted zone `Z09738543N152CE54R8TI`

🤖 Generated with [Claude Code](https://claude.com/claude-code)