### PR TITLE
feat: add namespaces, MinIO TLS, and CFK operator overlay for eks-demo

### DIFF
--- a/clusters/eks-demo/workloads/namespaces.yaml
+++ b/clusters/eks-demo/workloads/namespaces.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     repoURL: https://github.com/osowski/confluent-platform-gitops.git
     targetRevision: HEAD
-    path: workloads/namespaces/base
+    path: workloads/namespaces/overlays/eks-demo
   destination:
     server: https://kubernetes.default.svc
     namespace: argocd

--- a/clusters/eks-demo/workloads/namespaces.yaml
+++ b/clusters/eks-demo/workloads/namespaces.yaml
@@ -20,3 +20,11 @@ spec:
     automated:
       prune: true
       selfHeal: true
+    syncOptions:
+      - CreateNamespace=false
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/infrastructure/minio/overlays/eks-demo/certificates.yaml
+++ b/infrastructure/minio/overlays/eks-demo/certificates.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: minio-tls
+  namespace: storage
+spec:
+  secretName: minio-tls
+  dnsNames:
+    - s3.eks-demo.platform.dspdemos.com
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: letsencrypt-prod
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: minio-console-tls
+  namespace: storage
+spec:
+  secretName: minio-console-tls
+  dnsNames:
+    - s3-console.eks-demo.platform.dspdemos.com
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: letsencrypt-prod

--- a/infrastructure/minio/overlays/eks-demo/ingressroute-patch.yaml
+++ b/infrastructure/minio/overlays/eks-demo/ingressroute-patch.yaml
@@ -5,6 +5,8 @@ metadata:
   name: minio
   namespace: storage
 spec:
+  entryPoints:
+    - websecure
   routes:
     - match: Host(`s3.eks-demo.platform.dspdemos.com`)
       kind: Rule
@@ -12,6 +14,8 @@ spec:
         - name: minio
           port: 9000
           scheme: http
+  tls:
+    secretName: minio-tls
 ---
 apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
@@ -19,6 +23,8 @@ metadata:
   name: minio-console
   namespace: storage
 spec:
+  entryPoints:
+    - websecure
   routes:
     - match: Host(`s3-console.eks-demo.platform.dspdemos.com`)
       kind: Rule
@@ -26,3 +32,5 @@ spec:
         - name: minio
           port: 9001
           scheme: http
+  tls:
+    secretName: minio-console-tls

--- a/infrastructure/minio/overlays/eks-demo/kustomization.yaml
+++ b/infrastructure/minio/overlays/eks-demo/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 
 resources:
   - ../../base
+  - certificates.yaml
 
 patches:
   - path: ingressroute-patch.yaml

--- a/workloads/cfk-operator/overlays/eks-demo/values.yaml
+++ b/workloads/cfk-operator/overlays/eks-demo/values.yaml
@@ -1,4 +1,6 @@
 # eks-demo cluster-specific overrides for CFK operator
+# Explicit override prevents base changes from silently expanding watch scope.
+# flink-shapes and flink-colors will be added when group namespaces are enabled.
 namespaceList:
   - flink
   - kafka

--- a/workloads/cfk-operator/overlays/eks-demo/values.yaml
+++ b/workloads/cfk-operator/overlays/eks-demo/values.yaml
@@ -1,0 +1,5 @@
+# eks-demo cluster-specific overrides for CFK operator
+namespaceList:
+  - flink
+  - kafka
+  - operator

--- a/workloads/namespaces/overlays/eks-demo/kustomization.yaml
+++ b/workloads/namespaces/overlays/eks-demo/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Exclude ollama namespace — only needed for flink-demo clusters
+resources:
+  - ../../base/operator.yaml
+  - ../../base/kafka.yaml
+  - ../../base/flink.yaml

--- a/workloads/namespaces/overlays/eks-demo/kustomization.yaml
+++ b/workloads/namespaces/overlays/eks-demo/kustomization.yaml
@@ -1,8 +1,14 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-# Exclude ollama namespace — only needed for flink-demo clusters
 resources:
-  - ../../base/operator.yaml
-  - ../../base/kafka.yaml
-  - ../../base/flink.yaml
+  - ../../base
+
+# Exclude ollama namespace — only needed for flink-demo clusters
+patches:
+  - patch: |-
+      $patch: delete
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: ollama


### PR DESCRIPTION
## Summary
- `workloads/namespaces/overlays/eks-demo/` — eks-demo namespace overlay excluding `ollama` (only needed for flink-demo clusters); `clusters/eks-demo/workloads/namespaces.yaml` updated to point at overlay instead of base
- `workloads/cfk-operator/overlays/eks-demo/values.yaml` — CFK operator namespaceList scoped to `flink`, `kafka`, `operator` (no flink-shapes/flink-colors)
- `infrastructure/minio/overlays/eks-demo/certificates.yaml` — letsencrypt-prod Certificates for `s3.*` and `s3-console.*` (required per PR [#233](https://github.com/osowski/confluent-platform-gitops/pull/233) HTTP→HTTPS redirect)
- `infrastructure/minio/overlays/eks-demo/ingressroute-patch.yaml` — updated to `websecure`-only entrypoint with `tls.secretName` on both IngressRoutes

## Test plan
- [ ] `operator`, `kafka`, `flink` namespaces created; `ollama` namespace absent
- [ ] CFK operator pod running in `operator` namespace, watching `flink`/`kafka`/`operator`
- [ ] MinIO `minio-tls` and `minio-console-tls` Certificates issued via letsencrypt-prod
- [ ] `https://s3.eks-demo.platform.dspdemos.com` and `https://s3-console.eks-demo.platform.dspdemos.com` load over HTTPS

Closes [#198](https://github.com/osowski/confluent-platform-gitops/issues/198)

🤖 Generated with [Claude Code](https://claude.com/claude-code)