### PR TITLE
feat: add Keycloak overlay for eks-demo cluster

### DIFF
--- a/clusters/eks-demo/workloads/keycloak.yaml
+++ b/clusters/eks-demo/workloads/keycloak.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: keycloak
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "102"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: workloads
+  source:
+    repoURL: https://github.com/osowski/confluent-platform-gitops.git
+    targetRevision: HEAD
+    path: workloads/keycloak/overlays/eks-demo
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: keycloak
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: false
+    syncOptions:
+      - CreateNamespace=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/clusters/eks-demo/workloads/kustomization.yaml
+++ b/clusters/eks-demo/workloads/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 
 resources:
   - namespaces.yaml
+  - keycloak.yaml
   - cfk-operator.yaml
   - confluent-resources.yaml
   - workload-ingresses.yaml

--- a/workloads/keycloak/overlays/eks-demo/certificate-patch.yaml
+++ b/workloads/keycloak/overlays/eks-demo/certificate-patch.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: keycloak-tls
+  namespace: keycloak
+spec:
+  dnsNames:
+    - keycloak.eks-demo.platform.dspdemos.com
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: letsencrypt-prod

--- a/workloads/keycloak/overlays/eks-demo/ingress-patch.yaml
+++ b/workloads/keycloak/overlays/eks-demo/ingress-patch.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: keycloak
+  namespace: keycloak
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`keycloak.eks-demo.platform.dspdemos.com`)
+      kind: Rule
+      services:
+        - name: keycloak
+          port: 8080
+  tls:
+    secretName: keycloak-tls

--- a/workloads/keycloak/overlays/eks-demo/keycloak-external-service-patch.yaml
+++ b/workloads/keycloak/overlays/eks-demo/keycloak-external-service-patch.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak-external
+  namespace: keycloak
+spec:
+  type: ClusterIP

--- a/workloads/keycloak/overlays/eks-demo/keycloak-patch.yaml
+++ b/workloads/keycloak/overlays/eks-demo/keycloak-patch.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: keycloak
+  namespace: keycloak
+spec:
+  template:
+    spec:
+      containers:
+      - name: keycloak
+        env:
+        - name: KC_HOSTNAME
+          value: https://keycloak.eks-demo.platform.dspdemos.com
+        - name: KC_HOSTNAME_ADMIN
+          value: https://keycloak.eks-demo.platform.dspdemos.com
+        - name: KC_HOSTNAME_BACKCHANNEL_DYNAMIC
+          value: "true"

--- a/workloads/keycloak/overlays/eks-demo/kustomization.yaml
+++ b/workloads/keycloak/overlays/eks-demo/kustomization.yaml
@@ -30,6 +30,11 @@ patches:
       kind: ConfigMap
       name: keycloak-realm
 
+  - path: keycloak-external-service-patch.yaml
+    target:
+      kind: Service
+      name: keycloak-external
+
 labels:
 - includeSelectors: false
   includeTemplates: true

--- a/workloads/keycloak/overlays/eks-demo/kustomization.yaml
+++ b/workloads/keycloak/overlays/eks-demo/kustomization.yaml
@@ -25,6 +25,11 @@ patches:
       kind: PersistentVolumeClaim
       name: postgres-pvc
 
+  - path: realm-configmap.yaml
+    target:
+      kind: ConfigMap
+      name: keycloak-realm
+
 labels:
 - includeSelectors: false
   includeTemplates: true

--- a/workloads/keycloak/overlays/eks-demo/kustomization.yaml
+++ b/workloads/keycloak/overlays/eks-demo/kustomization.yaml
@@ -1,0 +1,32 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+patches:
+  - path: keycloak-patch.yaml
+    target:
+      kind: StatefulSet
+      name: keycloak
+
+  - path: certificate-patch.yaml
+    target:
+      kind: Certificate
+      name: keycloak-tls
+
+  - path: ingress-patch.yaml
+    target:
+      kind: IngressRoute
+      name: keycloak
+
+  - path: postgres-pvc-patch.yaml
+    target:
+      kind: PersistentVolumeClaim
+      name: postgres-pvc
+
+labels:
+- includeSelectors: false
+  includeTemplates: true
+  pairs:
+    cluster: eks-demo

--- a/workloads/keycloak/overlays/eks-demo/postgres-pvc-patch.yaml
+++ b/workloads/keycloak/overlays/eks-demo/postgres-pvc-patch.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-pvc
+  namespace: keycloak
+spec:
+  storageClassName: gp3

--- a/workloads/keycloak/overlays/eks-demo/realm-configmap.yaml
+++ b/workloads/keycloak/overlays/eks-demo/realm-configmap.yaml
@@ -1,0 +1,381 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: keycloak-realm
+  namespace: keycloak
+data:
+  confluent-realm.json: |
+    {
+      "realm": "confluent",
+      "enabled": true,
+      "sslRequired": "none",
+      "registrationAllowed": false,
+      "resetPasswordAllowed": false,
+      "rememberMe": true,
+      "accessTokenLifespan": 604800,
+      "ssoSessionIdleTimeout": 604800,
+      "ssoSessionMaxLifespan": 604800,
+      "groups": [
+        {
+          "name": "admins",
+          "path": "/admins"
+        },
+        {
+          "name": "shapes",
+          "path": "/shapes"
+        },
+        {
+          "name": "colors",
+          "path": "/colors"
+        }
+      ],
+      "users": [
+        {
+          "username": "admin@dspdemos.com",
+          "enabled": true,
+          "email": "admin@dspdemos.com",
+          "firstName": "Admin",
+          "lastName": "User",
+          "credentials": [
+            {
+              "type": "password",
+              "value": "admin123",
+              "temporary": false
+            }
+          ],
+          "groups": ["/admins"]
+        },
+        {
+          "username": "user-square@dspdemos.com",
+          "enabled": true,
+          "email": "user-square@dspdemos.com",
+          "firstName": "Square",
+          "lastName": "User",
+          "credentials": [
+            {
+              "type": "password",
+              "value": "square123",
+              "temporary": false
+            }
+          ],
+          "groups": ["/shapes"]
+        },
+        {
+          "username": "user-circle@dspdemos.com",
+          "enabled": true,
+          "email": "user-circle@dspdemos.com",
+          "firstName": "Circle",
+          "lastName": "User",
+          "credentials": [
+            {
+              "type": "password",
+              "value": "circle123",
+              "temporary": false
+            }
+          ],
+          "groups": ["/shapes"]
+        },
+        {
+          "username": "user-triangle@dspdemos.com",
+          "enabled": true,
+          "email": "user-triangle@dspdemos.com",
+          "firstName": "Triangle",
+          "lastName": "User",
+          "credentials": [
+            {
+              "type": "password",
+              "value": "triangle123",
+              "temporary": false
+            }
+          ],
+          "groups": ["/shapes"]
+        },
+        {
+          "username": "user-trapezoid@dspdemos.com",
+          "enabled": true,
+          "email": "user-trapezoid@dspdemos.com",
+          "firstName": "Trapezoid",
+          "lastName": "User",
+          "credentials": [
+            {
+              "type": "password",
+              "value": "trapezoid123",
+              "temporary": false
+            }
+          ],
+          "groups": ["/shapes"]
+        },
+        {
+          "username": "user-diamond@dspdemos.com",
+          "enabled": true,
+          "email": "user-diamond@dspdemos.com",
+          "firstName": "Diamond",
+          "lastName": "User",
+          "credentials": [
+            {
+              "type": "password",
+              "value": "diamond123",
+              "temporary": false
+            }
+          ],
+          "groups": ["/shapes"]
+        },
+        {
+          "username": "user-red@dspdemos.com",
+          "enabled": true,
+          "email": "user-red@dspdemos.com",
+          "firstName": "Red",
+          "lastName": "User",
+          "credentials": [
+            {
+              "type": "password",
+              "value": "red123",
+              "temporary": false
+            }
+          ],
+          "groups": ["/colors"]
+        },
+        {
+          "username": "user-green@dspdemos.com",
+          "enabled": true,
+          "email": "user-green@dspdemos.com",
+          "firstName": "Green",
+          "lastName": "User",
+          "credentials": [
+            {
+              "type": "password",
+              "value": "green123",
+              "temporary": false
+            }
+          ],
+          "groups": ["/colors"]
+        },
+        {
+          "username": "user-orange@dspdemos.com",
+          "enabled": true,
+          "email": "user-orange@dspdemos.com",
+          "firstName": "Orange",
+          "lastName": "User",
+          "credentials": [
+            {
+              "type": "password",
+              "value": "orange123",
+              "temporary": false
+            }
+          ],
+          "groups": ["/colors"]
+        },
+        {
+          "username": "user-blue@dspdemos.com",
+          "enabled": true,
+          "email": "user-blue@dspdemos.com",
+          "firstName": "Blue",
+          "lastName": "User",
+          "credentials": [
+            {
+              "type": "password",
+              "value": "blue123",
+              "temporary": false
+            }
+          ],
+          "groups": ["/colors"]
+        },
+        {
+          "username": "user-yellow@dspdemos.com",
+          "enabled": true,
+          "email": "user-yellow@dspdemos.com",
+          "firstName": "Yellow",
+          "lastName": "User",
+          "credentials": [
+            {
+              "type": "password",
+              "value": "yellow123",
+              "temporary": false
+            }
+          ],
+          "groups": ["/colors"]
+        }
+      ],
+      "clients": [
+        {
+          "clientId": "cmf",
+          "enabled": true,
+          "protocol": "openid-connect",
+          "publicClient": false,
+          "directAccessGrantsEnabled": true,
+          "serviceAccountsEnabled": true,
+          "authorizationServicesEnabled": true,
+          "redirectUris": ["*"],
+          "webOrigins": ["*"],
+          "secret": "cmf-secret",
+          "protocolMappers": [
+            {
+              "name": "email",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-usermodel-property-mapper",
+              "consentRequired": false,
+              "config": {
+                "userinfo.token.claim": "true",
+                "user.attribute": "email",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "email",
+                "jsonType.label": "String"
+              }
+            },
+            {
+              "name": "groups",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-group-membership-mapper",
+              "consentRequired": false,
+              "config": {
+                "full.path": "false",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "groups",
+                "userinfo.token.claim": "true"
+              }
+            },
+            {
+              "name": "audience-mapper",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-audience-mapper",
+              "consentRequired": false,
+              "config": {
+                "included.client.audience": "cmf",
+                "id.token.claim": "true",
+                "access.token.claim": "true"
+              }
+            }
+          ]
+        },
+        {
+          "clientId": "controlcenter",
+          "enabled": true,
+          "protocol": "openid-connect",
+          "publicClient": false,
+          "directAccessGrantsEnabled": true,
+          "serviceAccountsEnabled": true,
+          "standardFlowEnabled": true,
+          "redirectUris": [
+            "https://controlcenter.eks-demo.platform.dspdemos.com/api/metadata/security/1.0/oidc/authorization-code/callback"
+          ],
+          "webOrigins": ["*"],
+          "secret": "controlcenter-secret",
+          "attributes": {
+            "oauth2.device.authorization.grant.enabled": "true"
+          },
+          "defaultClientScopes": [
+            "web-origins",
+            "acr",
+            "profile",
+            "roles",
+            "email"
+          ],
+          "optionalClientScopes": [
+            "address",
+            "phone",
+            "microprofile-jwt",
+            "offline_access"
+          ],
+          "protocolMappers": [
+            {
+              "name": "email",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-usermodel-property-mapper",
+              "consentRequired": false,
+              "config": {
+                "userinfo.token.claim": "true",
+                "user.attribute": "email",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "email",
+                "jsonType.label": "String"
+              }
+            },
+            {
+              "name": "groups",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-group-membership-mapper",
+              "consentRequired": false,
+              "config": {
+                "full.path": "false",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "groups",
+                "userinfo.token.claim": "true"
+              }
+            }
+          ]
+        },
+        {
+          "clientId": "kafka",
+          "enabled": true,
+          "protocol": "openid-connect",
+          "publicClient": false,
+          "directAccessGrantsEnabled": true,
+          "serviceAccountsEnabled": true,
+          "redirectUris": ["*"],
+          "webOrigins": ["*"],
+          "secret": "kafka-secret",
+          "protocolMappers": [
+            {
+              "name": "email",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-usermodel-property-mapper",
+              "consentRequired": false,
+              "config": {
+                "userinfo.token.claim": "true",
+                "user.attribute": "email",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "email",
+                "jsonType.label": "String"
+              }
+            },
+            {
+              "name": "groups",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-group-membership-mapper",
+              "consentRequired": false,
+              "config": {
+                "full.path": "false",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "claim.name": "groups",
+                "userinfo.token.claim": "true"
+              }
+            }
+          ]
+        },
+        {
+          "clientId": "confluent-sso",
+          "enabled": true,
+          "protocol": "openid-connect",
+          "publicClient": false,
+          "directAccessGrantsEnabled": true,
+          "redirectUris": ["*"],
+          "webOrigins": ["*"],
+          "secret": "confluent-sso-secret"
+        }
+      ],
+      "roles": {
+        "realm": [
+          {
+            "name": "flink-admin",
+            "description": "Full Flink administration access"
+          },
+          {
+            "name": "flink-shapes-user",
+            "description": "Access to shapes environment"
+          },
+          {
+            "name": "flink-colors-user",
+            "description": "Access to colors environment"
+          }
+        ]
+      },
+      "clientScopeMappings": {},
+      "defaultRoles": ["offline_access", "uma_authorization"]
+    }


### PR DESCRIPTION
## Summary
- Creates `workloads/keycloak/overlays/eks-demo/` with cluster-specific patches
- `keycloak-patch.yaml` — sets `KC_HOSTNAME` / `KC_HOSTNAME_ADMIN` to `keycloak.eks-demo.platform.dspdemos.com` and enables backchannel dynamic routing
- `certificate-patch.yaml` — overrides base `selfsigned-cluster-issuer` with `letsencrypt-prod` for the `keycloak-tls` Certificate
- `ingress-patch.yaml` — sets IngressRoute host and `websecure`-only entrypoint with TLS termination (HTTP→HTTPS handled at Traefik entrypoint level per PR [#233](https://github.com/osowski/confluent-platform-gitops/pull/233))
- `postgres-pvc-patch.yaml` — overrides base `storageClassName: standard` with `gp3` (EKS has no `standard` class)
- `realm-configmap.yaml` — strategic merge patch replacing all user email/username domains from `osow.ski` → `dspdemos.com` and updating the controlcenter OIDC redirect URI to `eks-demo.platform.dspdemos.com`
- Adds `clusters/eks-demo/workloads/keycloak.yaml` ArgoCD Application at sync wave 102

## Test plan
- [ ] ArgoCD syncs `keycloak` Application in `keycloak` namespace
- [ ] Postgres PVC bound to a `gp3` volume
- [ ] cert-manager issues `keycloak-tls` cert via `letsencrypt-prod` DNS-01
- [ ] `https://keycloak.eks-demo.platform.dspdemos.com` loads Keycloak login page
- [ ] Login with `admin@dspdemos.com` / `admin123` succeeds
- [ ] Confluent realm exists with all 11 users under `dspdemos.com` email domain
- [ ] controlcenter client redirect URI points to `eks-demo.platform.dspdemos.com`
- [ ] Realm sync Job completes successfully (check Job status in `keycloak` namespace)

Closes [#196](https://github.com/osowski/confluent-platform-gitops/issues/196)

🤖 Generated with [Claude Code](https://claude.com/claude-code)