### PR TITLE
use both spec.sources and spec.source

### DIFF
--- a/scripts/update-repo-urls.sh
+++ b/scripts/update-repo-urls.sh
@@ -153,14 +153,16 @@ update_files() {
             else
                 # Create backup
                 cp "$file" "$file.bak"
-
+                echo "file: $file"
                 # Use yq to update URLs based on file type
                 if [[ "$file" == "bootstrap/values.yaml" ]]; then
                     # Update bootstrap values
                     yq eval ".git.repoUrl = \"${new_url}\"" -i "$file"
                 else
-                    # Update Application manifests - only repoURL fields matching old_url
-                    yq eval "(.spec.sources[] | select(.repoURL == \"${old_url}\").repoURL) = \"${new_url}\"" -i "$file"
+                    # Application manifests use spec.source (single) or spec.sources (multi-source Helm).
+                    # Updating only spec.sources[] misses the common spec.source case and changes nothing.
+                    yq eval "(.spec.source | select(.repoURL == \"${old_url}\") | .repoURL) = \"${new_url}\"" -i "$file" &&
+                        yq eval "(.spec.sources[]? | select(.repoURL == \"${old_url}\") | .repoURL) = \"${new_url}\"" -i "$file"
                 fi
 
                 # Check if yq succeeded (it validates YAML automatically)


### PR DESCRIPTION
Argo CD Applications usually declare the Git repo under spec.source (one source). A smaller set uses spec.sources (e.g. Helm chart + $values ref). Your line only updated .spec.sources[], so for manifests like clusters/flink-demo/bootstrap.yaml and flink-rbac.yaml there is no sources list—the expression never matched anything, so the file stayed the same. grep still saw the old URL in repoURL because it appears under spec.source, not in sources.

Change: Run two updates:

spec.source when repoURL equals the old URL
spec.sources[]? for multi-source apps (? so missing sources does not error)