### PR TITLE
fix: patch producer Deployment image to amd64 build for eks-demo

### DIFF
--- a/workloads/flink-resources-rbac/overlays/eks-demo/kustomization.yaml
+++ b/workloads/flink-resources-rbac/overlays/eks-demo/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
 
 patches:
   - path: flink-application-image-patch.yaml
+  - path: producer-image-patch.yaml
 
 labels:
 - includeSelectors: false

--- a/workloads/flink-resources-rbac/overlays/eks-demo/producer-image-patch.yaml
+++ b/workloads/flink-resources-rbac/overlays/eks-demo/producer-image-patch.yaml
@@ -1,0 +1,27 @@
+# Override producer image for eks-demo (amd64 EKS nodes)
+# Base image is arm64-only; this patch pins the amd64-specific build until
+# multi-arch CI/CD is set up in flink-sandbox (osowski/flink-sandbox#6)
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: shapes-producer
+  namespace: flink-shapes
+spec:
+  template:
+    spec:
+      containers:
+        - name: producer
+          image: quay.io/osowski/kafka-producer:v0.2.0-avro-amd64
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: colors-producer
+  namespace: flink-colors
+spec:
+  template:
+    spec:
+      containers:
+        - name: producer
+          image: quay.io/osowski/kafka-producer:v0.2.0-avro-amd64


### PR DESCRIPTION
## Summary
- Adds \`workloads/flink-resources-rbac/overlays/eks-demo/producer-image-patch.yaml\` patching both \`shapes-producer\` and \`colors-producer\` Deployments to use \`quay.io/osowski/kafka-producer:v0.2.0-avro-amd64\`
- Updates eks-demo overlay \`kustomization.yaml\` to apply the patch

## Why
The base producer image (\`v0.2.0-avro\`) was built natively on an arm64 MacBook and pushed as a single-arch arm64 image. EKS nodes are amd64, causing pods to fail with \`exec format error\`. This is a temporary overlay patch scoped to eks-demo until multi-arch CI/CD is implemented in [flink-sandbox#6](https://github.com/osowski/flink-sandbox/issues/6).

The \`flink-demo-rbac\` cluster (arm64 Kind) is unaffected — it continues using the base image.

## Test plan
- [ ] Build amd64 producer image: \`docker buildx build --platform linux/amd64 --push -t quay.io/osowski/kafka-producer:v0.2.0-avro-amd64 -f Dockerfile.producer .\`
- [ ] Sync \`flink-resources-rbac\` on eks-demo
- [ ] Scale a producer to 1 replica and confirm pod starts without exec format error

Part of #202
Part of #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)