### PR TITLE
fix: Phase 1 review fixes — minio selfHeal, gp3 PVC, empty ignoreDifferences

### DIFF
--- a/clusters/eks-demo/infrastructure/aws-ebs-csi-driver.yaml
+++ b/clusters/eks-demo/infrastructure/aws-ebs-csi-driver.yaml
@@ -37,4 +37,3 @@ spec:
         duration: 5s
         factor: 2
         maxDuration: 3m
-  ignoreDifferences: []

--- a/clusters/eks-demo/infrastructure/metrics-server.yaml
+++ b/clusters/eks-demo/infrastructure/metrics-server.yaml
@@ -37,4 +37,3 @@ spec:
         duration: 5s
         factor: 2
         maxDuration: 3m
-  ignoreDifferences: []

--- a/clusters/eks-demo/infrastructure/minio.yaml
+++ b/clusters/eks-demo/infrastructure/minio.yaml
@@ -20,7 +20,7 @@ spec:
   syncPolicy:
     automated:
       prune: true
-      selfHeal: false
+      selfHeal: true
     syncOptions:
       - CreateNamespace=true
     retry:

--- a/infrastructure/minio/overlays/eks-demo/kustomization.yaml
+++ b/infrastructure/minio/overlays/eks-demo/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
 patches:
   - path: ingressroute-patch.yaml
   - path: secret-patch.yaml
+  - path: pvc-patch.yaml
 
 labels:
 - includeSelectors: false

--- a/infrastructure/minio/overlays/eks-demo/pvc-patch.yaml
+++ b/infrastructure/minio/overlays/eks-demo/pvc-patch.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: minio-data
+  namespace: storage
+spec:
+  storageClassName: gp3


### PR DESCRIPTION
## Summary

Addresses Medium findings from the Phase 1 code review. All Critical findings were already resolved on main via PRs #228 and #229.

| Finding | File | Fix |
|---------|------|-----|
| `minio selfHeal: false` | `clusters/eks-demo/infrastructure/minio.yaml` | Changed to `true` — consistent with all other Phase 1 apps; prevents in-cluster credential edits from diverging from git |
| MinIO PVC no `storageClassName` | `infrastructure/minio/overlays/eks-demo/` | Added `pvc-patch.yaml` setting `storageClassName: gp3`; without it, two default StorageClasses (built-in `gp2` + `gp3` from EBS CSI chart) leave provisioner behavior undefined |
| Empty `ignoreDifferences: []` | `aws-ebs-csi-driver.yaml`, `metrics-server.yaml` | Removed no-op scaffolding artifact |

**Kustomize render validated** — MinIO overlay renders PVC with `storageClassName: gp3`.

Part of #183

## Test plan

- [ ] MinIO PVC binds to a `gp3` volume (not `gp2`)
- [ ] `kubectl get pvc minio-data -n storage -o jsonpath='{.spec.storageClassName}'` returns `gp3`
- [ ] ArgoCD `minio` app self-heals on next drift (instead of leaving manual edits in place)

🤖 Generated with [Claude Code](https://claude.com/claude-code)