### PR TITLE
feat: add ArgoCD ingress and config cluster apps for eks-demo (Task 17)

### DIFF
--- a/infrastructure/ingresses/overlays/eks-demo/argocd-certificate-patch.yaml
+++ b/infrastructure/ingresses/overlays/eks-demo/argocd-certificate-patch.yaml
@@ -7,3 +7,7 @@ metadata:
 spec:
   dnsNames:
     - argocd.eks-demo.platform.dspdemos.com
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: letsencrypt-staging


### PR DESCRIPTION
## Summary

All Task 17 files were already present from prior tasks except for one bug: `infrastructure/ingresses/overlays/eks-demo/argocd-certificate-patch.yaml` was missing `issuerRef`, causing cert-manager to silently fall back to the base cluster's `selfsigned-cluster-issuer` instead of `letsencrypt-staging`.

**Fix:** Added `issuerRef` to the certificate patch:
```yaml
issuerRef:
  group: cert-manager.io
  kind: ClusterIssuer
  name: letsencrypt-staging
```

**Validated kustomize render** — produces:
- `Certificate` for `argocd.eks-demo.platform.dspdemos.com` via `letsencrypt-staging`, secret `argocd-server-tls`
- `IngressRoute` routing `argocd.eks-demo.platform.dspdemos.com` → `argocd-server:443` with TLS from `argocd-server-tls`
- `ServersTransport` with `insecureSkipVerify: true` (ArgoCD serves its own internal TLS)

Closes #192
Part of #183

## Test plan

- [ ] `infra-ingresses` ArgoCD app syncs at wave 80 — Certificate, IngressRoute, and ServersTransport all created
- [ ] cert-manager issues a staging certificate for `argocd.eks-demo.platform.dspdemos.com`
- [ ] ArgoCD UI reachable at `https://argocd.eks-demo.platform.dspdemos.com` via SOCKS5 proxy (in addition to port-forward)

🤖 Generated with [Claude Code](https://claude.com/claude-code)