### PR TITLE
fix(eks-demo): set Schema Registry replicas to 2 for drain-safe node upgrades

### DIFF
--- a/workloads/confluent-resources/overlays/eks-demo/schemaregistry-patch.yaml
+++ b/workloads/confluent-resources/overlays/eks-demo/schemaregistry-patch.yaml
@@ -4,6 +4,7 @@ metadata:
   name: schemaregistry
   namespace: kafka
 spec:
+  replicas: 2
   podTemplate:
     resources:
       requests:


### PR DESCRIPTION
## Summary

- Sets `replicas: 2` in the eks-demo overlay patch for SchemaRegistry
- CFK automatically creates a PDB with `minAvailable: 1` for all managed components; with a single replica this blocks node drains indefinitely during EKS rolling updates
- Schema Registry is stateless (all data in the Kafka `_schemas` topic), so multiple replicas are consistent with no additional configuration

## Why overlay, not base

Other clusters (flink-demo, flink-demo-rbac) run with tighter resource budgets. The base stays at `replicas: 1`; only eks-demo gets the bump.

## Test plan

- [ ] Argo CD syncs and a second Schema Registry pod starts in the `kafka` namespace
- [ ] `kubectl get pdb -n kafka` shows Schema Registry PDB with `ALLOWED DISRUPTIONS: 1`
- [ ] Node drain no longer blocks on Schema Registry during future EKS rolling updates

Closes #266