### PR TITLE
feat(terraform): set EKS upgrade policy to STANDARD on shared module

### DIFF
--- a/terraform/modules/eks-cluster/eks.tf
+++ b/terraform/modules/eks-cluster/eks.tf
@@ -22,6 +22,12 @@ module "eks" {
   # Critical for a private cluster where CloudWatch is the primary debug path.
   enabled_log_types = ["audit", "api", "authenticator", "controllerManager", "scheduler"]
 
+  # STANDARD lets AWS force a control-plane upgrade at end of standard support
+  # (~14 months). EXTENDED costs extra; demo clusters have no reason to use it.
+  upgrade_policy = {
+    support_type = "STANDARD"
+  }
+
   # Core add-ons — vpc-cni and kube-proxy must be installed before nodes join
   # (before_compute = true) or nodes will have no CNI and pods will never schedule.
   addons = {


### PR DESCRIPTION
## Summary

- Adds `upgrade_policy { support_type = "STANDARD" }` to the shared `terraform/modules/eks-cluster/eks.tf` module
- STANDARD allows AWS to force a control-plane upgrade when a version reaches end of standard support (~14 months), preventing clusters from drifting onto paid extended support unintentionally
- Applies to all EKS clusters provisioned via this shared module

## Why

Without an explicit upgrade policy, clusters can silently enter AWS Extended Support at end of standard support life, incurring additional cost. Hardcoding STANDARD in the shared module ensures all demo/dev clusters stay on the expected upgrade path.

## Test plan

- [ ] `terraform validate` passes (verified locally)
- [ ] Run `terraform plan` against eks-demo and confirm only an in-place update to `aws_eks_cluster` for `upgrade_policy.support_type = "STANDARD"` — no resource replacements
- [ ] `terraform apply` to push the policy change to the live cluster

Closes #261