### PR TITLE
fix: set gp3 storageClass on Kafka and KRaftController for eks-demo

### DIFF
--- a/workloads/confluent-resources/overlays/eks-demo/kafka-patch.yaml
+++ b/workloads/confluent-resources/overlays/eks-demo/kafka-patch.yaml
@@ -4,6 +4,8 @@ metadata:
   name: kafka
   namespace: kafka
 spec:
+  storageClass:
+    name: gp3
   listeners:
     # Internal listener — OAuth authentication for inter-broker and client communication
     internal:

--- a/workloads/confluent-resources/overlays/eks-demo/kraftcontroller-patch.yaml
+++ b/workloads/confluent-resources/overlays/eks-demo/kraftcontroller-patch.yaml
@@ -4,6 +4,8 @@ metadata:
   name: kraftcontroller
   namespace: kafka
 spec:
+  storageClass:
+    name: gp3
   podTemplate:
     resources:
       requests:


### PR DESCRIPTION
## Summary
- Adds `storageClass.name: gp3` to `kafka-patch.yaml` and `kraftcontroller-patch.yaml` for the eks-demo overlay

## Why
EKS does not have a `standard` StorageClass. CFK creates PVCs via `dataVolumeCapacity` without a storageClass, falling back to the cluster default. On eks-demo, the default StorageClass resolution left Kafka PVCs in Pending state. Explicitly setting `gp3` routes provisioning through the EBS CSI driver, matching the pattern used for all other PVCs in this cluster (MinIO, Keycloak, kube-prometheus-stack).

## Test plan
- [ ] Merge and sync `confluent-resources` ArgoCD Application
- [ ] Confirm Kafka PVCs transition from Pending → Bound with `storageclass.kubernetes.io/is-default-class: "true"` on gp3
- [ ] Confirm Kafka pods start and reach Ready state

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)