### PR TITLE
fix: extend minio-credentials Reflector annotation to flink-colors and flink-shapes on eks-demo

### DIFF
--- a/infrastructure/minio/overlays/eks-demo/secret-patch.yaml
+++ b/infrastructure/minio/overlays/eks-demo/secret-patch.yaml
@@ -6,5 +6,5 @@ metadata:
   namespace: storage
   annotations:
     reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
-    reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "flink"
+    reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "flink,flink-colors,flink-shapes"
     reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"


### PR DESCRIPTION
## Summary
- Adds `flink-colors` and `flink-shapes` to the Reflector `reflection-allowed-namespaces` annotation on the `minio-credentials` secret for eks-demo

## Why
`FlinkApplication` pods in `flink-colors` and `flink-shapes` reference `minio-credentials` for S3 checkpoint/savepoint storage credentials. The eks-demo `secret-patch.yaml` only mirrored the secret to `flink`, so pods were crash-looping with `secret "minio-credentials" not found`. The flink-demo-rbac overlay already includes all three namespaces — this aligns eks-demo to match.

## Test plan
- [ ] Sync `minio` ArgoCD Application on eks-demo
- [ ] Verify `minio-credentials` secret appears in `flink-colors` and `flink-shapes` namespaces
- [ ] Confirm `colors` and `shapes` FlinkApplication pods start successfully

Part of #202
Part of #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)