### PR TITLE
feat: switch Let's Encrypt issuer from staging to prod for eks-demo

### DIFF
--- a/infrastructure/ingresses/overlays/eks-demo/argocd-certificate-patch.yaml
+++ b/infrastructure/ingresses/overlays/eks-demo/argocd-certificate-patch.yaml
@@ -10,4 +10,4 @@ spec:
   issuerRef:
     group: cert-manager.io
     kind: ClusterIssuer
-    name: letsencrypt-staging
+    name: letsencrypt-prod

--- a/infrastructure/kube-prometheus-stack/overlays/eks-demo/values.yaml
+++ b/infrastructure/kube-prometheus-stack/overlays/eks-demo/values.yaml
@@ -14,7 +14,7 @@ alertmanager:
     enabled: true
     ingressClassName: traefik
     annotations:
-      cert-manager.io/cluster-issuer: letsencrypt-staging
+      cert-manager.io/cluster-issuer: letsencrypt-prod
     hosts:
       - alertmanager.eks-demo.platform.dspdemos.com
     paths: [/]
@@ -38,7 +38,7 @@ grafana:
     enabled: true
     ingressClassName: traefik
     annotations:
-      cert-manager.io/cluster-issuer: letsencrypt-staging
+      cert-manager.io/cluster-issuer: letsencrypt-prod
     hosts:
       - grafana.eks-demo.platform.dspdemos.com
     path: /
@@ -66,7 +66,7 @@ prometheus:
     enabled: true
     ingressClassName: traefik
     annotations:
-      cert-manager.io/cluster-issuer: letsencrypt-staging
+      cert-manager.io/cluster-issuer: letsencrypt-prod
     hosts:
       - prometheus.eks-demo.platform.dspdemos.com
     paths: [/]


### PR DESCRIPTION
## Summary
- Swaps `letsencrypt-staging` → `letsencrypt-prod` in all eks-demo cert-manager issuer references
- Affects: Alertmanager, Grafana, and Prometheus Ingress annotations (`kube-prometheus-stack` overlay) and ArgoCD Certificate (`argocd-certificate-patch.yaml`)
- The `letsencrypt-staging` ClusterIssuer remains defined in `cert-manager-resources` for future use

## Pre-merge checklist
- [ ] Merge PR [#233](https://github.com/osowski/confluent-platform-gitops/pull/233) (HTTP→HTTPS redirect) first so browser access works cleanly
- [ ] After merge, delete the existing staging TLS Secrets to force cert-manager to re-issue with the prod issuer:
  ```
  kubectl delete secret alertmanager-tls grafana-tls prometheus-tls -n monitoring
  kubectl delete secret argocd-server-tls -n argocd
  ```
- [ ] Verify new certs are issued (no browser untrusted CA warning)

Closes [#232](https://github.com/osowski/confluent-platform-gitops/issues/232)

🤖 Generated with [Claude Code](https://claude.com/claude-code)