### PR TITLE
Align operator baselines: CMF 2.3.1 + CFK 3.2.3 on all clusters, CP Flink SQL pool image 1.19-cp8

### DIFF
--- a/clusters/eks-demo/workloads/cfk-operator.yaml
+++ b/clusters/eks-demo/workloads/cfk-operator.yaml
@@ -12,7 +12,7 @@ spec:
   sources:
     - repoURL: https://packages.confluent.io/helm
       chart: confluent-for-kubernetes
-      targetRevision: 0.1514.19
+      targetRevision: 0.1514.76
       helm:
         valueFiles:
           - $values/workloads/cfk-operator/base/values.yaml

--- a/clusters/eks-demo/workloads/cmf-operator.yaml
+++ b/clusters/eks-demo/workloads/cmf-operator.yaml
@@ -12,7 +12,7 @@ spec:
   sources:
     - repoURL: https://packages.confluent.io/helm
       chart: confluent-manager-for-apache-flink
-      targetRevision: 2.3.0
+      targetRevision: 2.3.1
       helm:
         valueFiles:
           - $values/workloads/cmf-operator/base/values.yaml

--- a/clusters/flink-demo-rbac-mtls/workloads/cfk-operator.yaml
+++ b/clusters/flink-demo-rbac-mtls/workloads/cfk-operator.yaml
@@ -12,7 +12,7 @@ spec:
   sources:
     - repoURL: https://packages.confluent.io/helm
       chart: confluent-for-kubernetes
-      targetRevision: 0.1514.19
+      targetRevision: 0.1514.76
       helm:
         valueFiles:
           - $values/workloads/cfk-operator/base/values.yaml

--- a/clusters/flink-demo-rbac-mtls/workloads/cmf-operator.yaml
+++ b/clusters/flink-demo-rbac-mtls/workloads/cmf-operator.yaml
@@ -12,7 +12,7 @@ spec:
   sources:
     - repoURL: https://packages.confluent.io/helm
       chart: confluent-manager-for-apache-flink
-      targetRevision: 2.3.0
+      targetRevision: 2.3.1
       helm:
         valueFiles:
           - $values/workloads/cmf-operator/base/values.yaml

--- a/clusters/flink-demo-rbac/workloads/cfk-operator.yaml
+++ b/clusters/flink-demo-rbac/workloads/cfk-operator.yaml
@@ -12,7 +12,7 @@ spec:
   sources:
     - repoURL: https://packages.confluent.io/helm
       chart: confluent-for-kubernetes
-      targetRevision: 0.1514.19
+      targetRevision: 0.1514.76
       helm:
         valueFiles:
           - $values/workloads/cfk-operator/base/values.yaml

--- a/clusters/flink-demo/workloads/cfk-operator.yaml
+++ b/clusters/flink-demo/workloads/cfk-operator.yaml
@@ -12,7 +12,7 @@ spec:
   sources:
     - repoURL: https://packages.confluent.io/helm
       chart: confluent-for-kubernetes
-      targetRevision: 0.1514.19
+      targetRevision: 0.1514.76
       helm:
         valueFiles:
           - $values/workloads/cfk-operator/base/values.yaml

--- a/clusters/flink-demo/workloads/cmf-operator.yaml
+++ b/clusters/flink-demo/workloads/cmf-operator.yaml
@@ -12,7 +12,7 @@ spec:
   sources:
     - repoURL: https://packages.confluent.io/helm
       chart: confluent-manager-for-apache-flink
-      targetRevision: 2.3.0
+      targetRevision: 2.3.1
       helm:
         valueFiles:
           - $values/workloads/cmf-operator/base/values.yaml

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Operator baseline alignment on all clusters** ([#302](https://github.com/osowski/confluent-platform-gitops/issues/302)): CMF operator chart 2.3.0 → 2.3.1 on flink-demo, flink-demo-rbac-mtls, and eks-demo (flink-demo-rbac was already there), aligning every cluster with the officially-paired CMF 2.3.1 + `cp-flink-sql:1.19-cp8` release; CFK chart 0.1514.19 (3.2.1) → 0.1514.76 (3.2.3, latest 3.2.x patch — supports CP 7.4–8.2) on all four clusters. FKO verified already at the latest 1.140.1 (`1.14.0-cp1`), the version paired with CMF 2.3.x — no change. Also bumped the cp-flink-sql-sandbox compute pool image `1.19-cp5` → `1.19-cp8` — cp5 is below the 1.19-cp7 minimum for CMF 2.3.x and fails statement-plan loading with a `key.format requires ... confluent.key.fields` error.
+
 ### Added
 - **Headlamp Kubernetes dashboard on all clusters** ([#148](https://github.com/osowski/confluent-platform-gitops/issues/148)): token-based login, reachable at `headlamp.<cluster>.<domain>`; new clusters get it automatically via `new-cluster.sh`. (Keycloak SSO deferred to a future auth-proxy design.)
 - **flink-demo-rbac — Flink SQL statement pipeline** ([#158](https://github.com/osowski/confluent-platform-gitops/issues/158)): standalone RBAC-secured Flink SQL `INSERT INTO` statement that reads the existing `shapes-input` topic and writes enriched records to a new `shapes-sql-output` topic, created via the CMF Statements API by the shapes init job. Coexists with the JAR FlinkApplications (same input, parallel output); scale `shapes-producer` to 1 to feed it. Requires CMF chart 2.3.1; Flink SQL image bumped to `cp-flink-sql:1.19-cp8`.

--- a/workloads/cp-flink-sql-sandbox/base/cmf-config-configmap.yaml
+++ b/workloads/cp-flink-sql-sandbox/base/cmf-config-configmap.yaml
@@ -57,7 +57,7 @@ data:
         "type": "DEDICATED",
         "clusterSpec": {
           "flinkVersion": "v1_19",
-          "image": "confluentinc/cp-flink-sql:1.19-cp5",
+          "image": "confluentinc/cp-flink-sql:1.19-cp8",
           "flinkConfiguration": {
             "pipeline.operator-chaining.enabled": "false",
             "execution.checkpointing.interval": "10s",


### PR DESCRIPTION
Closes #302

## Summary

Aligns every cluster on current operator patch levels and the officially-paired CMF 2.3.1 + `cp-flink-sql:1.19-cp8` release (Confluent release CF-3610).

| Component | Before | After | Clusters |
|---|---|---|---|
| CMF chart | 2.3.0 | **2.3.1** | flink-demo, flink-demo-rbac-mtls, eks-demo (flink-demo-rbac already 2.3.1) |
| CFK chart | 0.1514.19 (3.2.1) | **0.1514.76 (3.2.3)** | all four |
| FKO chart | 1.140.1 (1.14.0-cp1) | unchanged — already latest and paired with CMF 2.3.x | all four |
| cp-flink-sql-sandbox pool image | 1.19-cp5 | **1.19-cp8** | flink-demo |

## Why

- **cp5 pool image is broken on CMF 2.3.x**: below the documented 1.19-cp7 minimum; any SELECT against catalog-discovered tables fails at statement-plan load with `A key format 'key.format' requires the declaration of one or more of key fields using 'confluent.key.fields'`. Verified on the flink-demo cluster; cp8 verified working end-to-end.
- **CMF 2.3.1** is a patch release (CVEs + fixes, SQL feature set unchanged), released as a unit with `cp-flink-sql:1.19-cp8`.
- **CFK 3.2.3** is the latest patch on the 3.2.x line; CFK 3.2.x supports CP 7.4–8.2 and all clusters run CP 8.2.0. No separate CRD chart is pinned in this repo.
- `workloads/flink-resources-rbac` pools are already on 1.19-cp8 — no change.

## Out of scope

CFK 3.3.0 (0.1718.10, minor bump with new CRD versions) — noted on #302 for a follow-up.

## Notes for rollout

Syncing bumps the CMF and CFK operator deployments (brief control-plane restarts; running Flink jobs and Kafka brokers are unaffected). Statements/pools persist in CMF's database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)