### PR TITLE
feat: flink-demo-authn cluster (OIDC authN, no MDS/RBAC)

### DIFF
--- a/clusters/flink-demo-authn/README.md
+++ b/clusters/flink-demo-authn/README.md
@@ -1,0 +1,290 @@
+# flink-demo-authn Cluster
+
+$CLUSTER_DESCRIPTION
+
+## Overview
+
+The `flink-demo-authn` cluster provides:
+
+- **Kafka Cluster**: $KAFKA_DESCRIPTION
+- **Flink Integration**: $FLINK_DESCRIPTION
+- **Monitoring**: Prometheus, Grafana, and Alertmanager with pre-configured dashboards
+- **Security**: $SECURITY_DESCRIPTION
+- **Networking**: Traefik ingress controller with local DNS resolution
+
+**Domain**: `*.flink-demo-authn.confluentdemo.local`
+
+## Getting Started
+
+> [!TIP]
+> **New to this repository?** Start with the [Getting Started for the Uninitiated](../../docs/getting-started-for-the-uninitiated.md) guide for complete step-by-step setup instructions including:
+> - Prerequisites and tool installation
+> - DNS configuration (`/etc/hosts` setup with IPv6 timeout workaround)
+> - Cluster creation and ArgoCD installation
+> - Bootstrap and initial deployment
+> - Accessing ArgoCD UI
+
+### Deploy Bootstrap
+
+```bash
+kubectl apply -f clusters/flink-demo-authn/bootstrap.yaml
+```
+
+### Verify Deployment
+
+```bash
+# Check bootstrap application
+kubectl get application bootstrap -n argocd
+
+# Check all applications
+kubectl get applications -n argocd
+
+# Watch sync progress
+kubectl get applications -n argocd -w
+```
+
+### Manual Sync Applications
+
+<!-- Customize this section for applications that require manual sync in this cluster -->
+
+Some applications require manual sync to ensure operators and namespaces are fully ready.
+
+**Wait for operators to be healthy:**
+
+```bash
+# Check CFK operator
+kubectl wait --namespace operator --for=condition=Ready pods -l app=confluent-operator --timeout=300s
+
+# Check CMF operator
+kubectl wait --namespace operator --for=condition=Ready pods -l app.kubernetes.io/name=confluent-for-apache-flink --timeout=300s
+
+# Check Flink Kubernetes Operator
+kubectl wait --namespace operator --for=condition=Ready pods -l app.kubernetes.io/name=flink-kubernetes-operator --timeout=300s
+```
+
+**Sync confluent-resources:**
+
+In the ArgoCD UI:
+1. Click on `confluent-resources` Application
+2. Click **Sync** → **Synchronize**
+3. Wait for `Healthy` status (~5-10 minutes)
+
+**Sync flink-resources:**
+
+In the ArgoCD UI:
+1. Click on `flink-resources` Application
+2. Click **Sync** → **Synchronize**
+3. Wait for `Healthy` status (~2-3 minutes)
+
+<!-- Add any additional manual sync steps specific to this cluster -->
+
+## Applications
+
+### Infrastructure Applications
+
+Infrastructure applications are defined in `infrastructure/kustomization.yaml`:
+
+<!-- Update this list to match the actual applications in this cluster -->
+
+- **kube-prometheus-stack-crds** (wave 2) - Prometheus Operator CRDs
+- **metrics-server** (wave 5) - Kubernetes Metrics Server
+- **traefik** (wave 10) - Ingress controller
+- **cert-manager** (wave 20) - TLS certificate management
+- **kube-prometheus-stack** (wave 20) - Monitoring stack (Prometheus, Grafana, Alertmanager)
+- **trust-manager** (wave 30) - CA certificate distribution
+- **vault** (wave 40) - HashiCorp Vault (dev mode)
+- **vault-config** (wave 50) - Vault transit engine configuration
+- **cert-manager-resources** (wave 75) - ClusterIssuer and certificates
+- **argocd-ingress** (wave 80) - Traefik IngressRoute for ArgoCD UI
+- **argocd-config** (wave 85) - ArgoCD ConfigMap patches for custom health checks
+
+### Workload Applications
+
+Workload applications are defined in `workloads/kustomization.yaml`:
+
+<!-- Update this list to match the actual applications in this cluster -->
+
+- **namespaces** (wave 100) - Namespace definitions
+- **cfk-operator** (wave 105) - Confluent for Kubernetes operator
+- **confluent-resources** (wave 110) - Confluent Platform (KRaft, Kafka, Schema Registry, etc.)
+- **controlcenter-ingress** (wave 115) - Traefik IngressRoute for Control Center UI
+- **flink-kubernetes-operator** (wave 116) - Flink Kubernetes Operator
+- **observability-resources** (wave 117) - PodMonitors and Grafana dashboards
+- **cmf-operator** (wave 118) - Confluent Manager for Apache Flink
+- **flink-resources** (wave 120) - Flink integration resources
+
+## Environment Access
+
+### DNS Configuration
+
+Add these entries to `/etc/hosts`:
+
+```
+127.0.0.1  alertmanager.flink-demo-authn.confluentdemo.local
+127.0.0.1  argocd.flink-demo-authn.confluentdemo.local
+127.0.0.1  cmf.flink-demo-authn.confluentdemo.local
+127.0.0.1  controlcenter.flink-demo-authn.confluentdemo.local
+127.0.0.1  grafana.flink-demo-authn.confluentdemo.local
+127.0.0.1  kafka.flink-demo-authn.confluentdemo.local
+127.0.0.1  prometheus.flink-demo-authn.confluentdemo.local
+127.0.0.1  schemaregistry.flink-demo-authn.confluentdemo.local
+127.0.0.1  vault.flink-demo-authn.confluentdemo.local
+```
+
+> [!WARNING]
+> If you experience ~5-second timeouts when accessing services, add IPv6 entries as well:
+> ```
+> ::1  alertmanager.flink-demo-authn.confluentdemo.local
+> ::1  argocd.flink-demo-authn.confluentdemo.local
+> ::1  cmf.flink-demo-authn.confluentdemo.local
+> ::1  controlcenter.flink-demo-authn.confluentdemo.local
+> ::1  grafana.flink-demo-authn.confluentdemo.local
+> ::1  kafka.flink-demo-authn.confluentdemo.local
+> ::1  prometheus.flink-demo-authn.confluentdemo.local
+> ::1  schemaregistry.flink-demo-authn.confluentdemo.local
+> ::1  vault.flink-demo-authn.confluentdemo.local
+> ```
+
+### Services
+
+<!-- Customize URLs and credentials for this cluster's services -->
+
+**ArgoCD UI:**
+- **URL**: https://argocd.flink-demo-authn.confluentdemo.local
+- **Username**: `admin`
+- **Password**: `kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath="{.data.password}" | base64 -d`
+
+**Control Center:**
+- **URL**: https://controlcenter.flink-demo-authn.confluentdemo.local
+
+**Grafana:**
+- **URL**: http://grafana.flink-demo-authn.confluentdemo.local
+- **Username**: `admin`
+- **Password**: `prom-operator`
+
+**Prometheus:**
+- **URL**: http://prometheus.flink-demo-authn.confluentdemo.local
+
+**Alertmanager:**
+- **URL**: http://alertmanager.flink-demo-authn.confluentdemo.local
+
+**Vault** (dev mode):
+- **URL**: http://vault.flink-demo-authn.confluentdemo.local
+- **Token**: `root`
+- **Warning**: Dev mode - data is not persisted across restarts
+
+**CMF API:**
+- **URL**: http://cmf.flink-demo-authn.confluentdemo.local
+
+<!-- Add any additional services or port-forwarding fallbacks specific to this cluster -->
+
+## Cluster Specific Use Cases
+
+<!--
+Document anything unique to this cluster that doesn't fit the standard template.
+Examples:
+- RBAC naming conventions and permission model
+- Pre-created topics, schemas, or Flink resources
+- Special authentication flows (e.g., Keycloak SSO, MDS device-grant)
+- Token lifecycle management
+- Demo/sandbox environments (e.g., CP Flink SQL Sandbox)
+
+Remove this comment block and replace with cluster-specific content.
+If this cluster has no unique use cases, remove this section entirely.
+-->
+
+## Troubleshooting
+
+### ArgoCD Applications Not Syncing
+
+Check parent Application health:
+
+```bash
+kubectl get application infrastructure-apps --namespace argocd -o yaml
+kubectl get application workloads-apps --namespace argocd -o yaml
+```
+
+Verify Application manifests exist:
+
+```bash
+ls -la ./clusters/flink-demo-authn/infrastructure/
+ls -la ./clusters/flink-demo-authn/workloads/
+```
+
+### Pods Not Starting
+
+Check pod status and events:
+
+```bash
+kubectl get pods --namespace <namespace> --output wide
+kubectl describe pod <pod-name> --namespace <namespace>
+```
+
+Check resource availability:
+
+```bash
+kubectl top nodes
+kubectl top pods --all-namespaces
+```
+
+### Ingress Not Accessible
+
+Verify kind port mappings:
+
+```bash
+docker ps | grep flink-demo-authn
+```
+
+Should show port mappings: `0.0.0.0:80->30080/tcp, 0.0.0.0:443->30443/tcp`
+
+Check Traefik IngressRoutes:
+
+```bash
+kubectl get ingressroute --all-namespaces
+```
+
+### Certificate Issues
+
+Check cert-manager resources:
+
+```bash
+kubectl get certificates --all-namespaces
+kubectl get certificaterequests --all-namespaces
+kubectl get clusterissuers
+```
+
+### CFK Components Not Deploying
+
+Check operator logs:
+
+```bash
+kubectl logs --namespace operator deployment/confluent-operator --tail=100
+```
+
+Verify CRDs installed:
+
+```bash
+kubectl get crd | grep platform.confluent.io
+```
+
+### Validation Script
+
+Run the comprehensive validation script:
+
+```bash
+./scripts/validate-cluster.sh flink-demo-authn --verbose
+```
+
+## Cleanup
+
+Remove the kind cluster:
+
+```bash
+kind delete cluster --name flink-demo-authn
+```
+
+Stop the container runtime (if using Colima):
+
+```bash
+colima stop
+```

--- a/clusters/flink-demo-authn/README.md
+++ b/clusters/flink-demo-authn/README.md
@@ -190,10 +190,93 @@ Add these entries to `/etc/hosts`:
 
 <!-- Add any additional services or port-forwarding fallbacks specific to this cluster -->
 
+## Authenticating to CMF and Running Flink
+
+CMF in this cluster validates **Keycloak-issued OIDC bearer tokens** (no MDS, no RBAC). You authenticate by obtaining a token from Keycloak and presenting it to the **CMF REST API**.
+
+> [!IMPORTANT]
+> **The `confluent flink` CLI does not work against this cluster.** The on-premises `confluent flink` commands authenticate to CMF only via an **MDS login session** or **mTLS client certificates** — neither exists here (MDS is removed; CMF uses OIDC, not mTLS). The CLI has no bearer-token option, so every call returns `401` (verified with Confluent CLI v4.57.0, including with `CONFLUENT_CMF_ACCESS_TOKEN` set). Use the REST API below. See [Using the CLI anyway](#using-the-confluent-flink-cli-anyway-optional) if you need the CLI UX.
+
+### 1. Reach the CMF API
+
+Port-forward CMF (works regardless of ingress / `/etc/hosts`):
+
+```bash
+kubectl -n operator port-forward svc/cmf-service 8080:80
+```
+
+CMF is now reachable at `http://localhost:8080`, REST base path `/cmf/api/v1`. (Or use the ingress URL `http://cmf.flink-demo-authn.confluentdemo.local`.)
+
+### 2. Get a Keycloak token
+
+Any valid Keycloak token is accepted (no authorization — **allow-all**). The simplest is the `cmf` service client via the client-credentials grant. Port-forward Keycloak in a second terminal:
+
+```bash
+kubectl -n keycloak port-forward svc/keycloak 8081:8080
+```
+
+```bash
+export TOKEN=$(curl -s -X POST \
+  http://localhost:8081/realms/confluent/protocol/openid-connect/token \
+  -d grant_type=client_credentials \
+  -d client_id=cmf -d client_secret=cmf-secret | jq -r .access_token)
+```
+
+> The token's `iss` claim is `https://keycloak.flink-demo-authn.confluentdemo.local/realms/confluent` (set by Keycloak's `KC_HOSTNAME`), which matches CMF's `oauthbearer.expected.issuer` — so requesting the token over a port-forward on a different local port is fine.
+
+To authenticate as a **human user** instead of the service client, use the password grant:
+
+```bash
+export TOKEN=$(curl -s -X POST \
+  http://localhost:8081/realms/confluent/protocol/openid-connect/token \
+  -d grant_type=password -d client_id=controlcenter -d client_secret=controlcenter-secret \
+  -d username=<user> -d password=<pass> | jq -r .access_token)
+```
+
+### 3. Call the CMF REST API
+
+List environments (`shapes-env` and `colors-env` are pre-created by the `flink-resources-rbac` workload):
+
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" \
+  http://localhost:8080/cmf/api/v1/environments | jq .
+```
+
+Common endpoints (base `http://localhost:8080/cmf/api/v1`):
+
+| Action | Method + path |
+|---|---|
+| List / describe environments | `GET /environments`, `GET /environments/{env}` |
+| List / create applications | `GET` / `POST /environments/{env}/applications` |
+| List compute pools | `GET /environments/{env}/compute-pools` |
+| Manage secrets & mappings | `/secrets`, `/environments/{env}/secret-mappings` |
+| Kafka catalogs / databases | `/catalogs/kafka`, `/catalogs/kafka/{catalog}/databases` |
+
+Example — create a FlinkApplication in `shapes-env` from a JSON file:
+
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -X POST http://localhost:8080/cmf/api/v1/environments/shapes-env/applications \
+  -d @my-application.json | jq .
+```
+
+> Keycloak access tokens are short-lived. When a call starts returning `401`, re-run step 2 to refresh `$TOKEN`.
+
+### Using the `confluent flink` CLI anyway (optional)
+
+The CLI cannot send a bearer token, but it can target a local endpoint that injects one. Run a small local reverse proxy that adds `Authorization: Bearer $TOKEN` to every request and forwards to CMF, then point the CLI at the proxy:
+
+```bash
+confluent logout    # on-prem flink commands require being logged out of Confluent Cloud
+confluent flink environment list --url http://localhost:<proxy-port>
+```
+
+This is a local-dev convenience only (the pinned token expires). A maintained helper script is not yet provided — the proper fix is native CLI OIDC support for CMF.
+
 ## Cluster Specific Use Cases
 
 - **Authentication without authorization:** see the [Security Model](#security-model-oidc-authentication-no-authorization) above. All OAuth/OIDC tokens are issued by Keycloak and validated directly against its JWKS endpoint (no MDS-signed tokens).
-- **CMF access:** the CFK operator authenticates to CMF via a `CMFRestClass` using OAuth client-credentials; CLI/REST clients pass a Keycloak bearer token to the CMF REST API.
+- **CMF access:** the CFK operator authenticates to CMF via a `CMFRestClass` using OAuth client-credentials; human/automation clients use the **CMF REST API with a Keycloak bearer token** — see [Authenticating to CMF and Running Flink](#authenticating-to-cmf-and-running-flink). The `confluent flink` CLI is **not** usable here (no bearer-token support).
 - **Pre-created Flink resources:** the `flink-resources-rbac` workload provisions Flink environments, applications, and the CP Flink SQL Sandbox (shapes/colors demos) — identical to `flink-demo-rbac` but without role bindings.
 
 ## Troubleshooting

--- a/clusters/flink-demo-authn/README.md
+++ b/clusters/flink-demo-authn/README.md
@@ -1,18 +1,30 @@
 # flink-demo-authn Cluster
 
-$CLUSTER_DESCRIPTION
+A Confluent Platform + Apache Flink demo cluster that authenticates every principal via Keycloak OIDC but performs **no authorization** — no MDS, no RBAC. It is a variant of `flink-demo-rbac` with the MDS service and all authorization stripped out.
 
 ## Overview
 
 The `flink-demo-authn` cluster provides:
 
-- **Kafka Cluster**: $KAFKA_DESCRIPTION
-- **Flink Integration**: $FLINK_DESCRIPTION
+- **Kafka Cluster**: KRaft-based Kafka with OAuth/OIDC authentication (Keycloak) on all listeners and **no authorizer** (any authenticated principal is allowed).
+- **Flink Integration**: Confluent Manager for Apache Flink (CMF) authenticating clients via Keycloak OIDC; the CFK operator manages Flink through a `CMFRestClass` using OAuth client-credentials.
 - **Monitoring**: Prometheus, Grafana, and Alertmanager with pre-configured dashboards
-- **Security**: $SECURITY_DESCRIPTION
+- **Security**: Keycloak OIDC authentication everywhere; **NO authorization/RBAC, NO MDS** — see [Security Model](#security-model-oidc-authentication-no-authorization) below.
 - **Networking**: Traefik ingress controller with local DNS resolution
 
 **Domain**: `*.flink-demo-authn.confluentdemo.local`
+
+## Security Model: OIDC Authentication, NO Authorization
+
+This cluster authenticates every principal via Keycloak OIDC but performs **no authorization**. There is no Kafka authorizer and no MDS/RBAC.
+
+> [!WARNING]
+> **Allow-all:** any principal that presents a valid Keycloak token can perform any action on Kafka, Schema Registry, and CMF. Do not use this variant where tenant isolation or least-privilege is required.
+
+### Accessing the platform
+- **CLI/REST:** obtain a token directly from Keycloak (client-credentials, or device flow against Keycloak) and pass it as a bearer token. The MDS-hosted `confluent login` device-grant flow used by `flink-demo-rbac` is **not available** here (MDS is removed).
+- **Control Center UI:** anonymous access (no login). SSO/OIDC for Control Center requires MDS and is intentionally omitted; C3 still connects to Kafka and Schema Registry using service-account OAuth.
+- **What is removed vs. `flink-demo-rbac`:** Kafka `authorization: rbac` + `services.mds`, CMF `authorization` + MDS-coupled auth config, the `mds-keygen` job and `mds-token` secret, all `ConfluentRolebinding` resources, and Control Center's MDS/SSO dependency. Kubernetes RBAC for Flink (`flink-rbac`) is retained — it is unrelated to Confluent authorization.
 
 ## Getting Started
 
@@ -180,18 +192,9 @@ Add these entries to `/etc/hosts`:
 
 ## Cluster Specific Use Cases
 
-<!--
-Document anything unique to this cluster that doesn't fit the standard template.
-Examples:
-- RBAC naming conventions and permission model
-- Pre-created topics, schemas, or Flink resources
-- Special authentication flows (e.g., Keycloak SSO, MDS device-grant)
-- Token lifecycle management
-- Demo/sandbox environments (e.g., CP Flink SQL Sandbox)
-
-Remove this comment block and replace with cluster-specific content.
-If this cluster has no unique use cases, remove this section entirely.
--->
+- **Authentication without authorization:** see the [Security Model](#security-model-oidc-authentication-no-authorization) above. All OAuth/OIDC tokens are issued by Keycloak and validated directly against its JWKS endpoint (no MDS-signed tokens).
+- **CMF access:** the CFK operator authenticates to CMF via a `CMFRestClass` using OAuth client-credentials; CLI/REST clients pass a Keycloak bearer token to the CMF REST API.
+- **Pre-created Flink resources:** the `flink-resources-rbac` workload provisions Flink environments, applications, and the CP Flink SQL Sandbox (shapes/colors demos) — identical to `flink-demo-rbac` but without role bindings.
 
 ## Troubleshooting
 

--- a/clusters/flink-demo-authn/bootstrap.yaml
+++ b/clusters/flink-demo-authn/bootstrap.yaml
@@ -12,7 +12,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/osowski/confluent-platform-gitops.git
-    targetRevision: HEAD
+    targetRevision: feature-279/test-authn-with-no-authz
     path: bootstrap
     helm:
       valuesObject:
@@ -20,7 +20,7 @@ spec:
           name: flink-demo-authn
           domain: confluentdemo.local
         git:
-          targetRevision: "HEAD"
+          targetRevision: "feature-279/test-authn-with-no-authz"
   destination:
     server: https://kubernetes.default.svc
     namespace: argocd

--- a/clusters/flink-demo-authn/bootstrap.yaml
+++ b/clusters/flink-demo-authn/bootstrap.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: bootstrap
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/osowski/confluent-platform-gitops.git
+    targetRevision: HEAD
+    path: bootstrap
+    helm:
+      valuesObject:
+        cluster:
+          name: flink-demo-authn
+          domain: confluentdemo.local
+        git:
+          targetRevision: "HEAD"
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/clusters/flink-demo-authn/infrastructure/argocd-config.yaml
+++ b/clusters/flink-demo-authn/infrastructure/argocd-config.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argocd-config
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "85"  # After argocd-ingress (80), before workloads (100)
+spec:
+  project: infrastructure
+  source:
+    repoURL: https://github.com/osowski/confluent-platform-gitops.git
+    targetRevision: HEAD
+    path: infrastructure/argocd-config/overlays/flink-demo-authn
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/clusters/flink-demo-authn/infrastructure/argocd-config.yaml
+++ b/clusters/flink-demo-authn/infrastructure/argocd-config.yaml
@@ -7,12 +7,12 @@ metadata:
   finalizers:
     - resources-finalizer.argocd.argoproj.io
   annotations:
-    argocd.argoproj.io/sync-wave: "85"  # After argocd-ingress (80), before workloads (100)
+    argocd.argoproj.io/sync-wave: "85" # After argocd-ingress (80), before workloads (100)
 spec:
   project: infrastructure
   source:
     repoURL: https://github.com/osowski/confluent-platform-gitops.git
-    targetRevision: HEAD
+    targetRevision: feature-279/test-authn-with-no-authz
     path: infrastructure/argocd-config/overlays/flink-demo-authn
   destination:
     server: https://kubernetes.default.svc

--- a/clusters/flink-demo-authn/infrastructure/cert-manager-resources.yaml
+++ b/clusters/flink-demo-authn/infrastructure/cert-manager-resources.yaml
@@ -12,7 +12,7 @@ spec:
   project: infrastructure
   source:
     repoURL: https://github.com/osowski/confluent-platform-gitops.git
-    targetRevision: HEAD
+    targetRevision: feature-279/test-authn-with-no-authz
     path: infrastructure/cert-manager-resources/overlays/flink-demo-authn
   destination:
     server: https://kubernetes.default.svc

--- a/clusters/flink-demo-authn/infrastructure/cert-manager-resources.yaml
+++ b/clusters/flink-demo-authn/infrastructure/cert-manager-resources.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cert-manager-resources
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "75"
+spec:
+  project: infrastructure
+  source:
+    repoURL: https://github.com/osowski/confluent-platform-gitops.git
+    targetRevision: HEAD
+    path: infrastructure/cert-manager-resources/overlays/flink-demo-authn
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: cert-manager
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/clusters/flink-demo-authn/infrastructure/cert-manager.yaml
+++ b/clusters/flink-demo-authn/infrastructure/cert-manager.yaml
@@ -7,21 +7,21 @@ metadata:
   finalizers:
     - resources-finalizer.argocd.argoproj.io
   annotations:
-    argocd.argoproj.io/sync-wave: "20"  # Deploy after cert-manager and storage
+    argocd.argoproj.io/sync-wave: "20" # Deploy after cert-manager and storage
 spec:
   project: infrastructure
   sources:
-  - repoURL: oci://quay.io/jetstack/charts/cert-manager
-    targetRevision: v1.19.2  # Pin to specific version
-    chart: cert-manager
-    helm:
-      ignoreMissingValueFiles: true
-      valueFiles:
-        - $values/infrastructure/cert-manager/base/values.yaml
-        - $values/infrastructure/cert-manager/overlays/flink-demo-authn/values.yaml
-  - repoURL: https://github.com/osowski/confluent-platform-gitops.git
-    targetRevision: HEAD
-    ref: values
+    - repoURL: oci://quay.io/jetstack/charts/cert-manager
+      targetRevision: v1.19.2 # Pin to specific version
+      chart: cert-manager
+      helm:
+        ignoreMissingValueFiles: true
+        valueFiles:
+          - $values/infrastructure/cert-manager/base/values.yaml
+          - $values/infrastructure/cert-manager/overlays/flink-demo-authn/values.yaml
+    - repoURL: https://github.com/osowski/confluent-platform-gitops.git
+      targetRevision: feature-279/test-authn-with-no-authz
+      ref: values
   destination:
     server: https://kubernetes.default.svc
     namespace: cert-manager
@@ -31,7 +31,7 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
-      - ServerSideApply=true  # Required for CRDs
+      - ServerSideApply=true # Required for CRDs
     retry:
       limit: 5
       backoff:

--- a/clusters/flink-demo-authn/infrastructure/cert-manager.yaml
+++ b/clusters/flink-demo-authn/infrastructure/cert-manager.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cert-manager
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "20"  # Deploy after cert-manager and storage
+spec:
+  project: infrastructure
+  sources:
+  - repoURL: oci://quay.io/jetstack/charts/cert-manager
+    targetRevision: v1.19.2  # Pin to specific version
+    chart: cert-manager
+    helm:
+      ignoreMissingValueFiles: true
+      valueFiles:
+        - $values/infrastructure/cert-manager/base/values.yaml
+        - $values/infrastructure/cert-manager/overlays/flink-demo-authn/values.yaml
+  - repoURL: https://github.com/osowski/confluent-platform-gitops.git
+    targetRevision: HEAD
+    ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: cert-manager
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true  # Required for CRDs
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/clusters/flink-demo-authn/infrastructure/infra-ingresses.yaml
+++ b/clusters/flink-demo-authn/infrastructure/infra-ingresses.yaml
@@ -12,7 +12,7 @@ spec:
   project: infrastructure
   source:
     repoURL: https://github.com/osowski/confluent-platform-gitops.git
-    targetRevision: HEAD
+    targetRevision: feature-279/test-authn-with-no-authz
     path: infrastructure/ingresses/overlays/flink-demo-authn
   destination:
     server: https://kubernetes.default.svc

--- a/clusters/flink-demo-authn/infrastructure/infra-ingresses.yaml
+++ b/clusters/flink-demo-authn/infrastructure/infra-ingresses.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: infra-ingresses
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "80"
+spec:
+  project: infrastructure
+  source:
+    repoURL: https://github.com/osowski/confluent-platform-gitops.git
+    targetRevision: HEAD
+    path: infrastructure/ingresses/overlays/flink-demo-authn
+  destination:
+    server: https://kubernetes.default.svc
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=false
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/clusters/flink-demo-authn/infrastructure/kube-prometheus-stack-crds.yaml
+++ b/clusters/flink-demo-authn/infrastructure/kube-prometheus-stack-crds.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kube-prometheus-stack-crds
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"  # Deploy as early as possible so all others have access to CRDs
+spec:
+  project: infrastructure
+  sources:
+  - repoURL: https://prometheus-community.github.io/helm-charts
+    targetRevision: 81.6.1  # Pin to specific version
+    chart: kube-prometheus-stack
+    helm:
+      valueFiles:
+        - $values/infrastructure/kube-prometheus-stack-crds/base/values.yaml
+  - repoURL: https://github.com/osowski/confluent-platform-gitops.git
+    targetRevision: HEAD
+    ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: monitoring
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true  # Required for CRDs
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m
+  ignoreDifferences:
+    # Ignore differences in webhook CA bundles (auto-generated)
+    - group: admissionregistration.k8s.io
+      kind: MutatingWebhookConfiguration
+      jsonPointers:
+        - /webhooks/0/clientConfig/caBundle
+    - group: admissionregistration.k8s.io
+      kind: ValidatingWebhookConfiguration
+      jsonPointers:
+        - /webhooks/0/clientConfig/caBundle

--- a/clusters/flink-demo-authn/infrastructure/kube-prometheus-stack-crds.yaml
+++ b/clusters/flink-demo-authn/infrastructure/kube-prometheus-stack-crds.yaml
@@ -7,19 +7,19 @@ metadata:
   finalizers:
     - resources-finalizer.argocd.argoproj.io
   annotations:
-    argocd.argoproj.io/sync-wave: "2"  # Deploy as early as possible so all others have access to CRDs
+    argocd.argoproj.io/sync-wave: "2" # Deploy as early as possible so all others have access to CRDs
 spec:
   project: infrastructure
   sources:
-  - repoURL: https://prometheus-community.github.io/helm-charts
-    targetRevision: 81.6.1  # Pin to specific version
-    chart: kube-prometheus-stack
-    helm:
-      valueFiles:
-        - $values/infrastructure/kube-prometheus-stack-crds/base/values.yaml
-  - repoURL: https://github.com/osowski/confluent-platform-gitops.git
-    targetRevision: HEAD
-    ref: values
+    - repoURL: https://prometheus-community.github.io/helm-charts
+      targetRevision: 81.6.1 # Pin to specific version
+      chart: kube-prometheus-stack
+      helm:
+        valueFiles:
+          - $values/infrastructure/kube-prometheus-stack-crds/base/values.yaml
+    - repoURL: https://github.com/osowski/confluent-platform-gitops.git
+      targetRevision: feature-279/test-authn-with-no-authz
+      ref: values
   destination:
     server: https://kubernetes.default.svc
     namespace: monitoring
@@ -29,7 +29,7 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
-      - ServerSideApply=true  # Required for CRDs
+      - ServerSideApply=true # Required for CRDs
     retry:
       limit: 5
       backoff:

--- a/clusters/flink-demo-authn/infrastructure/kube-prometheus-stack.yaml
+++ b/clusters/flink-demo-authn/infrastructure/kube-prometheus-stack.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kube-prometheus-stack
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "20"  # Deploy after cert-manager and storage
+spec:
+  project: infrastructure
+  sources:
+  - repoURL: https://prometheus-community.github.io/helm-charts
+    targetRevision: 81.6.1  # Pin to specific version
+    chart: kube-prometheus-stack
+    helm:
+      valueFiles:
+        - $values/infrastructure/kube-prometheus-stack/base/values.yaml
+        - $values/infrastructure/kube-prometheus-stack/overlays/flink-demo-authn/values.yaml
+      ignoreMissingValueFiles: true
+  - repoURL: https://github.com/osowski/confluent-platform-gitops.git
+    targetRevision: HEAD
+    ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: monitoring
+  syncPolicy:
+    # automated: disabled # Explicitly NOT auto-sync while under development
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true  # Required for CRDs
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m
+  ignoreDifferences:
+    # Ignore differences in webhook CA bundles (auto-generated)
+    - group: admissionregistration.k8s.io
+      kind: MutatingWebhookConfiguration
+      jsonPointers:
+        - /webhooks/0/clientConfig/caBundle
+    - group: admissionregistration.k8s.io
+      kind: ValidatingWebhookConfiguration
+      jsonPointers:
+        - /webhooks/0/clientConfig/caBundle
+    # Ignore differences in auto-generated secrets
+    - group: ""
+      kind: Secret
+      name: alertmanager-kube-prometheus-stack-alertmanager
+      jsonPointers:
+        - /data
+    # Ignore Ingress loadBalancer status for NodePort environments (KIND clusters)
+    # NodePort services don't populate status.loadBalancer, causing ArgoCD to stay in Progressing
+    - group: networking.k8s.io
+      kind: Ingress
+      jsonPointers:
+        - /status/loadBalancer

--- a/clusters/flink-demo-authn/infrastructure/kube-prometheus-stack.yaml
+++ b/clusters/flink-demo-authn/infrastructure/kube-prometheus-stack.yaml
@@ -7,21 +7,21 @@ metadata:
   finalizers:
     - resources-finalizer.argocd.argoproj.io
   annotations:
-    argocd.argoproj.io/sync-wave: "20"  # Deploy after cert-manager and storage
+    argocd.argoproj.io/sync-wave: "20" # Deploy after cert-manager and storage
 spec:
   project: infrastructure
   sources:
-  - repoURL: https://prometheus-community.github.io/helm-charts
-    targetRevision: 81.6.1  # Pin to specific version
-    chart: kube-prometheus-stack
-    helm:
-      valueFiles:
-        - $values/infrastructure/kube-prometheus-stack/base/values.yaml
-        - $values/infrastructure/kube-prometheus-stack/overlays/flink-demo-authn/values.yaml
-      ignoreMissingValueFiles: true
-  - repoURL: https://github.com/osowski/confluent-platform-gitops.git
-    targetRevision: HEAD
-    ref: values
+    - repoURL: https://prometheus-community.github.io/helm-charts
+      targetRevision: 81.6.1 # Pin to specific version
+      chart: kube-prometheus-stack
+      helm:
+        valueFiles:
+          - $values/infrastructure/kube-prometheus-stack/base/values.yaml
+          - $values/infrastructure/kube-prometheus-stack/overlays/flink-demo-authn/values.yaml
+        ignoreMissingValueFiles: true
+    - repoURL: https://github.com/osowski/confluent-platform-gitops.git
+      targetRevision: feature-279/test-authn-with-no-authz
+      ref: values
   destination:
     server: https://kubernetes.default.svc
     namespace: monitoring
@@ -29,7 +29,7 @@ spec:
     # automated: disabled # Explicitly NOT auto-sync while under development
     syncOptions:
       - CreateNamespace=true
-      - ServerSideApply=true  # Required for CRDs
+      - ServerSideApply=true # Required for CRDs
     retry:
       limit: 5
       backoff:

--- a/clusters/flink-demo-authn/infrastructure/kustomization.yaml
+++ b/clusters/flink-demo-authn/infrastructure/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- argocd-config.yaml
+- infra-ingresses.yaml
+- cert-manager.yaml
+- cert-manager-resources.yaml
+- trust-manager.yaml
+- kube-prometheus-stack-crds.yaml
+- kube-prometheus-stack.yaml
+- metrics-server.yaml
+- reflector.yaml
+- traefik.yaml
+- minio.yaml
+- vault.yaml
+- vault-config.yaml
+
+# Infrastructure applications are deployed in sync wave order (10-85)
+# Remove any applications you don't need for your cluster

--- a/clusters/flink-demo-authn/infrastructure/metrics-server.yaml
+++ b/clusters/flink-demo-authn/infrastructure/metrics-server.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: metrics-server
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "5"  # After CRDs (2), before infrastructure (10+)
+spec:
+  project: infrastructure
+  sources:
+  - repoURL: https://kubernetes-sigs.github.io/metrics-server/
+    targetRevision: 3.12.2  # Pin to specific version
+    chart: metrics-server
+    helm:
+      ignoreMissingValueFiles: true
+      valueFiles:
+        - $values/infrastructure/metrics-server/base/values.yaml
+        - $values/infrastructure/metrics-server/overlays/flink-demo-authn/values.yaml
+  - repoURL: https://github.com/osowski/confluent-platform-gitops.git
+    targetRevision: HEAD
+    ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kube-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=false  # kube-system already exists
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m
+  ignoreDifferences: []

--- a/clusters/flink-demo-authn/infrastructure/metrics-server.yaml
+++ b/clusters/flink-demo-authn/infrastructure/metrics-server.yaml
@@ -7,21 +7,21 @@ metadata:
   finalizers:
     - resources-finalizer.argocd.argoproj.io
   annotations:
-    argocd.argoproj.io/sync-wave: "5"  # After CRDs (2), before infrastructure (10+)
+    argocd.argoproj.io/sync-wave: "5" # After CRDs (2), before infrastructure (10+)
 spec:
   project: infrastructure
   sources:
-  - repoURL: https://kubernetes-sigs.github.io/metrics-server/
-    targetRevision: 3.12.2  # Pin to specific version
-    chart: metrics-server
-    helm:
-      ignoreMissingValueFiles: true
-      valueFiles:
-        - $values/infrastructure/metrics-server/base/values.yaml
-        - $values/infrastructure/metrics-server/overlays/flink-demo-authn/values.yaml
-  - repoURL: https://github.com/osowski/confluent-platform-gitops.git
-    targetRevision: HEAD
-    ref: values
+    - repoURL: https://kubernetes-sigs.github.io/metrics-server/
+      targetRevision: 3.12.2 # Pin to specific version
+      chart: metrics-server
+      helm:
+        ignoreMissingValueFiles: true
+        valueFiles:
+          - $values/infrastructure/metrics-server/base/values.yaml
+          - $values/infrastructure/metrics-server/overlays/flink-demo-authn/values.yaml
+    - repoURL: https://github.com/osowski/confluent-platform-gitops.git
+      targetRevision: feature-279/test-authn-with-no-authz
+      ref: values
   destination:
     server: https://kubernetes.default.svc
     namespace: kube-system
@@ -30,7 +30,7 @@ spec:
       prune: true
       selfHeal: true
     syncOptions:
-      - CreateNamespace=false  # kube-system already exists
+      - CreateNamespace=false # kube-system already exists
     retry:
       limit: 5
       backoff:

--- a/clusters/flink-demo-authn/infrastructure/minio.yaml
+++ b/clusters/flink-demo-authn/infrastructure/minio.yaml
@@ -12,7 +12,7 @@ spec:
   project: infrastructure
   source:
     repoURL: https://github.com/osowski/confluent-platform-gitops.git
-    targetRevision: HEAD
+    targetRevision: feature-279/test-authn-with-no-authz
     path: infrastructure/minio/overlays/flink-demo-authn
   destination:
     server: https://kubernetes.default.svc

--- a/clusters/flink-demo-authn/infrastructure/minio.yaml
+++ b/clusters/flink-demo-authn/infrastructure/minio.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: minio
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "85" # After traefik/ingress (80), before workloads (100+)
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: infrastructure
+  source:
+    repoURL: https://github.com/osowski/confluent-platform-gitops.git
+    targetRevision: HEAD
+    path: infrastructure/minio/overlays/flink-demo-authn
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: storage
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: false
+    syncOptions:
+      - CreateNamespace=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/clusters/flink-demo-authn/infrastructure/reflector.yaml
+++ b/clusters/flink-demo-authn/infrastructure/reflector.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: reflector
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "40"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: infrastructure
+  sources:
+    - repoURL: https://emberstack.github.io/helm-charts
+      chart: reflector
+      targetRevision: 10.0.21  # Pin to specific chart version
+      helm:
+        valueFiles:
+          - $values/infrastructure/reflector/base/values.yaml
+    - repoURL: https://github.com/osowski/confluent-platform-gitops.git
+      targetRevision: HEAD
+      ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: reflector-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/clusters/flink-demo-authn/infrastructure/reflector.yaml
+++ b/clusters/flink-demo-authn/infrastructure/reflector.yaml
@@ -13,12 +13,12 @@ spec:
   sources:
     - repoURL: https://emberstack.github.io/helm-charts
       chart: reflector
-      targetRevision: 10.0.21  # Pin to specific chart version
+      targetRevision: 10.0.21 # Pin to specific chart version
       helm:
         valueFiles:
           - $values/infrastructure/reflector/base/values.yaml
     - repoURL: https://github.com/osowski/confluent-platform-gitops.git
-      targetRevision: HEAD
+      targetRevision: feature-279/test-authn-with-no-authz
       ref: values
   destination:
     server: https://kubernetes.default.svc

--- a/clusters/flink-demo-authn/infrastructure/traefik.yaml
+++ b/clusters/flink-demo-authn/infrastructure/traefik.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: traefik
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"  # Deploy after cert-manager and storage
+spec:
+  project: infrastructure
+  sources:
+  - repoURL: oci://ghcr.io/traefik/helm/traefik
+    targetRevision: 38.0.2  # Pin to specific version
+    chart: traefik
+    helm:
+      ignoreMissingValueFiles: true
+      valueFiles:
+        - $values/infrastructure/traefik/base/values.yaml
+        - $values/infrastructure/traefik/overlays/flink-demo-authn/values.yaml
+  - repoURL: https://github.com/osowski/confluent-platform-gitops.git
+    targetRevision: HEAD
+    ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: ingress
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true  # Required for CRDs
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m
+  ignoreDifferences: []

--- a/clusters/flink-demo-authn/infrastructure/traefik.yaml
+++ b/clusters/flink-demo-authn/infrastructure/traefik.yaml
@@ -7,21 +7,21 @@ metadata:
   finalizers:
     - resources-finalizer.argocd.argoproj.io
   annotations:
-    argocd.argoproj.io/sync-wave: "10"  # Deploy after cert-manager and storage
+    argocd.argoproj.io/sync-wave: "10" # Deploy after cert-manager and storage
 spec:
   project: infrastructure
   sources:
-  - repoURL: oci://ghcr.io/traefik/helm/traefik
-    targetRevision: 38.0.2  # Pin to specific version
-    chart: traefik
-    helm:
-      ignoreMissingValueFiles: true
-      valueFiles:
-        - $values/infrastructure/traefik/base/values.yaml
-        - $values/infrastructure/traefik/overlays/flink-demo-authn/values.yaml
-  - repoURL: https://github.com/osowski/confluent-platform-gitops.git
-    targetRevision: HEAD
-    ref: values
+    - repoURL: oci://ghcr.io/traefik/helm/traefik
+      targetRevision: 38.0.2 # Pin to specific version
+      chart: traefik
+      helm:
+        ignoreMissingValueFiles: true
+        valueFiles:
+          - $values/infrastructure/traefik/base/values.yaml
+          - $values/infrastructure/traefik/overlays/flink-demo-authn/values.yaml
+    - repoURL: https://github.com/osowski/confluent-platform-gitops.git
+      targetRevision: feature-279/test-authn-with-no-authz
+      ref: values
   destination:
     server: https://kubernetes.default.svc
     namespace: ingress
@@ -31,7 +31,7 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
-      - ServerSideApply=true  # Required for CRDs
+      - ServerSideApply=true # Required for CRDs
     retry:
       limit: 5
       backoff:

--- a/clusters/flink-demo-authn/infrastructure/trust-manager.yaml
+++ b/clusters/flink-demo-authn/infrastructure/trust-manager.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: trust-manager
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "30"  # Deploy after cert-manager (wave 20)
+spec:
+  project: infrastructure
+  sources:
+  - repoURL: oci://quay.io/jetstack/charts/trust-manager
+    targetRevision: v0.20.3  # Pin to specific version
+    chart: trust-manager
+    helm:
+      ignoreMissingValueFiles: true
+      valueFiles:
+        - $values/infrastructure/trust-manager/base/values.yaml
+        - $values/infrastructure/trust-manager/overlays/flink-demo-authn/values.yaml
+  - repoURL: https://github.com/osowski/confluent-platform-gitops.git
+    targetRevision: HEAD
+    ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: cert-manager
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=false  # cert-manager namespace already created by cert-manager app
+      - ServerSideApply=true  # Required for CRDs
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/clusters/flink-demo-authn/infrastructure/trust-manager.yaml
+++ b/clusters/flink-demo-authn/infrastructure/trust-manager.yaml
@@ -7,21 +7,21 @@ metadata:
   finalizers:
     - resources-finalizer.argocd.argoproj.io
   annotations:
-    argocd.argoproj.io/sync-wave: "30"  # Deploy after cert-manager (wave 20)
+    argocd.argoproj.io/sync-wave: "30" # Deploy after cert-manager (wave 20)
 spec:
   project: infrastructure
   sources:
-  - repoURL: oci://quay.io/jetstack/charts/trust-manager
-    targetRevision: v0.20.3  # Pin to specific version
-    chart: trust-manager
-    helm:
-      ignoreMissingValueFiles: true
-      valueFiles:
-        - $values/infrastructure/trust-manager/base/values.yaml
-        - $values/infrastructure/trust-manager/overlays/flink-demo-authn/values.yaml
-  - repoURL: https://github.com/osowski/confluent-platform-gitops.git
-    targetRevision: HEAD
-    ref: values
+    - repoURL: oci://quay.io/jetstack/charts/trust-manager
+      targetRevision: v0.20.3 # Pin to specific version
+      chart: trust-manager
+      helm:
+        ignoreMissingValueFiles: true
+        valueFiles:
+          - $values/infrastructure/trust-manager/base/values.yaml
+          - $values/infrastructure/trust-manager/overlays/flink-demo-authn/values.yaml
+    - repoURL: https://github.com/osowski/confluent-platform-gitops.git
+      targetRevision: feature-279/test-authn-with-no-authz
+      ref: values
   destination:
     server: https://kubernetes.default.svc
     namespace: cert-manager
@@ -30,8 +30,8 @@ spec:
       prune: true
       selfHeal: true
     syncOptions:
-      - CreateNamespace=false  # cert-manager namespace already created by cert-manager app
-      - ServerSideApply=true  # Required for CRDs
+      - CreateNamespace=false # cert-manager namespace already created by cert-manager app
+      - ServerSideApply=true # Required for CRDs
     retry:
       limit: 5
       backoff:

--- a/clusters/flink-demo-authn/infrastructure/vault-config.yaml
+++ b/clusters/flink-demo-authn/infrastructure/vault-config.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: vault-config
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "50"
+spec:
+  project: infrastructure
+  source:
+    repoURL: https://github.com/osowski/confluent-platform-gitops.git
+    targetRevision: HEAD
+    path: infrastructure/vault-config/overlays/flink-demo-authn
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: vault
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/clusters/flink-demo-authn/infrastructure/vault-config.yaml
+++ b/clusters/flink-demo-authn/infrastructure/vault-config.yaml
@@ -12,7 +12,7 @@ spec:
   project: infrastructure
   source:
     repoURL: https://github.com/osowski/confluent-platform-gitops.git
-    targetRevision: HEAD
+    targetRevision: feature-279/test-authn-with-no-authz
     path: infrastructure/vault-config/overlays/flink-demo-authn
   destination:
     server: https://kubernetes.default.svc

--- a/clusters/flink-demo-authn/infrastructure/vault.yaml
+++ b/clusters/flink-demo-authn/infrastructure/vault.yaml
@@ -11,17 +11,17 @@ metadata:
 spec:
   project: infrastructure
   sources:
-  - repoURL: https://helm.releases.hashicorp.com
-    targetRevision: 0.31.0
-    chart: vault
-    helm:
-      ignoreMissingValueFiles: true
-      valueFiles:
-        - $values/infrastructure/vault/base/values.yaml
-        - $values/infrastructure/vault/overlays/flink-demo-authn/values.yaml
-  - repoURL: https://github.com/osowski/confluent-platform-gitops.git
-    targetRevision: HEAD
-    ref: values
+    - repoURL: https://helm.releases.hashicorp.com
+      targetRevision: 0.31.0
+      chart: vault
+      helm:
+        ignoreMissingValueFiles: true
+        valueFiles:
+          - $values/infrastructure/vault/base/values.yaml
+          - $values/infrastructure/vault/overlays/flink-demo-authn/values.yaml
+    - repoURL: https://github.com/osowski/confluent-platform-gitops.git
+      targetRevision: feature-279/test-authn-with-no-authz
+      ref: values
   destination:
     server: https://kubernetes.default.svc
     namespace: vault

--- a/clusters/flink-demo-authn/infrastructure/vault.yaml
+++ b/clusters/flink-demo-authn/infrastructure/vault.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: vault
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "40"
+spec:
+  project: infrastructure
+  sources:
+  - repoURL: https://helm.releases.hashicorp.com
+    targetRevision: 0.31.0
+    chart: vault
+    helm:
+      ignoreMissingValueFiles: true
+      valueFiles:
+        - $values/infrastructure/vault/base/values.yaml
+        - $values/infrastructure/vault/overlays/flink-demo-authn/values.yaml
+  - repoURL: https://github.com/osowski/confluent-platform-gitops.git
+    targetRevision: HEAD
+    ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: vault
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/clusters/flink-demo-authn/kind-config.yaml
+++ b/clusters/flink-demo-authn/kind-config.yaml
@@ -1,0 +1,41 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+    kubeadmConfigPatches:
+      - |
+        kind: InitConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "ingress-ready=true"
+    extraPortMappings:
+      # Traefik HTTP/HTTPS
+      - containerPort: 30000
+        hostPort: 80
+        protocol: TCP
+      - containerPort: 30001
+        hostPort: 443
+        protocol: TCP
+      # Keycloak NodePort
+      - containerPort: 30080
+        hostPort: 30080
+        protocol: TCP
+      # Kafka Bootstrap
+      - containerPort: 31000
+        hostPort: 31000
+        protocol: TCP
+      # Kafka Broker 0
+      - containerPort: 31001
+        hostPort: 31001
+        protocol: TCP
+      # Kafka Broker 1
+      - containerPort: 31002
+        hostPort: 31002
+        protocol: TCP
+      # Kafka Broker 2
+      - containerPort: 31003
+        hostPort: 31003
+        protocol: TCP
+  - role: worker
+  - role: worker
+  - role: worker

--- a/clusters/flink-demo-authn/workloads/cfk-operator.yaml
+++ b/clusters/flink-demo-authn/workloads/cfk-operator.yaml
@@ -19,7 +19,7 @@ spec:
           - $values/workloads/cfk-operator/overlays/flink-demo-authn/values.yaml
         ignoreMissingValueFiles: true
     - repoURL: https://github.com/osowski/confluent-platform-gitops.git
-      targetRevision: HEAD
+      targetRevision: feature-279/test-authn-with-no-authz
       ref: values
   destination:
     server: https://kubernetes.default.svc

--- a/clusters/flink-demo-authn/workloads/cfk-operator.yaml
+++ b/clusters/flink-demo-authn/workloads/cfk-operator.yaml
@@ -1,0 +1,38 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cfk-operator
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "105"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: workloads
+  sources:
+    - repoURL: https://packages.confluent.io/helm
+      chart: confluent-for-kubernetes
+      targetRevision: 0.1514.19
+      helm:
+        valueFiles:
+          - $values/workloads/cfk-operator/base/values.yaml
+          - $values/workloads/cfk-operator/overlays/flink-demo-authn/values.yaml
+        ignoreMissingValueFiles: true
+    - repoURL: https://github.com/osowski/confluent-platform-gitops.git
+      targetRevision: HEAD
+      ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: operator
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: false
+    syncOptions:
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/clusters/flink-demo-authn/workloads/cmf-operator-secrets.yaml
+++ b/clusters/flink-demo-authn/workloads/cmf-operator-secrets.yaml
@@ -11,7 +11,7 @@ spec:
   project: workloads
   source:
     repoURL: https://github.com/osowski/confluent-platform-gitops.git
-    targetRevision: HEAD
+    targetRevision: feature-279/test-authn-with-no-authz
     path: workloads/cmf-operator/overlays/flink-demo-authn
   destination:
     server: https://kubernetes.default.svc

--- a/clusters/flink-demo-authn/workloads/cmf-operator-secrets.yaml
+++ b/clusters/flink-demo-authn/workloads/cmf-operator-secrets.yaml
@@ -1,10 +1,10 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: observability-resources
+  name: cmf-operator-secrets
   namespace: argocd
   annotations:
-    argocd.argoproj.io/sync-wave: "117" # After Flink operator (wave 116)
+    argocd.argoproj.io/sync-wave: "117" # Deploy before cmf-operator at wave 118
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
@@ -12,7 +12,7 @@ spec:
   source:
     repoURL: https://github.com/osowski/confluent-platform-gitops.git
     targetRevision: HEAD
-    path: workloads/observability-resources/base
+    path: workloads/cmf-operator/overlays/flink-demo-authn
   destination:
     server: https://kubernetes.default.svc
     namespace: operator
@@ -21,4 +21,10 @@ spec:
       prune: true
       selfHeal: false
     syncOptions:
-      - CreateNamespace=false # Namespace should already exist from wave 100
+      - CreateNamespace=false # operator namespace already exists
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/clusters/flink-demo-authn/workloads/cmf-operator.yaml
+++ b/clusters/flink-demo-authn/workloads/cmf-operator.yaml
@@ -1,0 +1,44 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cmf-operator
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "118"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: workloads
+  sources:
+    - repoURL: https://packages.confluent.io/helm
+      chart: confluent-manager-for-apache-flink
+      targetRevision: 2.3.0
+      helm:
+        valueFiles:
+          - $values/workloads/cmf-operator/base/values.yaml
+          - $values/workloads/cmf-operator/overlays/flink-demo-authn/values.yaml
+        ignoreMissingValueFiles: true
+    - repoURL: https://github.com/osowski/confluent-platform-gitops.git
+      targetRevision: HEAD
+      ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: operator
+  ignoreDifferences:
+    - group: apps
+      kind: Deployment
+      name: confluent-manager-for-apache-flink
+      jsonPointers:
+        - /spec/template/metadata/annotations/rollme
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: false
+    syncOptions:
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/clusters/flink-demo-authn/workloads/cmf-operator.yaml
+++ b/clusters/flink-demo-authn/workloads/cmf-operator.yaml
@@ -19,7 +19,7 @@ spec:
           - $values/workloads/cmf-operator/overlays/flink-demo-authn/values.yaml
         ignoreMissingValueFiles: true
     - repoURL: https://github.com/osowski/confluent-platform-gitops.git
-      targetRevision: HEAD
+      targetRevision: feature-279/test-authn-with-no-authz
       ref: values
   destination:
     server: https://kubernetes.default.svc

--- a/clusters/flink-demo-authn/workloads/confluent-resources.yaml
+++ b/clusters/flink-demo-authn/workloads/confluent-resources.yaml
@@ -11,7 +11,7 @@ spec:
   project: workloads
   source:
     repoURL: https://github.com/osowski/confluent-platform-gitops.git
-    targetRevision: HEAD
+    targetRevision: feature-279/test-authn-with-no-authz
     path: workloads/confluent-resources/overlays/flink-demo-authn
   destination:
     server: https://kubernetes.default.svc

--- a/clusters/flink-demo-authn/workloads/confluent-resources.yaml
+++ b/clusters/flink-demo-authn/workloads/confluent-resources.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: confluent-resources
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "110"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: workloads
+  source:
+    repoURL: https://github.com/osowski/confluent-platform-gitops.git
+    targetRevision: HEAD
+    path: workloads/confluent-resources/overlays/flink-demo-authn
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kafka
+  syncPolicy:
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/clusters/flink-demo-authn/workloads/flink-kubernetes-operator.yaml
+++ b/clusters/flink-demo-authn/workloads/flink-kubernetes-operator.yaml
@@ -19,7 +19,7 @@ spec:
           - $values/workloads/flink-kubernetes-operator/overlays/flink-demo-authn/values.yaml
         ignoreMissingValueFiles: true
     - repoURL: https://github.com/osowski/confluent-platform-gitops.git
-      targetRevision: HEAD
+      targetRevision: feature-279/test-authn-with-no-authz
       ref: values
   destination:
     server: https://kubernetes.default.svc

--- a/clusters/flink-demo-authn/workloads/flink-kubernetes-operator.yaml
+++ b/clusters/flink-demo-authn/workloads/flink-kubernetes-operator.yaml
@@ -1,0 +1,43 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: flink-kubernetes-operator
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "116"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: workloads
+  sources:
+    - repoURL: https://packages.confluent.io/helm
+      chart: flink-kubernetes-operator
+      targetRevision: 1.140.1
+      helm:
+        valueFiles:
+          - $values/workloads/flink-kubernetes-operator/base/values.yaml
+          - $values/workloads/flink-kubernetes-operator/overlays/flink-demo-authn/values.yaml
+        ignoreMissingValueFiles: true
+    - repoURL: https://github.com/osowski/confluent-platform-gitops.git
+      targetRevision: HEAD
+      ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: operator
+  ignoreDifferences:
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      jqPathExpressions:
+        - .spec.versions[].additionalPrinterColumns[].priority
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: false
+    syncOptions:
+      - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/clusters/flink-demo-authn/workloads/flink-rbac.yaml
+++ b/clusters/flink-demo-authn/workloads/flink-rbac.yaml
@@ -1,10 +1,11 @@
+---
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: observability-resources
+  name: flink-rbac
   namespace: argocd
   annotations:
-    argocd.argoproj.io/sync-wave: "117" # After Flink operator (wave 116)
+    argocd.argoproj.io/sync-wave: "100"
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
@@ -12,13 +13,19 @@ spec:
   source:
     repoURL: https://github.com/osowski/confluent-platform-gitops.git
     targetRevision: HEAD
-    path: workloads/observability-resources/base
+    path: workloads/flink-rbac/overlays/flink-demo-authn
   destination:
     server: https://kubernetes.default.svc
-    namespace: operator
+    namespace: default
   syncPolicy:
     automated:
       prune: true
       selfHeal: false
     syncOptions:
-      - CreateNamespace=false # Namespace should already exist from wave 100
+      - CreateNamespace=false
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/clusters/flink-demo-authn/workloads/flink-rbac.yaml
+++ b/clusters/flink-demo-authn/workloads/flink-rbac.yaml
@@ -12,7 +12,7 @@ spec:
   project: workloads
   source:
     repoURL: https://github.com/osowski/confluent-platform-gitops.git
-    targetRevision: HEAD
+    targetRevision: feature-279/test-authn-with-no-authz
     path: workloads/flink-rbac/overlays/flink-demo-authn
   destination:
     server: https://kubernetes.default.svc

--- a/clusters/flink-demo-authn/workloads/flink-resources-rbac.yaml
+++ b/clusters/flink-demo-authn/workloads/flink-resources-rbac.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: flink-resources
+  name: flink-resources-rbac
   namespace: argocd
   annotations:
     argocd.argoproj.io/sync-wave: "120"
@@ -12,7 +12,16 @@ spec:
   source:
     repoURL: https://github.com/osowski/confluent-platform-gitops.git
     targetRevision: HEAD
-    path: workloads/flink-resources/overlays/flink-demo-authn
+    path: workloads/flink-resources-rbac/overlays/flink-demo-authn
   destination:
     server: https://kubernetes.default.svc
     namespace: flink
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=false
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/clusters/flink-demo-authn/workloads/flink-resources-rbac.yaml
+++ b/clusters/flink-demo-authn/workloads/flink-resources-rbac.yaml
@@ -11,7 +11,7 @@ spec:
   project: workloads
   source:
     repoURL: https://github.com/osowski/confluent-platform-gitops.git
-    targetRevision: HEAD
+    targetRevision: feature-279/test-authn-with-no-authz
     path: workloads/flink-resources-rbac/overlays/flink-demo-authn
   destination:
     server: https://kubernetes.default.svc

--- a/clusters/flink-demo-authn/workloads/flink-resources.yaml
+++ b/clusters/flink-demo-authn/workloads/flink-resources.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: flink-resources
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "120"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: workloads
+  source:
+    repoURL: https://github.com/osowski/confluent-platform-gitops.git
+    targetRevision: HEAD
+    path: workloads/flink-resources/overlays/flink-demo-authn
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: flink

--- a/clusters/flink-demo-authn/workloads/keycloak.yaml
+++ b/clusters/flink-demo-authn/workloads/keycloak.yaml
@@ -12,7 +12,7 @@ spec:
   project: workloads
   source:
     repoURL: https://github.com/osowski/confluent-platform-gitops.git
-    targetRevision: HEAD
+    targetRevision: feature-279/test-authn-with-no-authz
     path: workloads/keycloak/overlays/flink-demo-authn
   destination:
     server: https://kubernetes.default.svc

--- a/clusters/flink-demo-authn/workloads/keycloak.yaml
+++ b/clusters/flink-demo-authn/workloads/keycloak.yaml
@@ -1,10 +1,11 @@
+---
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: observability-resources
+  name: keycloak
   namespace: argocd
   annotations:
-    argocd.argoproj.io/sync-wave: "117" # After Flink operator (wave 116)
+    argocd.argoproj.io/sync-wave: "102"
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
@@ -12,13 +13,19 @@ spec:
   source:
     repoURL: https://github.com/osowski/confluent-platform-gitops.git
     targetRevision: HEAD
-    path: workloads/observability-resources/base
+    path: workloads/keycloak/overlays/flink-demo-authn
   destination:
     server: https://kubernetes.default.svc
-    namespace: operator
+    namespace: keycloak
   syncPolicy:
     automated:
       prune: true
       selfHeal: false
     syncOptions:
-      - CreateNamespace=false # Namespace should already exist from wave 100
+      - CreateNamespace=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/clusters/flink-demo-authn/workloads/kustomization.yaml
+++ b/clusters/flink-demo-authn/workloads/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespaces.yaml
+  - cfk-operator.yaml
+  - confluent-resources.yaml
+  - workload-ingresses.yaml
+  - flink-kubernetes-operator.yaml
+  - observability-resources.yaml
+  - cmf-operator.yaml
+  - flink-resources.yaml
+
+# Workload applications are deployed in sync wave order (100-120)
+# Remove any applications you don't need for your cluster

--- a/clusters/flink-demo-authn/workloads/kustomization.yaml
+++ b/clusters/flink-demo-authn/workloads/kustomization.yaml
@@ -3,13 +3,16 @@ kind: Kustomization
 
 resources:
   - namespaces.yaml
+  - keycloak.yaml
+  - flink-rbac.yaml
   - cfk-operator.yaml
   - confluent-resources.yaml
   - workload-ingresses.yaml
   - flink-kubernetes-operator.yaml
   - observability-resources.yaml
+  - cmf-operator-secrets.yaml
   - cmf-operator.yaml
-  - flink-resources.yaml
+  - flink-resources-rbac.yaml
 
 # Workload applications are deployed in sync wave order (100-120)
 # Remove any applications you don't need for your cluster

--- a/clusters/flink-demo-authn/workloads/namespaces.yaml
+++ b/clusters/flink-demo-authn/workloads/namespaces.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: namespaces
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "100"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: workloads
+  source:
+    repoURL: https://github.com/osowski/confluent-platform-gitops.git
+    targetRevision: HEAD
+    path: workloads/namespaces/base
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/clusters/flink-demo-authn/workloads/namespaces.yaml
+++ b/clusters/flink-demo-authn/workloads/namespaces.yaml
@@ -11,7 +11,7 @@ spec:
   project: workloads
   source:
     repoURL: https://github.com/osowski/confluent-platform-gitops.git
-    targetRevision: HEAD
+    targetRevision: feature-279/test-authn-with-no-authz
     path: workloads/namespaces/base
   destination:
     server: https://kubernetes.default.svc

--- a/clusters/flink-demo-authn/workloads/observability-resources.yaml
+++ b/clusters/flink-demo-authn/workloads/observability-resources.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: observability-resources
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "117"  # After Flink operator (wave 116)
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: workloads
+  source:
+    repoURL: https://github.com/osowski/confluent-platform-gitops.git
+    targetRevision: HEAD
+    path: workloads/observability-resources/base
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: operator
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: false
+    syncOptions:
+      - CreateNamespace=false  # Namespace should already exist from wave 100

--- a/clusters/flink-demo-authn/workloads/observability-resources.yaml
+++ b/clusters/flink-demo-authn/workloads/observability-resources.yaml
@@ -11,7 +11,7 @@ spec:
   project: workloads
   source:
     repoURL: https://github.com/osowski/confluent-platform-gitops.git
-    targetRevision: HEAD
+    targetRevision: feature-279/test-authn-with-no-authz
     path: workloads/observability-resources/base
   destination:
     server: https://kubernetes.default.svc

--- a/clusters/flink-demo-authn/workloads/workload-ingresses.yaml
+++ b/clusters/flink-demo-authn/workloads/workload-ingresses.yaml
@@ -12,7 +12,7 @@ spec:
   project: workloads
   source:
     repoURL: https://github.com/osowski/confluent-platform-gitops.git
-    targetRevision: HEAD
+    targetRevision: feature-279/test-authn-with-no-authz
     path: workloads/ingresses/overlays/flink-demo-authn
   destination:
     server: https://kubernetes.default.svc

--- a/clusters/flink-demo-authn/workloads/workload-ingresses.yaml
+++ b/clusters/flink-demo-authn/workloads/workload-ingresses.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: workload-ingresses
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "110"
+spec:
+  project: workloads
+  source:
+    repoURL: https://github.com/osowski/confluent-platform-gitops.git
+    targetRevision: HEAD
+    path: workloads/ingresses/overlays/flink-demo-authn
+  destination:
+    server: https://kubernetes.default.svc
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=false
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -327,6 +327,10 @@ The eks-demo authorization model mirrors flink-demo-rbac exactly: Keycloak for O
 - Route53 + ACM provide real public DNS and TLS instead of self-signed certificates and `/etc/hosts` resolution
 - `workers-v2` managed node group (t3.2xlarge, min=4, max=6) spread across 3 availability zones
 
+### Authentication-Only Variant (flink-demo-authn cluster)
+
+The `flink-demo-authn` cluster is a variant of `flink-demo-rbac` that keeps Keycloak OIDC **authentication** on every tier but removes **authorization** entirely. There is no MDS and no Confluent RBAC: Kafka, KRaft, Schema Registry, and CMF validate Keycloak-issued tokens directly via JWKS, and with no Kafka authorizer any authenticated principal is allowed (allow-all). Because Control Center SSO requires MDS, its UI runs anonymously; the CFK operator reaches CMF through a `CMFRestClass` using OAuth client-credentials. This removes the entire three-layer model described in [Multi-Tenant RBAC Architecture (flink-demo-rbac cluster)](#multi-tenant-rbac-architecture-flink-demo-rbac-cluster); Kubernetes RBAC (`flink-rbac`) is retained as it is unrelated to Confluent authorization. See `clusters/flink-demo-authn/README.md` for the security model and access details.
+
 ## RBAC Boundaries
 
 ### Infrastructure Project

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **flink-demo-authn — OIDC authentication without authorization** ([#279](https://github.com/osowski/confluent-platform-gitops/issues/279)): variant of `flink-demo-rbac` keeping Keycloak OIDC authentication across the platform with MDS and all RBAC removed (allow-all). Control Center UI is anonymous; CLI/REST authenticate directly against Keycloak.
 - **flink-demo-rbac-mtls — Kafka↔KRaft controller mTLS** ([#273](https://github.com/osowski/confluent-platform-gitops/issues/273)): controller quorum listener now uses cert-manager-issued mTLS (cert CN→`User:kafka`) while OIDC/RBAC stays for all other auth. Changing listener auth requires a clean CFK redeploy (see cluster README).
 
 ## [0.7.0] - 2026-05-13

--- a/infrastructure/argocd-config/overlays/flink-demo-authn/kustomization.yaml
+++ b/infrastructure/argocd-config/overlays/flink-demo-authn/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+# No cluster-specific patches needed
+# Health check configuration applies to all clusters

--- a/infrastructure/cert-manager-resources/overlays/flink-demo-authn/kustomization.yaml
+++ b/infrastructure/cert-manager-resources/overlays/flink-demo-authn/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base

--- a/infrastructure/cert-manager/overlays/flink-demo-authn/values.yaml
+++ b/infrastructure/cert-manager/overlays/flink-demo-authn/values.yaml
@@ -1,0 +1,1 @@
+# flink-demo-authn cluster-specific configuration for cert-manager

--- a/infrastructure/ingresses/overlays/flink-demo-authn/argocd-certificate-patch.yaml
+++ b/infrastructure/ingresses/overlays/flink-demo-authn/argocd-certificate-patch.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: argocd-server-tls
+  namespace: argocd
+spec:
+  dnsNames:
+    - argocd.flink-demo-authn.confluentdemo.local

--- a/infrastructure/ingresses/overlays/flink-demo-authn/argocd-ingressroute-patch.yaml
+++ b/infrastructure/ingresses/overlays/flink-demo-authn/argocd-ingressroute-patch.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: argocd-server
+  namespace: argocd
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`argocd.flink-demo-authn.confluentdemo.local`)
+      kind: Rule
+      services:
+        - name: argocd-server
+          port: 443
+          scheme: https
+          serversTransport: argocd-server-insecure-transport
+  tls:
+    secretName: argocd-server-tls

--- a/infrastructure/ingresses/overlays/flink-demo-authn/kustomization.yaml
+++ b/infrastructure/ingresses/overlays/flink-demo-authn/kustomization.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+patches:
+  - path: argocd-ingressroute-patch.yaml
+    target:
+      kind: IngressRoute
+      name: argocd-server
+
+  - path: argocd-certificate-patch.yaml
+    target:
+      kind: Certificate
+      name: argocd-server-tls
+
+# Cluster-specific labels
+labels:
+- includeSelectors: false
+  includeTemplates: true
+  pairs:
+    cluster: flink-demo-authn

--- a/infrastructure/kube-prometheus-stack/overlays/flink-demo-authn/values.yaml
+++ b/infrastructure/kube-prometheus-stack/overlays/flink-demo-authn/values.yaml
@@ -1,0 +1,101 @@
+---
+# flink-demo-authn cluster-specific configuration for kube-prometheus-stack
+
+# Alertmanager configuration
+alertmanager:
+  alertmanagerSpec:
+    storage:
+      volumeClaimTemplate:
+        spec:
+          storageClassName: standard
+          accessModes: ["ReadWriteOnce"]
+          resources:
+            requests:
+              storage: 5Gi
+
+    # External URL for flink-demo-authn cluster
+    externalUrl: https://alertmanager.flink-demo-authn.confluentdemo.local
+
+  # Enable ingress for Alertmanager
+  ingress:
+    enabled: true
+    ingressClassName: traefik
+    annotations:
+      traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
+      argocd.argoproj.io/ignore-healthcheck: "true"
+    hosts:
+      - alertmanager.flink-demo-authn.confluentdemo.local
+    paths:
+      - /
+    pathType: Prefix
+    tls:
+      - secretName: alertmanager-tls
+        hosts:
+          - alertmanager.flink-demo-authn.confluentdemo.local
+
+# Grafana configuration for flink-demo-authn
+grafana:
+  # Override admin password (use sealed-secrets in production)
+  adminPassword: "flink-demo-admin-password"
+
+  # Persistence
+  persistence:
+    enabled: true
+    type: pvc
+    storageClassName: standard
+    size: 5Gi
+
+  # Enable ingress for Grafana
+  ingress:
+    enabled: true
+    ingressClassName: traefik
+    annotations:
+      traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
+      argocd.argoproj.io/ignore-healthcheck: "true"
+    hosts:
+      - grafana.flink-demo-authn.confluentdemo.local
+    path: /
+    pathType: Prefix
+    tls:
+      - secretName: grafana-tls
+        hosts:
+          - grafana.flink-demo-authn.confluentdemo.local
+
+# Prometheus configuration for flink-demo-authn
+prometheus:
+  prometheusSpec:
+    storageSpec:
+      volumeClaimTemplate:
+        spec:
+          storageClassName: standard
+          accessModes: ["ReadWriteOnce"]
+          resources:
+            requests:
+              storage: 10Gi
+
+    # External URL
+    externalUrl: https://prometheus.flink-demo-authn.confluentdemo.local
+
+    retention: 15d
+    retentionSize: "9GB"
+
+  # Enable ingress for Prometheus
+  ingress:
+    enabled: true
+    ingressClassName: traefik
+    annotations:
+      traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
+      argocd.argoproj.io/ignore-healthcheck: "true"
+    hosts:
+      - prometheus.flink-demo-authn.confluentdemo.local
+    paths:
+      - /
+    pathType: Prefix
+    tls:
+      - secretName: prometheus-tls
+        hosts:
+          - prometheus.flink-demo-authn.confluentdemo.local
+
+# Node Exporter configuration
+nodeExporter:
+  enabled: true

--- a/infrastructure/metrics-server/overlays/flink-demo-authn/values.yaml
+++ b/infrastructure/metrics-server/overlays/flink-demo-authn/values.yaml
@@ -1,0 +1,5 @@
+---
+# flink-demo-authn cluster-specific configuration for metrics-server
+# Enable insecure TLS for kind cluster
+args:
+  - --kubelet-insecure-tls

--- a/infrastructure/minio/overlays/flink-demo-authn/ingressroute-patch.yaml
+++ b/infrastructure/minio/overlays/flink-demo-authn/ingressroute-patch.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: minio
+  namespace: storage
+spec:
+  routes:
+    - match: Host(`s3.flink-demo-authn.confluentdemo.local`)
+      kind: Rule
+      services:
+        - name: minio
+          port: 9000
+          scheme: http
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: minio-console
+  namespace: storage
+spec:
+  routes:
+    - match: Host(`s3-console.flink-demo-authn.confluentdemo.local`)
+      kind: Rule
+      services:
+        - name: minio
+          port: 9001
+          scheme: http

--- a/infrastructure/minio/overlays/flink-demo-authn/kustomization.yaml
+++ b/infrastructure/minio/overlays/flink-demo-authn/kustomization.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Reference base configuration
+resources:
+  - ../../base
+
+# Cluster-specific patches
+patches:
+  - path: ingressroute-patch.yaml
+  - path: secret-patch.yaml
+
+# Cluster-specific labels
+labels:
+- includeSelectors: false
+  includeTemplates: true
+  pairs:
+    cluster: flink-demo-authn

--- a/infrastructure/minio/overlays/flink-demo-authn/secret-patch.yaml
+++ b/infrastructure/minio/overlays/flink-demo-authn/secret-patch.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-credentials
+  namespace: storage
+  annotations:
+    reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+    reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "flink,flink-colors,flink-shapes"
+    reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"

--- a/infrastructure/traefik/overlays/flink-demo-authn/values.yaml
+++ b/infrastructure/traefik/overlays/flink-demo-authn/values.yaml
@@ -1,0 +1,9 @@
+deployment:
+  kind: DaemonSet
+service:
+  type: NodePort
+nodeSelector: ~
+tolerations:
+  - key: node-role.kubernetes.io/control-plane
+    operator: Equal
+    effect: NoSchedule

--- a/infrastructure/trust-manager/overlays/flink-demo-authn/values.yaml
+++ b/infrastructure/trust-manager/overlays/flink-demo-authn/values.yaml
@@ -1,0 +1,1 @@
+# flink-demo-authn cluster-specific configuration for trust-manager

--- a/infrastructure/vault-config/overlays/flink-demo-authn/kustomization.yaml
+++ b/infrastructure/vault-config/overlays/flink-demo-authn/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base

--- a/infrastructure/vault/overlays/flink-demo-authn/values.yaml
+++ b/infrastructure/vault/overlays/flink-demo-authn/values.yaml
@@ -1,0 +1,3 @@
+---
+# flink-demo-authn cluster-specific overrides for Vault
+# Dev mode defaults from base are sufficient for this cluster

--- a/workloads/cfk-operator/overlays/flink-demo-authn/values.yaml
+++ b/workloads/cfk-operator/overlays/flink-demo-authn/values.yaml
@@ -1,0 +1,14 @@
+# Confluent for Kubernetes - flink-demo-authn Cluster Overlay
+# Cluster-specific configuration overrides
+
+# Additional pod annotations for flink-demo-authn cluster identification
+podAnnotations:
+  cluster: flink-demo-authn
+
+# Watch additional namespaces for group-based Flink resources
+namespaceList:
+  - flink
+  - flink-shapes
+  - flink-colors
+  - kafka
+  - operator

--- a/workloads/cmf-operator/overlays/flink-demo-authn/cmf-encryption-key.yaml
+++ b/workloads/cmf-operator/overlays/flink-demo-authn/cmf-encryption-key.yaml
@@ -1,0 +1,13 @@
+---
+# CMF Encryption Key for AES-GCM encryption of Secret spec.data
+# CMF requires this key to encrypt and store Flink SQL secrets in its metadata database
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cmf-encryption-key
+  namespace: operator
+type: Opaque
+stringData:
+  # AES-256 key (32 bytes base64 encoded)
+  # In production, use external-secrets or vault to manage this
+  key: "Y29uZmx1ZW50LWNtZi1lbmNyeXB0aW9uLWtleS0zMmJ5dGVz"

--- a/workloads/cmf-operator/overlays/flink-demo-authn/cmf-mds-oauth-secret.yaml
+++ b/workloads/cmf-operator/overlays/flink-demo-authn/cmf-mds-oauth-secret.yaml
@@ -1,0 +1,25 @@
+# OAuth client credential used to obtain a Keycloak token for the CMF REST API.
+# NOTE: the name retains "mds" for compatibility with the shared flink-resources
+# base (sql-init Jobs reference `cmf-mds-oauth-client`), but this cluster has NO
+# MDS — this is purely a Keycloak OAuth client (client_credentials grant).
+# Lives in the operator namespace (where CMF runs) and is mirrored to the Flink
+# namespaces via Reflector for the SQL initialization Jobs.
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cmf-mds-oauth-client
+  namespace: operator
+  annotations:
+    # Reflector annotations to mirror secret to Flink namespaces for SQL init Jobs
+    reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+    reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "flink-shapes,flink-colors"
+    reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+type: Opaque
+stringData:
+  # Client ID for CMF (matches Keycloak client)
+  clientId: cmf
+  # Client secret from Keycloak realm configuration
+  # WARNING: DEMO-ONLY secret that matches the Keycloak realm config.
+  # For production, rotate this secret and use external secret management.
+  clientSecret: cmf-secret

--- a/workloads/cmf-operator/overlays/flink-demo-authn/kustomization.yaml
+++ b/workloads/cmf-operator/overlays/flink-demo-authn/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 namespace: operator
 
 resources:
+  - cmf-mds-oauth-secret.yaml   # Keycloak OAuth client for CMF REST API (used by sql-init Jobs; NOT MDS)
   - cmf-encryption-key.yaml
   - postgres-secret.yaml
   - postgres.yaml

--- a/workloads/cmf-operator/overlays/flink-demo-authn/kustomization.yaml
+++ b/workloads/cmf-operator/overlays/flink-demo-authn/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: operator
+
+resources:
+  - cmf-encryption-key.yaml
+  - postgres-secret.yaml
+  - postgres.yaml

--- a/workloads/cmf-operator/overlays/flink-demo-authn/postgres-secret.yaml
+++ b/workloads/cmf-operator/overlays/flink-demo-authn/postgres-secret.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cmf-postgres-credentials
+  namespace: operator
+type: Opaque
+stringData:
+  POSTGRES_DB: cmf
+  POSTGRES_USER: cmf
+  POSTGRES_PASSWORD: cmf-password

--- a/workloads/cmf-operator/overlays/flink-demo-authn/postgres.yaml
+++ b/workloads/cmf-operator/overlays/flink-demo-authn/postgres.yaml
@@ -1,0 +1,83 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cmf-postgres-pvc
+  namespace: operator
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+  storageClassName: standard
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cmf-postgres
+  namespace: operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cmf-postgres
+  template:
+    metadata:
+      labels:
+        app: cmf-postgres
+    spec:
+      containers:
+      - name: postgres
+        image: postgres:16
+        envFrom:
+        - secretRef:
+            name: cmf-postgres-credentials
+        ports:
+        - containerPort: 5432
+          name: postgres
+        volumeMounts:
+        - name: postgres-storage
+          mountPath: /var/lib/postgresql/data
+          subPath: postgres
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+        readinessProbe:
+          exec:
+            command:
+            - pg_isready
+            - -U
+            - cmf
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          exec:
+            command:
+            - pg_isready
+            - -U
+            - cmf
+          initialDelaySeconds: 30
+          periodSeconds: 30
+      volumes:
+      - name: postgres-storage
+        persistentVolumeClaim:
+          claimName: cmf-postgres-pvc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cmf-postgres
+  namespace: operator
+spec:
+  selector:
+    app: cmf-postgres
+  ports:
+  - port: 5432
+    targetPort: 5432
+    name: postgres
+  type: ClusterIP

--- a/workloads/cmf-operator/overlays/flink-demo-authn/values.yaml
+++ b/workloads/cmf-operator/overlays/flink-demo-authn/values.yaml
@@ -1,0 +1,52 @@
+# Confluent Manager for Apache Flink - flink-demo-authn Cluster Overlay
+# OIDC authentication via Keycloak. NO authorization (RBAC), NO MDS.
+
+podAnnotations:
+  cluster: flink-demo-authn
+
+env:
+  - name: LOGGING_LEVEL_IO_CONFLUENT_CMF
+    value: DEBUG
+
+encryption:
+  key:
+    kubernetesSecretName: cmf-encryption-key
+    kubernetesSecretProperty: key
+
+cmf:
+  stackTraceLogging: true
+
+  sql:
+    examples-catalog:
+      enabled: true
+
+  database:
+    type: jdbc
+    jdbc:
+      engine: postgresql
+      database: cmf
+      url: cmf-postgres.operator.svc.cluster.local
+      user: cmf
+      password:
+        kubernetesSecretName: cmf-postgres-credentials
+        kubernetesSecretProperty: POSTGRES_PASSWORD
+      port: 5432
+      options: ""
+
+  # Authentication ONLY — validate Keycloak bearer tokens directly via JWKS.
+  # NO public.key.path, NO confluent.metadata.*, NO token.issuer (those were
+  # for MDS-signed Control Center SSO tokens, which no longer exist).
+  authentication:
+    type: oauth
+    config:
+      oauthbearer.jwks.endpoint.url: http://keycloak.keycloak.svc.cluster.local:8080/realms/confluent/protocol/openid-connect/certs
+      oauthbearer.expected.issuer: https://keycloak.flink-demo-authn.confluentdemo.local/realms/confluent
+      oauthbearer.sub.claim.name: client_id
+      oauthbearer.groups.claim.name: groups
+
+  # Kafka OAuth allowed URLs (token + certs endpoints, internal + external)
+  kafka:
+    oauthbearerAllowedUrls: http://keycloak.keycloak.svc.cluster.local:8080/realms/confluent/protocol/openid-connect/token,http://keycloak.keycloak.svc.cluster.local:8080/realms/confluent/protocol/openid-connect/certs,http://keycloak.flink-demo-authn.confluentdemo.local:30080/realms/confluent/protocol/openid-connect/token,http://keycloak.flink-demo-authn.confluentdemo.local:30080/realms/confluent/protocol/openid-connect/certs
+
+# NO cmf.authorization block (MDS/RBAC removed).
+# NO mountedVolumes for mds-token (no MDS public key to validate).

--- a/workloads/confluent-resources/overlays/flink-demo-authn/controlcenter-oauth-client-secret.yaml
+++ b/workloads/confluent-resources/overlays/flink-demo-authn/controlcenter-oauth-client-secret.yaml
@@ -1,0 +1,16 @@
+# OAuth Client Secret for Control Center
+# Control Center uses its own OAuth client identity when authenticating to Kafka and MDS
+# This follows the pattern from confluent-demo where each component has its own OAuth client
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: controlcenter-oauth-client
+  namespace: kafka
+type: Opaque
+stringData:
+  # JAAS format for OAuth client credentials
+  # clientId must match the Keycloak client configuration
+  oauth.txt: |
+    clientId=controlcenter
+    clientSecret=controlcenter-secret

--- a/workloads/confluent-resources/overlays/flink-demo-authn/controlcenter-patch.yaml
+++ b/workloads/confluent-resources/overlays/flink-demo-authn/controlcenter-patch.yaml
@@ -1,0 +1,63 @@
+# ==============================================================================
+# Control Center (Next-Gen) Configuration for flink-demo-authn Cluster
+# ==============================================================================
+# Anonymous UI access (OIDC SSO requires MDS, which is removed). C3 still
+# connects to Kafka and Schema Registry using service-account OAuth.
+# NO authorization (RBAC), NO MDS dependency.
+# ==============================================================================
+apiVersion: platform.confluent.io/v1beta1
+kind: ControlCenter
+metadata:
+  name: controlcenter
+  namespace: kafka
+spec:
+  podTemplate:
+    resources:
+      requests:
+        cpu: 200m
+        memory: 1Gi
+      limits:
+        cpu: 500m
+        memory: 2Gi
+
+  configOverrides:
+    server:
+      - confluent.controlcenter.ksql.enable=false
+      - confluent.controlcenter.connect.enable=false
+      - confluent.controlcenter.ui.replicator.monitoring.enable=false
+      # Enable CMF integration
+      - confluent.controlcenter.cmf.enable=true
+      - confluent.controlcenter.cmf.url=http://cmf-service.operator.svc.cluster.local:80
+      # Schema Registry OAuth bearer authentication
+      - confluent.controlcenter.schema.registry.bearer.auth.credentials.source=OAUTHBEARER
+      - confluent.controlcenter.schema.registry.bearer.auth.issuer.endpoint.url=http://keycloak.keycloak.svc.cluster.local:8080/realms/confluent/protocol/openid-connect/token
+      - confluent.controlcenter.schema.registry.bearer.auth.client.id=controlcenter
+      - confluent.controlcenter.schema.registry.bearer.auth.client.secret=controlcenter-secret
+
+  # NO authorization block (RBAC removed).
+  # NO dependencies.mds block (MDS/SSO removed) => anonymous browser access.
+
+  dependencies:
+    connect: null
+    ksqldb: null
+
+    # Kafka connection with OAuth (service account)
+    kafka:
+      bootstrapEndpoint: kafka.kafka.svc.cluster.local:9071
+      authentication:
+        type: oauth
+        jaasConfig:
+          secretRef: controlcenter-oauth-client
+        oauthSettings:
+          subClaimName: client_id
+          tokenEndpointUri: http://keycloak.keycloak.svc.cluster.local:8080/realms/confluent/protocol/openid-connect/token
+
+    # Schema Registry connection with OAuth (service account)
+    schemaRegistry:
+      url: http://schemaregistry.kafka.svc.cluster.local:8081
+      authentication:
+        type: oauth
+        oauth:
+          secretRef: controlcenter-oauth-client
+          configuration:
+            tokenEndpointUri: http://keycloak.keycloak.svc.cluster.local:8080/realms/confluent/protocol/openid-connect/token

--- a/workloads/confluent-resources/overlays/flink-demo-authn/controlcenter-patch.yaml
+++ b/workloads/confluent-resources/overlays/flink-demo-authn/controlcenter-patch.yaml
@@ -33,6 +33,19 @@ spec:
       - confluent.controlcenter.schema.registry.bearer.auth.issuer.endpoint.url=http://keycloak.keycloak.svc.cluster.local:8080/realms/confluent/protocol/openid-connect/token
       - confluent.controlcenter.schema.registry.bearer.auth.client.id=controlcenter
       - confluent.controlcenter.schema.registry.bearer.auth.client.secret=controlcenter-secret
+      # Internal Streams/command-store Kafka client OAuth (Keycloak, direct).
+      # Without MDS, CFK does not auto-wire OAuth login for C3's internal clients,
+      # so configure them explicitly here (otherwise they fall back to the
+      # unsecured callback handler and fail with "No principal name in JWT claim: sub").
+      - confluent.controlcenter.streams.security.protocol=SASL_PLAINTEXT
+      - confluent.controlcenter.streams.sasl.mechanism=OAUTHBEARER
+      - confluent.controlcenter.streams.sasl.login.callback.handler.class=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginCallbackHandler
+      - confluent.controlcenter.streams.sasl.oauthbearer.token.endpoint.url=http://keycloak.keycloak.svc.cluster.local:8080/realms/confluent/protocol/openid-connect/token
+      - confluent.controlcenter.streams.sasl.oauthbearer.sub.claim.name=client_id
+      - confluent.controlcenter.streams.sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required clientId="controlcenter" clientSecret="controlcenter-secret";
+    jvm:
+      # Allow C3's OAuth clients to call the Keycloak token endpoint (required CP 8.0+)
+      - "-Dorg.apache.kafka.sasl.oauthbearer.allowed.urls=http://keycloak.keycloak.svc.cluster.local:8080/realms/confluent/protocol/openid-connect/token"
 
   # NO authorization block (RBAC removed).
   # NO dependencies.mds block (MDS/SSO removed) => anonymous browser access.

--- a/workloads/confluent-resources/overlays/flink-demo-authn/kafka-patch.yaml
+++ b/workloads/confluent-resources/overlays/flink-demo-authn/kafka-patch.yaml
@@ -61,8 +61,13 @@ spec:
       clusterRef:
         name: kraftcontroller
 
-    # Kafka REST OAuth authentication
+    # Kafka REST (Admin REST API server) OAuth authentication.
+    # bootstrapEndpoint MUST be set explicitly here: without MDS, CFK cannot
+    # auto-resolve the Admin REST server's Kafka client endpoint, so it must
+    # point at the OAuth internal listener (port 9071) for the auth type to
+    # match. (In flink-demo-rbac, services.mds provided this resolution.)
     kafkaRest:
+      bootstrapEndpoint: kafka.kafka.svc.cluster.local:9071
       authentication:
         type: oauth
         jaasConfig:

--- a/workloads/confluent-resources/overlays/flink-demo-authn/kafka-patch.yaml
+++ b/workloads/confluent-resources/overlays/flink-demo-authn/kafka-patch.yaml
@@ -1,0 +1,85 @@
+# ==============================================================================
+# Kafka Broker Configuration for flink-demo-authn Cluster
+# ==============================================================================
+# OIDC authentication via Keycloak on all listeners. NO MDS. NO authorization
+# (no authorizer => all authenticated principals are allowed: allow-all).
+# ==============================================================================
+apiVersion: platform.confluent.io/v1beta1
+kind: Kafka
+metadata:
+  name: kafka
+  namespace: kafka
+spec:
+  # External NodePort listener (TLS disabled for local kind access)
+  listeners:
+    custom:
+      - name: external-nodeport
+        port: 9094
+        externalAccess:
+          type: nodePort
+          nodePort:
+            host: kafka.flink-demo-authn.confluentdemo.local
+            nodePortOffset: 31000
+        tls:
+          enabled: false
+
+    # Internal listener - OAuth authentication for inter-broker communication
+    internal:
+      authentication:
+        type: oauth
+        jaasConfig:
+          secretRef: kafka-oauth-client
+        oauthSettings:
+          tokenEndpointUri: http://keycloak.keycloak.svc.cluster.local:8080/realms/confluent/protocol/openid-connect/token
+          expectedIssuer: https://keycloak.flink-demo-authn.confluentdemo.local/realms/confluent
+          jwksEndpointUri: http://keycloak.keycloak.svc.cluster.local:8080/realms/confluent/protocol/openid-connect/certs
+          subClaimName: client_id
+          groupsClaimName: groups
+
+  podTemplate:
+    resources:
+      requests:
+        cpu: 1500m
+        memory: 1Gi
+      limits:
+        cpu: 2500m
+        memory: 3Gi
+
+  # NO authorization block => no authorizer => allow-all authenticated principals.
+  # NO services.mds block => MDS removed entirely.
+
+  dependencies:
+    # Broker-to-KRaft controller OAuth authentication
+    kRaftController:
+      controllerListener:
+        authentication:
+          type: oauth
+          jaasConfig:
+            secretRef: kafka-oauth-client
+          oauthSettings:
+            tokenEndpointUri: http://keycloak.keycloak.svc.cluster.local:8080/realms/confluent/protocol/openid-connect/token
+      clusterRef:
+        name: kraftcontroller
+
+    # Kafka REST OAuth authentication
+    kafkaRest:
+      authentication:
+        type: oauth
+        jaasConfig:
+          secretRef: kafka-oauth-client
+        oauthSettings:
+          tokenEndpointUri: http://keycloak.keycloak.svc.cluster.local:8080/realms/confluent/protocol/openid-connect/token
+          expectedIssuer: https://keycloak.flink-demo-authn.confluentdemo.local/realms/confluent
+          jwksEndpointUri: http://keycloak.keycloak.svc.cluster.local:8080/realms/confluent/protocol/openid-connect/certs
+          subClaimName: client_id
+
+  # JVM/server overrides: OAuth SASL only. MDS device-grant + SSO props removed.
+  configOverrides:
+    jvm:
+      - "-Dorg.apache.kafka.sasl.login.callback.handler.class=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginCallbackHandler"
+      - "-Dsasl.login.callback.handler.class=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginCallbackHandler"
+      - "-Dorg.apache.kafka.sasl.oauthbearer.allowed.urls=http://keycloak.keycloak.svc.cluster.local:8080/realms/confluent,http://keycloak.keycloak.svc.cluster.local:8080/realms/confluent/protocol/openid-connect/certs,http://keycloak.keycloak.svc.cluster.local:8080/realms/confluent/protocol/openid-connect/token,https://keycloak.flink-demo-authn.confluentdemo.local/realms/confluent,https://keycloak.flink-demo-authn.confluentdemo.local/realms/confluent/protocol/openid-connect/certs,https://keycloak.flink-demo-authn.confluentdemo.local/realms/confluent/protocol/openid-connect/token,https://keycloak.flink-demo-authn.confluentdemo.local/realms/confluent/protocol/openid-connect/auth/device"
+      - "-Dorg.apache.kafka.common.security.oauthbearer.OAuthBearerLoginCallbackHandler.JWKS_ENDPOINT_REFRESH_MS=3600000"
+    server:
+      # Internal listener OAuth groups claim extraction (harmless without RBAC; kept for token parsing parity)
+      - listener.name.internal.sasl.oauthbearer.groups.claim.name=groups

--- a/workloads/confluent-resources/overlays/flink-demo-authn/kafkarestclass-patch.yaml
+++ b/workloads/confluent-resources/overlays/flink-demo-authn/kafkarestclass-patch.yaml
@@ -1,0 +1,23 @@
+# ==============================================================================
+# KafkaRestClass Configuration for flink-demo-authn Cluster
+# ==============================================================================
+# This patch adds OAuth authentication to KafkaRestClass, which is required
+# when the Kafka cluster has authentication enabled.
+#
+# KafkaRestClass is used by:
+# - ConfluentRoleBindings for RBAC
+# - MDS for role management
+# ==============================================================================
+apiVersion: platform.confluent.io/v1beta1
+kind: KafkaRestClass
+metadata:
+  name: default
+  namespace: kafka
+spec:
+  kafkaRest:
+    authentication:
+      type: oauth
+      oauth:
+        secretRef: kafka-oauth-client
+        configuration:
+          tokenEndpointUri: http://keycloak.keycloak.svc.cluster.local:8080/realms/confluent/protocol/openid-connect/token

--- a/workloads/confluent-resources/overlays/flink-demo-authn/kraftcontroller-patch.yaml
+++ b/workloads/confluent-resources/overlays/flink-demo-authn/kraftcontroller-patch.yaml
@@ -1,0 +1,55 @@
+# ==============================================================================
+# KRaft Controller Configuration for flink-demo-authn Cluster
+# ==============================================================================
+# This patch consolidates all KRaft controller configuration including:
+# - Resource limits for local demo environment
+# - OAuth authentication for controller quorum communication
+# - JVM configuration for OAuth SASL mechanism
+# NOTE: Authorization intentionally omitted to avoid circular dependency with Kafka MDS.
+#       Controllers are an internal control plane — principals connecting to them (kafka brokers)
+#       are already super users. Fine-grained RBAC adds no practical security benefit here.
+# TODO: Issue #72 - Switch from OAuth to mTLS authentication when TLS is implemented
+# ==============================================================================
+apiVersion: platform.confluent.io/v1beta1
+kind: KRaftController
+metadata:
+  name: kraftcontroller
+  namespace: kafka
+spec:
+  # ==============================================================================
+  # RESOURCE LIMITS - Tuned for 24GB total cluster memory
+  # ==============================================================================
+  podTemplate:
+    resources:
+      requests:
+        cpu: 200m
+        memory: 512Mi
+      limits:
+        cpu: 500m
+        memory: 1Gi
+
+  # ==============================================================================
+  # CONTROLLER LISTENER - OAuth authentication for quorum communication
+  # ==============================================================================
+  listeners:
+    controller:
+      authentication:
+        type: oauth
+        jaasConfig:
+          secretRef: kraft-oauth-client
+        oauthSettings:
+          tokenEndpointUri: http://keycloak.keycloak.svc.cluster.local:8080/realms/confluent/protocol/openid-connect/token
+          expectedIssuer: https://keycloak.flink-demo-authn.confluentdemo.local/realms/confluent
+          jwksEndpointUri: http://keycloak.keycloak.svc.cluster.local:8080/realms/confluent/protocol/openid-connect/certs
+          subClaimName: client_id
+
+  # ==============================================================================
+  # JVM CONFIGURATION - OAuth SASL mechanism
+  # ==============================================================================
+  configOverrides:
+    jvm:
+      # OAuth login callback handler
+      - "-Dorg.apache.kafka.sasl.login.callback.handler.class=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginCallbackHandler"
+      - "-Dsasl.login.callback.handler.class=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginCallbackHandler"
+      # OAuth allowed URLs (internal HTTP and external HTTPS Keycloak endpoints)
+      - "-Dorg.apache.kafka.sasl.oauthbearer.allowed.urls=http://keycloak.keycloak.svc.cluster.local:8080/realms/confluent,http://keycloak.keycloak.svc.cluster.local:8080/realms/confluent/protocol/openid-connect/certs,http://keycloak.keycloak.svc.cluster.local:8080/realms/confluent/protocol/openid-connect/token,https://keycloak.flink-demo-authn.confluentdemo.local/realms/confluent,https://keycloak.flink-demo-authn.confluentdemo.local/realms/confluent/protocol/openid-connect/certs,https://keycloak.flink-demo-authn.confluentdemo.local/realms/confluent/protocol/openid-connect/token"

--- a/workloads/confluent-resources/overlays/flink-demo-authn/kustomization.yaml
+++ b/workloads/confluent-resources/overlays/flink-demo-authn/kustomization.yaml
@@ -1,0 +1,59 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: kafka
+
+# OAuth authentication only — NO MDS, NO RBAC, NO role bindings.
+resources:
+  - ../../base
+  - oauth-client-secrets.yaml
+  - controlcenter-oauth-client-secret.yaml
+
+patches:
+  # Kafka broker - OAuth listeners, NO MDS, NO authorization (allow-all)
+  - path: kafka-patch.yaml
+    target:
+      kind: Kafka
+      name: kafka
+
+  # KRaft controller - OAuth listener auth (already MDS-free)
+  - path: kraftcontroller-patch.yaml
+    target:
+      kind: KRaftController
+      name: kraftcontroller
+
+  # Control Center - Next-Gen image, OAuth to Kafka/SR, anonymous UI, NO MDS/SSO/RBAC
+  - path: controlcenter-patch.yaml
+    target:
+      kind: ControlCenter
+      name: controlcenter
+
+  # Schema Registry - OAuth authN, NO RBAC
+  - path: schemaregistry-patch.yaml
+    target:
+      kind: SchemaRegistry
+      name: schemaregistry
+
+  # KafkaRestClass - OAuth authentication
+  - path: kafkarestclass-patch.yaml
+    target:
+      kind: KafkaRestClass
+      name: default
+
+  # Explicitly delete Connect from this cluster overlay
+  - patch: |-
+      $patch: delete
+      apiVersion: platform.confluent.io/v1beta1
+      kind: Connect
+      metadata:
+        name: connect
+        namespace: kafka
+
+  # Explicitly delete ksqlDB from this cluster overlay
+  - patch: |-
+      $patch: delete
+      apiVersion: platform.confluent.io/v1beta1
+      kind: KsqlDB
+      metadata:
+        name: ksqldb
+        namespace: kafka

--- a/workloads/confluent-resources/overlays/flink-demo-authn/oauth-client-secrets.yaml
+++ b/workloads/confluent-resources/overlays/flink-demo-authn/oauth-client-secrets.yaml
@@ -1,0 +1,30 @@
+# OAuth Client Secrets for Kafka components
+# These secrets contain client credentials for authenticating with Keycloak
+# Format: Plain text oauth.txt file with clientId=value and clientSecret=value
+# This matches the JAAS format expected by Kafka/KRaft OAuth configuration
+---
+# OAuth client credentials for Kafka REST Proxy (used by MDS)
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kafka-oauth-client
+  namespace: kafka
+type: Opaque
+stringData:
+  # JAAS format for OAuth client credentials
+  oauth.txt: |
+    clientId=kafka
+    clientSecret=kafka-secret
+---
+# OAuth client credentials for KRaft Controller
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kraft-oauth-client
+  namespace: kafka
+type: Opaque
+stringData:
+  # JAAS format for OAuth client credentials
+  oauth.txt: |
+    clientId=kafka
+    clientSecret=kafka-secret

--- a/workloads/confluent-resources/overlays/flink-demo-authn/schemaregistry-patch.yaml
+++ b/workloads/confluent-resources/overlays/flink-demo-authn/schemaregistry-patch.yaml
@@ -1,0 +1,34 @@
+# ==============================================================================
+# Schema Registry Configuration for flink-demo-authn Cluster
+# ==============================================================================
+# OAuth authentication to Kafka via Keycloak. NO MDS dependency, NO RBAC.
+# ==============================================================================
+apiVersion: platform.confluent.io/v1beta1
+kind: SchemaRegistry
+metadata:
+  name: schemaregistry
+  namespace: kafka
+spec:
+  podTemplate:
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+
+  # NO authorization block (RBAC removed).
+  # NO dependencies.mds block (MDS removed).
+
+  dependencies:
+    # Kafka connection with OAuth authentication
+    kafka:
+      bootstrapEndpoint: kafka.kafka.svc.cluster.local:9071
+      authentication:
+        type: oauth
+        jaasConfig:
+          secretRef: kafka-oauth-client
+        oauthSettings:
+          subClaimName: client_id
+          tokenEndpointUri: http://keycloak.keycloak.svc.cluster.local:8080/realms/confluent/protocol/openid-connect/token

--- a/workloads/cp-flink-sql-sandbox/overlays/flink-demo-authn/kustomization.yaml
+++ b/workloads/cp-flink-sql-sandbox/overlays/flink-demo-authn/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Reference base configuration
+resources:
+  - ../../base
+
+# Cluster-specific labels
+labels:
+- includeSelectors: false
+  includeTemplates: true
+  pairs:
+    cluster: flink-demo-authn

--- a/workloads/flink-kubernetes-operator/overlays/flink-demo-authn/values.yaml
+++ b/workloads/flink-kubernetes-operator/overlays/flink-demo-authn/values.yaml
@@ -1,0 +1,28 @@
+# Flink Kubernetes Operator - flink-demo-authn Cluster Overlay
+# Cluster-specific configuration overrides
+
+# Watch additional namespaces for group-based Flink resources
+watchNamespaces:
+  - flink
+  - flink-shapes
+  - flink-colors
+
+# Additional pod labels for flink-demo-authn cluster
+operatorPod:
+  labels:
+    cluster: flink-demo-authn
+
+defaultConfiguration:
+  create: true
+  append: true
+  flink-conf.yaml: |+
+    # Prometheus metrics reporter - exposes metrics at /metrics endpoint
+    kubernetes.operator.metrics.reporter.prom.factory.class: org.apache.flink.metrics.prometheus.PrometheusReporterFactory
+    kubernetes.operator.metrics.reporter.prom.port: 9999
+
+    # SLF4J metrics reporter - logs detailed autoscaler metrics
+    kubernetes.operator.metrics.reporter.slf4j.factory.class: org.apache.flink.metrics.slf4j.Slf4jReporterFactory
+    kubernetes.operator.metrics.reporter.slf4j.interval: 5 MINUTE
+
+metrics:
+  port: 9999

--- a/workloads/flink-rbac/overlays/flink-demo-authn/kustomization.yaml
+++ b/workloads/flink-rbac/overlays/flink-demo-authn/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+# Cluster-specific labels
+labels:
+- includeSelectors: false
+  includeTemplates: true
+  pairs:
+    cluster: flink-demo-authn

--- a/workloads/flink-resources-rbac/overlays/flink-demo-authn/kustomization.yaml
+++ b/workloads/flink-resources-rbac/overlays/flink-demo-authn/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+labels:
+- includeSelectors: false
+  includeTemplates: true
+  pairs:
+    cluster: flink-demo-authn

--- a/workloads/ingresses/overlays/flink-demo-authn/cmf-ingressroute-patch.yaml
+++ b/workloads/ingresses/overlays/flink-demo-authn/cmf-ingressroute-patch.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: cmf
+  namespace: operator
+spec:
+  routes:
+    - match: Host(`cmf.flink-demo-authn.confluentdemo.local`)
+      kind: Rule
+      services:
+        - name: cmf-service
+          port: 80
+          scheme: http

--- a/workloads/ingresses/overlays/flink-demo-authn/controlcenter-certificate-patch.yaml
+++ b/workloads/ingresses/overlays/flink-demo-authn/controlcenter-certificate-patch.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: controlcenter-tls
+  namespace: kafka
+spec:
+  dnsNames:
+    - controlcenter.flink-demo-authn.confluentdemo.local

--- a/workloads/ingresses/overlays/flink-demo-authn/controlcenter-ingressroute-patch.yaml
+++ b/workloads/ingresses/overlays/flink-demo-authn/controlcenter-ingressroute-patch.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: controlcenter
+  namespace: kafka
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`controlcenter.flink-demo-authn.confluentdemo.local`)
+      kind: Rule
+      services:
+        - name: controlcenter
+          port: 9021
+          scheme: http
+  tls:
+    secretName: controlcenter-tls

--- a/workloads/ingresses/overlays/flink-demo-authn/kustomization.yaml
+++ b/workloads/ingresses/overlays/flink-demo-authn/kustomization.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+patches:
+  - path: cmf-ingressroute-patch.yaml
+    target:
+      kind: IngressRoute
+      name: cmf
+
+  - path: controlcenter-ingressroute-patch.yaml
+    target:
+      kind: IngressRoute
+      name: controlcenter
+
+  - path: controlcenter-certificate-patch.yaml
+    target:
+      kind: Certificate
+      name: controlcenter-tls
+
+  - path: schema-registry-ingressroute-patch.yaml
+    target:
+      kind: IngressRoute
+      name: schema-registry
+
+# Cluster-specific labels
+labels:
+- includeSelectors: false
+  includeTemplates: true
+  pairs:
+    cluster: flink-demo-authn

--- a/workloads/ingresses/overlays/flink-demo-authn/schema-registry-ingressroute-patch.yaml
+++ b/workloads/ingresses/overlays/flink-demo-authn/schema-registry-ingressroute-patch.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: schema-registry
+  namespace: kafka
+spec:
+  routes:
+    - kind: Rule
+      match: Host(`schema-registry.flink-demo-authn.confluentdemo.local`)
+      services:
+        - name: schemaregistry
+          port: 8081
+          scheme: http

--- a/workloads/keycloak/overlays/flink-demo-authn/certificate-patch.yaml
+++ b/workloads/keycloak/overlays/flink-demo-authn/certificate-patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: keycloak-tls
+  namespace: keycloak
+spec:
+  dnsNames:
+    - keycloak.flink-demo-authn.confluentdemo.local

--- a/workloads/keycloak/overlays/flink-demo-authn/ingress-patch.yaml
+++ b/workloads/keycloak/overlays/flink-demo-authn/ingress-patch.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: keycloak
+  namespace: keycloak
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`keycloak.flink-demo-authn.confluentdemo.local`)
+      kind: Rule
+      services:
+        - name: keycloak
+          port: 8080
+  tls:
+    secretName: keycloak-tls

--- a/workloads/keycloak/overlays/flink-demo-authn/keycloak-patch.yaml
+++ b/workloads/keycloak/overlays/flink-demo-authn/keycloak-patch.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: keycloak
+  namespace: keycloak
+spec:
+  template:
+    spec:
+      containers:
+      - name: keycloak
+        env:
+        - name: KC_HOSTNAME
+          value: https://keycloak.flink-demo-authn.confluentdemo.local
+        - name: KC_HOSTNAME_ADMIN
+          value: https://keycloak.flink-demo-authn.confluentdemo.local
+        - name: KC_HOSTNAME_BACKCHANNEL_DYNAMIC
+          value: "true"

--- a/workloads/keycloak/overlays/flink-demo-authn/kustomization.yaml
+++ b/workloads/keycloak/overlays/flink-demo-authn/kustomization.yaml
@@ -1,0 +1,29 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+# Cluster-specific patches
+patches:
+  - path: keycloak-patch.yaml
+    target:
+      kind: StatefulSet
+      name: keycloak
+
+  - path: certificate-patch.yaml
+    target:
+      kind: Certificate
+      name: keycloak-tls
+
+  - path: ingress-patch.yaml
+    target:
+      kind: IngressRoute
+      name: keycloak
+
+# Cluster-specific labels
+labels:
+- includeSelectors: false
+  includeTemplates: true
+  pairs:
+    cluster: flink-demo-authn


### PR DESCRIPTION
Closes #279

## Summary

Adds the **`flink-demo-authn`** cluster variant: Keycloak OIDC authentication across every tier with **MDS and all authorization removed** (allow-all). It forks `flink-demo-rbac` and strips the authorization layer while keeping OIDC authentication.

- **Kept (OIDC authN):** Kafka/KRaft OAuth listeners → Keycloak JWKS, `kafkaRest` OAuth, CMF `authentication.type: oauth`, Control Center → Kafka/SR service-account OAuth.
- **Removed:** Kafka `authorization: rbac` + `services.mds`, CMF `authorization` + MDS-coupled auth config (`public.key.path`, `confluent.metadata.*`, `token.issuer`), `mds-keygen` job, `mds-token` secret, all `ConfluentRolebinding` resources, Control Center MDS/SSO dependency.
- **Control Center:** Next-Gen image (unchanged); browser SSO requires MDS so the UI is **anonymous**. CLI/REST authenticate directly against Keycloak.
- **Kubernetes RBAC (`flink-rbac`) retained** — it is unrelated to Confluent authorization.

See `clusters/flink-demo-authn/README.md` for the security model and access instructions.

## ⚠️ Before merging

The final commit (`point targetRevision to feature branch for local testing`) repoints all git-source `targetRevision` fields in `clusters/flink-demo-authn/` to this branch so ArgoCD can deploy it locally pre-merge. **Revert that commit before merging** so `main` tracks `HEAD`:

```bash
git revert <commit-sha>   # or: ./scripts/update-target-revision.sh flink-demo-authn HEAD
```

## Test Plan

- [x] `scripts/validate-cluster.sh flink-demo-authn` passes (YAML, 12 Kustomize builds, Helm, sync waves) — parity with `flink-demo-rbac` warnings
- [x] Rendered Kafka resource has no `services.mds`/`authorization`; Control Center has no `mds` dependency/`authorization`
- [x] No dangling `mds-token`/`mds-keygen` references; pinned Helm chart versions untouched
- [ ] Local deploy from branch: `kubectl apply -f clusters/flink-demo-authn/bootstrap.yaml` and verify ArgoCD syncs all apps