### PR TITLE
feat(eks-demo): bump kubernetes_version default to 1.35

### DIFF
--- a/terraform/clusters/eks-demo/terraform.tfvars.example
+++ b/terraform/clusters/eks-demo/terraform.tfvars.example
@@ -1,6 +1,6 @@
 aws_region         = "us-east-1"
 cluster_name       = "eks-demo"
-kubernetes_version = "1.32"
+kubernetes_version = "1.35"
 platform_zone_id   = "<output from dns-bootstrap: platform_zone_id>"
 platform_domain    = "platform.dspdemos.com"
 vpc_cidr           = "10.0.0.0/16"

--- a/terraform/clusters/eks-demo/variables.tf
+++ b/terraform/clusters/eks-demo/variables.tf
@@ -13,7 +13,7 @@ variable "cluster_name" {
 variable "kubernetes_version" {
   description = "Kubernetes version for the EKS cluster"
   type        = string
-  default     = "1.32"
+  default     = "1.35"
 }
 
 variable "platform_zone_id" {

--- a/terraform/modules/eks-cluster/eks.tf
+++ b/terraform/modules/eks-cluster/eks.tf
@@ -22,6 +22,12 @@ module "eks" {
   # Critical for a private cluster where CloudWatch is the primary debug path.
   enabled_log_types = ["audit", "api", "authenticator", "controllerManager", "scheduler"]
 
+  # STANDARD lets AWS force a control-plane upgrade at end of standard support
+  # (~14 months). EXTENDED costs extra; demo clusters have no reason to use it.
+  upgrade_policy = {
+    support_type = "STANDARD"
+  }
+
   # Core add-ons — vpc-cni and kube-proxy must be installed before nodes join
   # (before_compute = true) or nodes will have no CNI and pods will never schedule.
   addons = {


### PR DESCRIPTION
## Summary

- Bumps `kubernetes_version` default to `1.35` in `terraform/clusters/eks-demo`
- Updates `terraform.tfvars.example` to reflect the new target version
- 1.35 is the current EKS standard-support release (May 2026)

## Operator Runbook — Sequential Upgrade

EKS requires one minor version hop per apply. Starting from 1.32:

```bash
# Step 1: 1.32 → 1.33
TF_VAR_kubernetes_version=1.33 terraform apply

# Step 2: 1.33 → 1.34
TF_VAR_kubernetes_version=1.34 terraform apply

# Step 3: 1.34 → 1.35
terraform apply   # picks up new default
```

Each apply updates the control plane first, then the managed node group rolls automatically (EKS handles node group version to match control plane).

## Test plan

- [ ] `terraform validate` passes
- [ ] Run `terraform plan` at each hop and confirm only `aws_eks_cluster` version changes — no unexpected replacements
- [ ] Apply sequentially 1.32→1.33→1.34→1.35
- [ ] Verify `kubectl version` reports 1.35 after final apply

Part of #261