### PR TITLE
fix: add mds-keygen overlay and cluster app for eks-demo

### DIFF
--- a/clusters/eks-demo/workloads/kustomization.yaml
+++ b/clusters/eks-demo/workloads/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - namespaces.yaml
   - keycloak.yaml
   - cfk-operator.yaml
+  - mds-keygen.yaml
   - confluent-resources.yaml
   - workload-ingresses.yaml
   - flink-kubernetes-operator.yaml

--- a/clusters/eks-demo/workloads/mds-keygen.yaml
+++ b/clusters/eks-demo/workloads/mds-keygen.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: mds-keygen
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "106" # After cfk-operator (105), before confluent-resources (110)
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: workloads
+  source:
+    repoURL: https://github.com/osowski/confluent-platform-gitops.git
+    targetRevision: HEAD
+    path: workloads/mds-keygen/overlays/eks-demo
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kafka
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: false
+    syncOptions:
+      - CreateNamespace=false
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/workloads/mds-keygen/overlays/eks-demo/kustomization.yaml
+++ b/workloads/mds-keygen/overlays/eks-demo/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - mds-keygen-job.yaml
+
+labels:
+- includeSelectors: false
+  includeTemplates: true
+  pairs:
+    cluster: eks-demo

--- a/workloads/mds-keygen/overlays/eks-demo/mds-keygen-job.yaml
+++ b/workloads/mds-keygen/overlays/eks-demo/mds-keygen-job.yaml
@@ -68,7 +68,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: keygen
-          image: bitnami/kubectl@sha256:26496fc7c0b8549e3bb352b7c26238a20c1f264532ba42b6d9f67c884ffa0066
+          image: bitnami/kubectl@sha256:26496fc7c0b8549e3bb352b7c26238a20c1f264532ba42b6d9f67c884ffa0066  # kubectl v1.35.4
           command:
             - /bin/bash
             - -c

--- a/workloads/mds-keygen/overlays/eks-demo/mds-keygen-job.yaml
+++ b/workloads/mds-keygen/overlays/eks-demo/mds-keygen-job.yaml
@@ -68,7 +68,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: keygen
-          image: bitnami/kubectl:latest
+          image: bitnami/kubectl@sha256:26496fc7c0b8549e3bb352b7c26238a20c1f264532ba42b6d9f67c884ffa0066
           command:
             - /bin/bash
             - -c

--- a/workloads/mds-keygen/overlays/eks-demo/mds-keygen-job.yaml
+++ b/workloads/mds-keygen/overlays/eks-demo/mds-keygen-job.yaml
@@ -1,0 +1,151 @@
+# MDS Token Keypair Generation Job
+# Generates RSA keypair for MDS authentication tokens
+# Runs as a standalone Application to decouple key generation from Confluent Resources sync
+---
+# ServiceAccount for the keygen job
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mds-keygen
+  namespace: kafka
+  annotations:
+    argocd.argoproj.io/sync-wave: "5"
+---
+# Role to allow creating/updating the mds-token secret
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: mds-keygen
+  namespace: kafka
+  annotations:
+    argocd.argoproj.io/sync-wave: "5"
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "create", "update", "patch"]
+    resourceNames: ["mds-token"]
+  # Allow creating the secret if it doesn't exist (no resourceName restriction)
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create"]
+---
+# RoleBinding for the keygen ServiceAccount
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: mds-keygen
+  namespace: kafka
+  annotations:
+    argocd.argoproj.io/sync-wave: "5"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: mds-keygen
+subjects:
+  - kind: ServiceAccount
+    name: mds-keygen
+    namespace: kafka
+---
+# Job to generate MDS token keypair
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mds-keygen
+  namespace: kafka
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+spec:
+  ttlSecondsAfterFinished: 300  # Clean up 5 minutes after completion
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        app: mds-keygen
+    spec:
+      serviceAccountName: mds-keygen
+      restartPolicy: OnFailure
+      containers:
+        - name: keygen
+          image: bitnami/kubectl:latest
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -e
+
+              echo "=== MDS Token Keypair Generator ==="
+
+              # Check if secret already exists and has valid keys
+              if kubectl get secret mds-token -n kafka >/dev/null 2>&1; then
+                echo "Secret mds-token already exists, checking if it has valid keys..."
+
+                # Check if the secret has the placeholder text (invalid keys)
+                PUBLIC_KEY=$(kubectl get secret mds-token -n kafka -o jsonpath='{.data.mdsPublicKey\.pem}' | base64 -d)
+
+                if echo "$PUBLIC_KEY" | grep -q "REPLACE_WITH_ACTUAL_PUBLIC_KEY"; then
+                  echo "Found placeholder keys, will regenerate..."
+                elif echo "$PUBLIC_KEY" | grep -q "BEGIN PUBLIC KEY"; then
+                  echo "Valid keys already exist, ensuring reflector annotations are present..."
+
+                  # Add reflector annotations to existing secret
+                  kubectl annotate secret mds-token -n kafka \
+                    reflector.v1.k8s.emberstack.com/reflection-allowed="true" \
+                    reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces="operator" \
+                    reflector.v1.k8s.emberstack.com/reflection-auto-enabled="true" \
+                    --overwrite
+
+                  echo "Reflector annotations applied to existing secret"
+                  exit 0
+                else
+                  echo "Invalid key format detected, will regenerate..."
+                fi
+              fi
+
+              echo "Generating RSA 2048-bit keypair..."
+
+              # Install openssl if not available
+              if ! command -v openssl &> /dev/null; then
+                echo "Installing openssl..."
+                apk add --no-cache openssl
+              fi
+
+              # Generate private key
+              openssl genrsa -out /tmp/mds-tokenkeypair.pem 2048
+
+              # Extract public key
+              openssl rsa -in /tmp/mds-tokenkeypair.pem -outform PEM -pubout -out /tmp/mds-publickey.pem
+
+              echo "Keys generated successfully:"
+              echo "- Private key: /tmp/mds-tokenkeypair.pem"
+              echo "- Public key: /tmp/mds-publickey.pem"
+
+              # Create or update the secret with reflector annotations
+              echo "Creating/updating mds-token secret with reflector annotations..."
+
+              kubectl create secret generic mds-token \
+                --from-file=mdsPublicKey.pem=/tmp/mds-publickey.pem \
+                --from-file=mdsTokenKeyPair.pem=/tmp/mds-tokenkeypair.pem \
+                --namespace kafka \
+                --dry-run=client -o yaml | \
+              kubectl annotate -f - \
+                reflector.v1.k8s.emberstack.com/reflection-allowed="true" \
+                reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces="operator" \
+                reflector.v1.k8s.emberstack.com/reflection-auto-enabled="true" \
+                --local --dry-run=client -o yaml | \
+              kubectl apply -f -
+
+              echo "Secret mds-token created/updated successfully with reflector annotations"
+
+              # Clean up temporary files
+              rm -f /tmp/mds-tokenkeypair.pem /tmp/mds-publickey.pem
+
+              echo "=== Keypair generation complete ==="
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi

--- a/workloads/mds-keygen/overlays/flink-demo-rbac/mds-keygen-job.yaml
+++ b/workloads/mds-keygen/overlays/flink-demo-rbac/mds-keygen-job.yaml
@@ -68,7 +68,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: keygen
-          image: bitnami/kubectl@sha256:26496fc7c0b8549e3bb352b7c26238a20c1f264532ba42b6d9f67c884ffa0066
+          image: bitnami/kubectl@sha256:26496fc7c0b8549e3bb352b7c26238a20c1f264532ba42b6d9f67c884ffa0066  # kubectl v1.35.4
           command:
             - /bin/bash
             - -c

--- a/workloads/mds-keygen/overlays/flink-demo-rbac/mds-keygen-job.yaml
+++ b/workloads/mds-keygen/overlays/flink-demo-rbac/mds-keygen-job.yaml
@@ -68,7 +68,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: keygen
-          image: bitnami/kubectl:latest
+          image: bitnami/kubectl@sha256:26496fc7c0b8549e3bb352b7c26238a20c1f264532ba42b6d9f67c884ffa0066
           command:
             - /bin/bash
             - -c


### PR DESCRIPTION
## Summary
- Adds `workloads/mds-keygen/overlays/eks-demo/` with the RSA keypair generation job
- Adds `clusters/eks-demo/workloads/mds-keygen.yaml` ArgoCD Application (sync wave 106)
- Registers the new app in `clusters/eks-demo/workloads/kustomization.yaml`

## Why
The `mds-token` Kubernetes Secret (containing MDS RSA keypair) was missing for eks-demo, causing a `secretRef mds-token not found` error that blocked Kafka rollout. The flink-demo-rbac cluster uses an identical PostSync job to generate this secret.

## Test plan
- [ ] Merge and sync ArgoCD — verify `mds-keygen` Application appears and syncs at wave 106
- [ ] Confirm PostSync Job runs and `mds-token` Secret is created in the `kafka` namespace
- [ ] Confirm Kafka pod recovers and reports Ready

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)