### PR TITLE
feat: add ExternalDNS overlay for eks-demo cluster

### DIFF
--- a/clusters/eks-demo/infrastructure/external-dns.yaml
+++ b/clusters/eks-demo/infrastructure/external-dns.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: external-dns
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "18"  # After traefik/LB (10), before cert-manager-resources/ingresses (75+)
+spec:
+  project: infrastructure
+  sources:
+  - repoURL: https://kubernetes-sigs.github.io/external-dns/
+    targetRevision: 1.15.0
+    chart: external-dns
+    helm:
+      ignoreMissingValueFiles: true
+      valueFiles:
+        - $values/infrastructure/external-dns/base/values.yaml
+        - $values/infrastructure/external-dns/overlays/eks-demo/values.yaml
+  - repoURL: https://github.com/osowski/confluent-platform-gitops.git
+    targetRevision: HEAD
+    ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: external-dns
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/clusters/eks-demo/infrastructure/external-dns.yaml
+++ b/clusters/eks-demo/infrastructure/external-dns.yaml
@@ -12,7 +12,7 @@ spec:
   project: infrastructure
   sources:
   - repoURL: https://kubernetes-sigs.github.io/external-dns/
-    targetRevision: 1.15.0
+    targetRevision: 1.15.0  # Pin to specific version
     chart: external-dns
     helm:
       ignoreMissingValueFiles: true

--- a/clusters/eks-demo/infrastructure/kustomization.yaml
+++ b/clusters/eks-demo/infrastructure/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
 - metrics-server.yaml
 - aws-ebs-csi-driver.yaml
 - aws-load-balancer-controller.yaml
+- external-dns.yaml
 - reflector.yaml
 - traefik.yaml
 - minio.yaml

--- a/infrastructure/external-dns/base/values.yaml
+++ b/infrastructure/external-dns/base/values.yaml
@@ -1,0 +1,17 @@
+provider:
+  name: aws
+
+sources:
+  - service
+
+policy: sync
+registry: txt
+interval: 1m
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    cpu: 100m
+    memory: 128Mi

--- a/infrastructure/external-dns/base/values.yaml
+++ b/infrastructure/external-dns/base/values.yaml
@@ -1,6 +1,9 @@
 provider:
   name: aws
 
+# Only 'service' is listed — DNS is managed via a wildcard annotation on the Traefik
+# LoadBalancer Service, so per-Ingress record registration is redundant and would
+# cause Route53 write churn and potential TXT record conflicts.
 sources:
   - service
 

--- a/infrastructure/external-dns/overlays/eks-demo/values.yaml
+++ b/infrastructure/external-dns/overlays/eks-demo/values.yaml
@@ -1,0 +1,8 @@
+domainFilters:
+  - platform.dspdemos.com
+
+txtOwnerId: eks-demo
+
+serviceAccount:
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::829250931565:role/ExternalDNS_eks-demo

--- a/infrastructure/external-dns/overlays/eks-demo/values.yaml
+++ b/infrastructure/external-dns/overlays/eks-demo/values.yaml
@@ -1,6 +1,9 @@
 domainFilters:
   - platform.dspdemos.com
 
+# txtOwnerId scopes all TXT ownership records to this cluster, making policy: sync
+# safe on the shared platform.dspdemos.com zone — ExternalDNS will only delete
+# records it originally created for eks-demo, not records owned by other clusters.
 txtOwnerId: eks-demo
 
 serviceAccount:


### PR DESCRIPTION
## Summary
- Creates `infrastructure/external-dns/base/values.yaml` with AWS provider, service sources, sync policy, and resource limits
- Creates `infrastructure/external-dns/overlays/eks-demo/values.yaml` with `platform.dspdemos.com` domain filter, `eks-demo` TXT owner ID, and IRSA role ARN
- Adds `clusters/eks-demo/infrastructure/external-dns.yaml` ArgoCD Application at sync wave 18 (after Traefik LB provisioning, before ingress routing)

## Test plan
- [ ] ArgoCD syncs `external-dns` Application in `external-dns` namespace
- [ ] ExternalDNS pod has `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE` injected via IRSA
- [ ] Route53 TXT records (`txt-*.eks-demo.platform.dspdemos.com`) appear for ownership registry
- [ ] Wildcard A/CNAME record `*.eks-demo.platform.dspdemos.com` resolves to Traefik NLB

Closes [#194](https://github.com/osowski/confluent-platform-gitops/issues/194)

🤖 Generated with [Claude Code](https://claude.com/claude-code)