### PR TITLE
feat: add metrics-server EKS overlay for eks-demo (Task 15)

### DIFF
--- a/infrastructure/metrics-server/overlays/eks-demo/values.yaml
+++ b/infrastructure/metrics-server/overlays/eks-demo/values.yaml
@@ -1,0 +1,6 @@
+# EKS has proper kubelet TLS — do NOT use --kubelet-insecure-tls
+replicas: 2
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1


### PR DESCRIPTION
## Summary

- Creates `infrastructure/metrics-server/overlays/eks-demo/values.yaml` — 2 replicas with PodDisruptionBudget for HA; no `--kubelet-insecure-tls` flag since EKS uses proper kubelet TLS (unlike Kind)
- `clusters/eks-demo/infrastructure/reflector.yaml` and `metrics-server.yaml` already existed from Task 9 scaffolding

Closes #190
Part of #183

## Test plan

- [ ] ArgoCD `metrics-server` app syncs and shows Healthy
- [ ] `kubectl get pods -n kube-system -l app.kubernetes.io/name=metrics-server` shows 2 Running pods
- [ ] `kubectl top nodes` returns node resource usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)