### PR TITLE
feat(terraform): migrate eks-demo worker nodes from t3.xlarge to t3.2xlarge

### DIFF
--- a/terraform/eks-demo/README.md
+++ b/terraform/eks-demo/README.md
@@ -18,7 +18,7 @@ Provisions a private EKS cluster on AWS for Confluent Platform and Flink demo de
 | VPC Interface Endpoints | SSM, SSMMessages, EC2Messages, ECR API, ECR DKR, EKS, STS, CloudWatch Logs |
 | VPC Gateway Endpoint | S3 (required for ECR image layer pulls) |
 | EKS Cluster | Kubernetes 1.32, private-only API endpoint, IRSA via OIDC, core add-ons managed |
-| Managed Node Group | AL2023, `t3.xlarge`, 100 GiB gp3 root volume, 2-5 nodes |
+| Managed Node Group | AL2023, `t3.2xlarge`, 100 GiB gp3 root volume, 4-6 nodes (`workers-v2`) |
 | Bastion Host | AL2023 EC2 in private subnet, SSM-only access, 3proxy SOCKS5 on `localhost:1080` |
 | IRSA IAM Roles | EBS CSI Driver, cert-manager, ExternalDNS, AWS Load Balancer Controller |
 
@@ -52,10 +52,10 @@ The apply takes 15-20 minutes, the majority of which is the EKS cluster and node
 | `platform_zone_id` | — | Route53 zone ID for `platform.dspdemos.com`, from dns-bootstrap output |
 | `platform_domain` | `platform.dspdemos.com` | Platform domain used by ExternalDNS and cert-manager |
 | `vpc_cidr` | `10.0.0.0/16` | CIDR block for the VPC |
-| `node_instance_type` | `t3.xlarge` | EC2 instance type for managed node group workers |
-| `node_desired_size` | `2` | Desired number of worker nodes |
-| `node_min_size` | `2` | Minimum number of worker nodes |
-| `node_max_size` | `5` | Maximum number of worker nodes |
+| `node_instance_type` | `t3.2xlarge` | EC2 instance type for managed node group workers |
+| `node_desired_size` | `4` | Desired number of worker nodes |
+| `node_min_size` | `4` | Minimum number of worker nodes |
+| `node_max_size` | `6` | Maximum number of worker nodes |
 | `common_tags` | see below | Confluent mandatory tags applied to all resources |
 | `cflt_keep_until` | *(required)* | Static expiry date tag (YYYY-MM-DD). Set at least one year out. Must be set explicitly to prevent plan drift from computed timestamps. |
 

--- a/terraform/eks-demo/README.md
+++ b/terraform/eks-demo/README.md
@@ -57,9 +57,10 @@ The apply takes 15-20 minutes, the majority of which is the EKS cluster and node
 | `node_min_size` | `2` | Minimum number of worker nodes |
 | `node_max_size` | `5` | Maximum number of worker nodes |
 | `common_tags` | see below | Confluent mandatory tags applied to all resources |
+| `cflt_keep_until` | *(required)* | Static expiry date tag (YYYY-MM-DD). Set at least one year out. Must be set explicitly to prevent plan drift from computed timestamps. |
 
-> [!NOTE]
-> The `cflt_keep_until` tag is computed automatically at plan time using `plantimestamp()` and set one year out. You do not need to set it manually.
+> [!WARNING]
+> `cflt_keep_until` has no default and must be supplied on every apply — either via `terraform.tfvars`, `-var`, or an environment variable. Using a computed value (e.g. `plantimestamp()`) causes a perpetual diff on every `terraform plan`.
 
 ## Outputs
 

--- a/terraform/eks-demo/eks.tf
+++ b/terraform/eks-demo/eks.tf
@@ -38,14 +38,37 @@ module "eks" {
 
   eks_managed_node_groups = {
     default = {
-      instance_types = [var.node_instance_type]
-      min_size       = var.node_min_size
-      max_size       = var.node_max_size
-      desired_size   = var.node_desired_size
+      instance_types = ["t3.xlarge"]      # pinned to live type; var.node_instance_type now targets workers-v2
+      min_size       = 3                  # pinned to live value; ignore_scaling_changes only covers desired_size
+      max_size       = 5
+      desired_size   = 5
+
+      ignore_scaling_changes = true
 
       ami_type = "AL2023_x86_64_STANDARD"
 
       # 20 GiB default fills rapidly under Confluent Platform image pulls + ephemeral storage.
+      block_device_mappings = {
+        xvda = {
+          device_name = "/dev/xvda"
+          ebs = {
+            volume_size           = 100
+            volume_type           = "gp3"
+            delete_on_termination = true
+            encrypted             = true
+          }
+        }
+      }
+    }
+
+    workers-v2 = {
+      instance_types = [var.node_instance_type]
+      min_size       = 4
+      max_size       = 6
+      desired_size   = 4
+
+      ami_type = "AL2023_x86_64_STANDARD"
+
       block_device_mappings = {
         xvda = {
           device_name = "/dev/xvda"

--- a/terraform/eks-demo/eks.tf
+++ b/terraform/eks-demo/eks.tf
@@ -37,38 +37,15 @@ module "eks" {
   enable_cluster_creator_admin_permissions = true
 
   eks_managed_node_groups = {
-    default = {
-      instance_types = ["t3.xlarge"]      # pinned to live type; var.node_instance_type now targets workers-v2
-      min_size       = 3                  # pinned to live value; ignore_scaling_changes only covers desired_size
-      max_size       = 5
-      desired_size   = 5
-
-      ignore_scaling_changes = true
+    workers-v2 = {
+      instance_types = [var.node_instance_type]
+      min_size       = var.node_min_size
+      max_size       = var.node_max_size
+      desired_size   = var.node_desired_size
 
       ami_type = "AL2023_x86_64_STANDARD"
 
       # 20 GiB default fills rapidly under Confluent Platform image pulls + ephemeral storage.
-      block_device_mappings = {
-        xvda = {
-          device_name = "/dev/xvda"
-          ebs = {
-            volume_size           = 100
-            volume_type           = "gp3"
-            delete_on_termination = true
-            encrypted             = true
-          }
-        }
-      }
-    }
-
-    workers-v2 = {
-      instance_types = [var.node_instance_type]
-      min_size       = 4
-      max_size       = 6
-      desired_size   = 4
-
-      ami_type = "AL2023_x86_64_STANDARD"
-
       block_device_mappings = {
         xvda = {
           device_name = "/dev/xvda"

--- a/terraform/eks-demo/main.tf
+++ b/terraform/eks-demo/main.tf
@@ -17,9 +17,8 @@ locals {
     0, 3
   )
 
-  # cflt_keep_until is stable across plan→apply via plantimestamp()
   mandatory_tags = merge(var.common_tags, {
-    cflt_keep_until = formatdate("YYYY-MM-DD", timeadd(plantimestamp(), "8766h"))
+    cflt_keep_until = var.cflt_keep_until
   })
 }
 

--- a/terraform/eks-demo/variables.tf
+++ b/terraform/eks-demo/variables.tf
@@ -36,7 +36,7 @@ variable "vpc_cidr" {
 variable "node_instance_type" {
   description = "EC2 instance type for EKS managed node group workers"
   type        = string
-  default     = "t3.xlarge"
+  default     = "t3.2xlarge"
 }
 
 variable "node_desired_size" {

--- a/terraform/eks-demo/variables.tf
+++ b/terraform/eks-demo/variables.tf
@@ -42,19 +42,19 @@ variable "node_instance_type" {
 variable "node_desired_size" {
   description = "Desired number of worker nodes"
   type        = number
-  default     = 2
+  default     = 4
 }
 
 variable "node_min_size" {
   description = "Minimum number of worker nodes"
   type        = number
-  default     = 2
+  default     = 4
 }
 
 variable "node_max_size" {
   description = "Maximum number of worker nodes"
   type        = number
-  default     = 5
+  default     = 6
 }
 
 variable "common_tags" {

--- a/terraform/eks-demo/variables.tf
+++ b/terraform/eks-demo/variables.tf
@@ -58,7 +58,7 @@ variable "node_max_size" {
 }
 
 variable "common_tags" {
-  description = "Confluent mandatory tags applied to all resources. cflt_keep_until is computed and injected automatically — do not set it here."
+  description = "Confluent mandatory tags applied to all resources"
   type        = map(string)
   default = {
     cflt_environment = "devel"
@@ -68,4 +68,9 @@ variable "common_tags" {
     cflt_managed_id  = "osowski/confluent-platform-gitops"
     cflt_protected   = "false"
   }
+}
+
+variable "cflt_keep_until" {
+  description = "Static expiry date tag applied to all resources (YYYY-MM-DD). Set to a date at least one year out. Must be set explicitly — no default — to prevent plan drift from computed timestamps."
+  type        = string
 }


### PR DESCRIPTION
## Summary
- Adds `workers-v2` nodegroup (t3.2xlarge, 4-6 nodes) alongside existing `default` nodegroup, then removes `default` after draining
- Replaces computed `cflt_keep_until` tag with a static variable to eliminate perpetual plan drift
- Reconciles all sizing variables and README to reflect the new nodegroup configuration

## Migration Phases
1. **Phase 1** — Added `workers-v2` (t3.2xlarge) nodegroup; protected `default` nodegroup with `ignore_scaling_changes=true` and pinned `instance_types` to prevent drift during coexistence window
2. **Phase 2** — Manually cordoned and drained all `default` nodegroup nodes; verified Kafka (3/3) and KRaft (3/3) health after each drain; confirmed all PVCs remained Bound
3. **Phase 3** — Removed `default` nodegroup from IaC; wired `workers-v2` through variables; `terraform plan` confirmed clean (`No changes`)

## Test Plan
- [x] `aws eks list-nodegroups --cluster-name eks-demo` shows only `workers-v2`
- [x] `kubectl get nodes` shows 4 nodes, all `t3.2xlarge`, all `Ready`
- [x] `kubectl get kafka -n kafka && kubectl get kraftcontroller -n kafka` — all `Ready: True`
- [x] No pods on old `default` nodes
- [x] All 15 PVCs remain `Bound`
- [x] `terraform plan` shows `No changes`

Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)