### PR TITLE
fix(terraform): pre-build 3proxy binary in S3 for reliable bastion bootstrap

### DIFF
--- a/terraform/clusters/eks-demo/main.tf
+++ b/terraform/clusters/eks-demo/main.tf
@@ -44,9 +44,11 @@ module "eks_cluster" {
   platform_zone_id   = var.platform_zone_id
   platform_domain    = var.platform_domain
   vpc_cidr           = var.vpc_cidr
-  node_instance_type = var.node_instance_type
-  node_desired_size  = var.node_desired_size
-  node_min_size      = var.node_min_size
-  node_max_size      = var.node_max_size
-  common_tags        = var.common_tags
+  node_instance_type    = var.node_instance_type
+  node_desired_size     = var.node_desired_size
+  node_min_size         = var.node_min_size
+  node_max_size         = var.node_max_size
+  common_tags           = var.common_tags
+  infra_binaries_bucket = var.infra_binaries_bucket
+  proxy_version         = var.proxy_version
 }

--- a/terraform/clusters/eks-demo/terraform.tfvars.example
+++ b/terraform/clusters/eks-demo/terraform.tfvars.example
@@ -8,4 +8,6 @@ node_instance_type = "t3.2xlarge"
 node_desired_size  = 4
 node_min_size      = 4
 node_max_size      = 6
-cflt_keep_until    = "YYYY-MM-DD"
+cflt_keep_until       = "YYYY-MM-DD"
+infra_binaries_bucket = "confluent-platform-gitops-tfstate"
+proxy_version         = "0.9.6"

--- a/terraform/clusters/eks-demo/variables.tf
+++ b/terraform/clusters/eks-demo/variables.tf
@@ -74,3 +74,15 @@ variable "cflt_keep_until" {
   description = "Static expiry date tag applied to all resources (YYYY-MM-DD). Set to a date at least one year out. Must be set explicitly — no default — to prevent plan drift from computed timestamps."
   type        = string
 }
+
+variable "infra_binaries_bucket" {
+  description = "S3 bucket containing pre-built infrastructure binaries for bastion bootstrap"
+  type        = string
+  default     = "confluent-platform-gitops-tfstate"
+}
+
+variable "proxy_version" {
+  description = "3proxy version to download at bastion boot — must match the binary at infra_binaries_bucket/binaries/3proxy-<version>-linux-x86_64"
+  type        = string
+  default     = "0.9.6"
+}

--- a/terraform/modules/eks-cluster/bastion.tf
+++ b/terraform/modules/eks-cluster/bastion.tf
@@ -38,6 +38,20 @@ resource "aws_iam_role_policy_attachment" "bastion_ssm" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }
 
+resource "aws_iam_role_policy" "bastion_s3" {
+  name = "bastion-infra-binaries-s3"
+  role = aws_iam_role.bastion.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["s3:GetObject"]
+      Resource = ["arn:aws:s3:::${var.infra_binaries_bucket}/binaries/*"]
+    }]
+  })
+}
+
 resource "aws_iam_instance_profile" "bastion" {
   name = "${var.cluster_name}-bastion"
   role = aws_iam_role.bastion.name
@@ -73,7 +87,10 @@ resource "aws_instance" "bastion" {
   # The bastion is a dumb SOCKS5 relay — operators tunnel through it via SSM
   # port-forwarding and authenticate to EKS using their local AWS credentials.
   # Do not run kubectl or AWS CLI on the bastion itself.
-  user_data_base64 = base64encode(templatefile("${path.module}/scripts/bastion-init.sh", {}))
+  user_data_base64 = base64encode(templatefile("${path.module}/scripts/bastion-init.sh", {
+    infra_binaries_bucket = var.infra_binaries_bucket
+    proxy_version         = var.proxy_version
+  }))
 
   metadata_options {
     http_endpoint               = "enabled"

--- a/terraform/modules/eks-cluster/bastion.tf
+++ b/terraform/modules/eks-cluster/bastion.tf
@@ -70,7 +70,7 @@ resource "aws_security_group" "bastion" {
     to_port     = 443
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
-    description = "HTTPS only - SSM, EKS API, ECR/S3 via VPC endpoints, and cloning 3proxy from GitHub at boot"
+    description = "HTTPS only - SSM, EKS API, ECR/S3 via VPC endpoints"
   }
 
   tags = merge(var.common_tags, { Name = "${var.cluster_name}-bastion" })
@@ -87,10 +87,11 @@ resource "aws_instance" "bastion" {
   # The bastion is a dumb SOCKS5 relay — operators tunnel through it via SSM
   # port-forwarding and authenticate to EKS using their local AWS credentials.
   # Do not run kubectl or AWS CLI on the bastion itself.
-  user_data_base64 = base64encode(templatefile("${path.module}/scripts/bastion-init.sh", {
+  user_data_base64            = base64encode(templatefile("${path.module}/scripts/bastion-init.sh", {
     infra_binaries_bucket = var.infra_binaries_bucket
     proxy_version         = var.proxy_version
   }))
+  user_data_replace_on_change = true
 
   metadata_options {
     http_endpoint               = "enabled"

--- a/terraform/modules/eks-cluster/bastion.tf
+++ b/terraform/modules/eks-cluster/bastion.tf
@@ -4,7 +4,7 @@ data "aws_ami" "amazon_linux_2023" {
 
   filter {
     name   = "name"
-    values = ["al2023-ami-*-x86_64"]
+    values = ["al2023-ami-2023.*-x86_64"]
   }
 
   filter {

--- a/terraform/modules/eks-cluster/scripts/bastion-init.sh
+++ b/terraform/modules/eks-cluster/scripts/bastion-init.sh
@@ -42,8 +42,7 @@ systemctl daemon-reload
 systemctl enable 3proxy
 systemctl start 3proxy
 
-# Install SSM agent explicitly — the al2023-ami-minimal variant does not include
-# it, and even the standard AMI may need a restart after IMDS becomes available.
-dnf install -y amazon-ssm-agent
+# Standard AL2023 AMI ships with SSM agent. Enable and start it explicitly so
+# it registers even if it failed to reach IMDS during early boot.
 systemctl enable amazon-ssm-agent
 systemctl start amazon-ssm-agent

--- a/terraform/modules/eks-cluster/scripts/bastion-init.sh
+++ b/terraform/modules/eks-cluster/scripts/bastion-init.sh
@@ -42,7 +42,8 @@ systemctl daemon-reload
 systemctl enable 3proxy
 systemctl start 3proxy
 
-# Ensure SSM agent is running — AL2023 ships with it pre-installed but the
-# service may not be active if it failed to reach IMDS during early boot.
+# Install SSM agent explicitly — the al2023-ami-minimal variant does not include
+# it, and even the standard AMI may need a restart after IMDS becomes available.
+dnf install -y amazon-ssm-agent
 systemctl enable amazon-ssm-agent
-systemctl restart amazon-ssm-agent
+systemctl start amazon-ssm-agent

--- a/terraform/modules/eks-cluster/scripts/bastion-init.sh
+++ b/terraform/modules/eks-cluster/scripts/bastion-init.sh
@@ -41,3 +41,8 @@ UNIT
 systemctl daemon-reload
 systemctl enable 3proxy
 systemctl start 3proxy
+
+# Ensure SSM agent is running — AL2023 ships with it pre-installed but the
+# service may not be active if it failed to reach IMDS during early boot.
+systemctl enable amazon-ssm-agent
+systemctl restart amazon-ssm-agent

--- a/terraform/modules/eks-cluster/scripts/bastion-init.sh
+++ b/terraform/modules/eks-cluster/scripts/bastion-init.sh
@@ -1,28 +1,14 @@
 #!/bin/bash
 set -euo pipefail
 
-# Build 3proxy from source — avoids AL2023 package repo uncertainty.
-# Pinned to a specific release tag for reproducibility.
-PROXY_VERSION="0.9.6"
+PROXY_VERSION="${proxy_version}"
 
-yum install -y git gcc make
-
-# Wait for internet connectivity before attempting clone
-until curl -s --max-time 5 https://github.com 2>&1 >/dev/null;
-do
-  echo "Waiting for internet connectivity..."
-  sleep 5
-done
-
-git clone --depth 1 --branch "$PROXY_VERSION" \
-  https://github.com/3proxy/3proxy.git /opt/3proxy
-
-cd /opt/3proxy && make -f Makefile.Linux
-
-# Fail loudly if the build didn't produce the expected binary
-test -f bin/3proxy || { echo "ERROR: 3proxy build failed — binary not found" >&2; exit 1; }
-
-install -m 755 bin/3proxy /usr/local/bin/3proxy
+# Download pre-built 3proxy binary from S3 via the VPC Gateway endpoint.
+# S3 Gateway endpoints are available immediately at instance launch — no NAT
+# gateway or internet access required, eliminating the bootstrap race condition
+# that caused SSM registration failures when building from source.
+aws s3 cp "s3://${infra_binaries_bucket}/binaries/3proxy-$PROXY_VERSION-linux-x86_64" /usr/local/bin/3proxy
+chmod 755 /usr/local/bin/3proxy
 
 mkdir -p /etc/3proxy /var/log/3proxy
 

--- a/terraform/modules/eks-cluster/variables.tf
+++ b/terraform/modules/eks-cluster/variables.tf
@@ -52,3 +52,14 @@ variable "common_tags" {
   description = "Tags applied to all resources — provider default_tags adds cflt_keep_until on top of these"
   type        = map(string)
 }
+
+variable "infra_binaries_bucket" {
+  description = "S3 bucket containing pre-built infrastructure binaries (e.g. 3proxy). Must be accessible via the VPC S3 Gateway endpoint."
+  type        = string
+}
+
+variable "proxy_version" {
+  description = "3proxy version to download from S3 — must match the binary uploaded to infra_binaries_bucket/binaries/3proxy-<version>-linux-x86_64"
+  type        = string
+  default     = "0.9.6"
+}


### PR DESCRIPTION
## Summary

- Replaces the `git clone + compile` approach with a pre-built binary downloaded from S3 via the VPC Gateway endpoint
- S3 Gateway endpoints are available immediately at instance launch — no NAT gateway or internet access required
- Eliminates the ~51s boot-time race condition that caused SSM registration failures when building from source
- Adds explicit `systemctl enable/start amazon-ssm-agent` to handle cases where the agent failed to register during early boot (IMDS not yet available)
- Tightens AMI filter from `al2023-ami-*-x86_64` to `al2023-ami-2023.*-x86_64` to exclude the minimal AL2023 variant, which does not ship with `amazon-ssm-agent`
- Adds `infra_binaries_bucket` and `proxy_version` variables to the shared module and eks-demo cluster config
- Adds S3 read IAM policy to the bastion role (scoped to `binaries/*` prefix in the infra bucket)
- Adds `user_data_replace_on_change = true` to ensure bastion is recreated whenever the init script changes

## Uploading the binary

**IMPORTANT: You must pass `--platform linux/amd64` explicitly.** Without it, Docker on Apple Silicon builds an ARM64 binary that silently uploads with an x86_64 name but fails at runtime with `status=203/EXEC`.

### Option A: Docker (run from your Mac)

```bash
docker run --rm --platform linux/amd64 -v "$PWD":/out amazonlinux:2023 \
  bash -c "
    yum install -y git gcc make 2>/dev/null
    git clone --depth 1 --branch 0.9.6 https://github.com/3proxy/3proxy.git /tmp/3proxy
    cd /tmp/3proxy && make -f Makefile.Linux
    cp bin/3proxy /out/3proxy-0.9.6-linux-x86_64
  "

# Verify architecture before uploading
file 3proxy-0.9.6-linux-x86_64
# Must show: ELF 64-bit LSB executable, x86-64

aws s3 cp 3proxy-0.9.6-linux-x86_64 \
  s3://confluent-platform-gitops-tfstate/binaries/3proxy-0.9.6-linux-x86_64
```

### Option B: EC2 build host (Amazon Linux 2023)

```bash
sudo yum install -y git gcc make
git clone --depth 1 --branch 0.9.6 https://github.com/3proxy/3proxy.git
cd 3proxy && make -f Makefile.Linux
aws s3 cp bin/3proxy \
  s3://confluent-platform-gitops-tfstate/binaries/3proxy-0.9.6-linux-x86_64
```

## Test plan

- [x] Binary is uploaded to S3 at the expected path
- [x] `terraform apply -replace=module.eks_cluster.aws_instance.bastion` recreates the bastion
- [x] EC2 console output shows S3 download succeeds and cloud-init finishes in ~10s
- [x] `aws ssm describe-instance-information` shows the new instance registered
- [x] SSM port-forward tunnel connects successfully
- [x] `kubectl get pods -A` returns cluster state through the SOCKS5 tunnel

Closes #256