### PR TITLE
feat: add HTTP-to-HTTPS redirect on Traefik web entrypoint for eks-demo

### DIFF
--- a/infrastructure/traefik/overlays/eks-demo/values.yaml
+++ b/infrastructure/traefik/overlays/eks-demo/values.yaml
@@ -24,6 +24,11 @@ service:
 ports:
   web:
     port: 80
+    redirections:
+      entryPoint:
+        to: websecure
+        scheme: https
+        permanent: true
   websecure:
     port: 443
 


### PR DESCRIPTION
## Summary
- Adds a permanent (301) entrypoint-level redirect on port 80 → 443 in the Traefik eks-demo overlay
- Covers all services behind Traefik — IngressRoutes (ArgoCD, Traefik dashboard) and Kubernetes Ingress objects (Grafana, Alertmanager, Prometheus) — without per-route middleware changes

## Why entrypoint-level vs per-route middleware
A global `redirections.entryPoint` in Traefik values applies to all traffic on port 80 regardless of resource type, eliminating the need to add a `Middleware` CRD and reference it in every IngressRoute and Ingress annotation.

## Test plan
- [ ] `curl -I http://grafana.eks-demo.platform.dspdemos.com` returns `301 Moved Permanently` with `Location: https://...`
- [ ] `curl -I http://argocd.eks-demo.platform.dspdemos.com` returns `301`
- [ ] HTTPS URLs continue to load normally in browser via FoxyProxy

Part of [#195](https://github.com/osowski/confluent-platform-gitops/issues/195)

🤖 Generated with [Claude Code](https://claude.com/claude-code)