### PR TITLE
fix: clear nodePort field when converting keycloak-external to ClusterIP

### DIFF
--- a/workloads/keycloak/overlays/eks-demo/keycloak-external-service-patch.yaml
+++ b/workloads/keycloak/overlays/eks-demo/keycloak-external-service-patch.yaml
@@ -6,3 +6,8 @@ metadata:
   namespace: keycloak
 spec:
   type: ClusterIP
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+    nodePort: null


### PR DESCRIPTION
## Summary
Kubernetes rejects a `ClusterIP` service that still has an explicit `nodePort` value on its port spec. The initial fix in PR [#235](https://github.com/osowski/confluent-platform-gitops/pull/235) patched the service `type` to `ClusterIP` but did not null out the `nodePort: 30080` field inherited from the base, causing:

```
Service "keycloak-external" is invalid: spec.ports[0].nodePort: Forbidden: may not be used when `type` is 'ClusterIP'
```

This fix adds `nodePort: null` to the port spec in the patch, clearing the field and allowing the type change to apply cleanly.

## Test plan
- [ ] ArgoCD syncs `keycloak` Application without the Service validation error
- [ ] `kubectl get svc -n keycloak keycloak-external` shows `TYPE: ClusterIP` with no nodePort

Part of [#196](https://github.com/osowski/confluent-platform-gitops/issues/196)

🤖 Generated with [Claude Code](https://claude.com/claude-code)