### PR TITLE
fix: patch FlinkApplication image to amd64 build for eks-demo

### DIFF
--- a/workloads/flink-resources-rbac/overlays/eks-demo/flink-application-image-patch.yaml
+++ b/workloads/flink-resources-rbac/overlays/eks-demo/flink-application-image-patch.yaml
@@ -1,0 +1,19 @@
+# Override Flink application image for eks-demo (amd64 EKS nodes)
+# Base image is arm64-only; this patch pins the amd64-specific build until
+# multi-arch CI/CD is set up in flink-sandbox (osowski/flink-sandbox#6)
+---
+apiVersion: platform.confluent.io/v1beta1
+kind: FlinkApplication
+metadata:
+  name: colors
+  namespace: flink-colors
+spec:
+  image: quay.io/osowski/flink-kafka-demo:2.1.1-202604212254-amd
+---
+apiVersion: platform.confluent.io/v1beta1
+kind: FlinkApplication
+metadata:
+  name: shapes
+  namespace: flink-shapes
+spec:
+  image: quay.io/osowski/flink-kafka-demo:2.1.1-202604212254-amd

--- a/workloads/flink-resources-rbac/overlays/eks-demo/kustomization.yaml
+++ b/workloads/flink-resources-rbac/overlays/eks-demo/kustomization.yaml
@@ -4,6 +4,9 @@ kind: Kustomization
 resources:
   - ../../base
 
+patches:
+  - path: flink-application-image-patch.yaml
+
 labels:
 - includeSelectors: false
   includeTemplates: true


### PR DESCRIPTION
## Summary
- Adds \`workloads/flink-resources-rbac/overlays/eks-demo/flink-application-image-patch.yaml\` patching both \`colors\` and \`shapes\` FlinkApplications to use \`quay.io/osowski/flink-kafka-demo:2.1.1-202604212254-amd\`
- Updates eks-demo overlay \`kustomization.yaml\` to apply the patch

## Why
The base image (\`2.1.1-202603240800\`) was built natively on an arm64 MacBook and pushed as a single-arch arm64 image. EKS nodes are amd64, causing pods to fail with \`exec format error\`. This is a temporary overlay patch scoped to eks-demo until multi-arch CI/CD is implemented in [flink-sandbox#6](https://github.com/osowski/flink-sandbox/issues/6).

The \`flink-demo-rbac\` cluster (arm64 Kind) is unaffected — it continues using the base image.

## Test plan
- [ ] Sync \`flink-resources-rbac\` on eks-demo
- [ ] Confirm \`colors\` and \`shapes\` FlinkApplication pods start without exec format error
- [ ] Remove this patch once multi-arch image is available from CI/CD

Part of #202
Part of #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)