### PR TITLE
Serve HTTPS on HTTP-only IngressRoutes: flink-demo, flink-demo-rbac, eks-demo cmf (#309)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CMF Artifact Management on all clusters** ([#306](https://github.com/osowski/confluent-platform-gitops/issues/306)): CMF 2.4.0 artifact management enabled fleet-wide, backed by the in-cluster MinIO (dedicated `artifacts` bucket, `basePath: s3://artifacts/cmf`); credentials injected via `extraEnv` from the reflected `minio-credentials` secret.
 
 ### Fixed
-- **flink-demo — HTTPS on MinIO, CMF, and Schema Registry endpoints** ([#309](https://github.com/osowski/confluent-platform-gitops/issues/309)): the `s3`, `s3-console`, `cmf`, and `schema-registry` IngressRoutes were HTTP-only (served Traefik's default self-signed cert over HTTPS); each now gets a cert-manager `Certificate` and `websecure` + `tls` so all endpoints serve valid HTTPS.
+- **HTTPS on MinIO, CMF, and Schema Registry endpoints** ([#309](https://github.com/osowski/confluent-platform-gitops/issues/309)): the previously HTTP-only `s3`, `s3-console`, `cmf`, and `schema-registry` IngressRoutes now serve valid HTTPS via per-route cert-manager `Certificate`s + `websecure`/`tls` on flink-demo and flink-demo-rbac; eks-demo's `cmf` route likewise gets a proper cert (was falling back to Traefik's default self-signed cert).
 
 ## [0.8.0] - 2026-07-15
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **CMF Artifact Management on all clusters** ([#306](https://github.com/osowski/confluent-platform-gitops/issues/306)): CMF 2.4.0 artifact management enabled fleet-wide, backed by the in-cluster MinIO (dedicated `artifacts` bucket, `basePath: s3://artifacts/cmf`); credentials injected via `extraEnv` from the reflected `minio-credentials` secret.
 
+### Fixed
+- **flink-demo — HTTPS on MinIO, CMF, and Schema Registry endpoints** ([#309](https://github.com/osowski/confluent-platform-gitops/issues/309)): the `s3`, `s3-console`, `cmf`, and `schema-registry` IngressRoutes were HTTP-only (served Traefik's default self-signed cert over HTTPS); each now gets a cert-manager `Certificate` and `websecure` + `tls` so all endpoints serve valid HTTPS.
+
 ## [0.8.0] - 2026-07-15
 
 ### Fixed

--- a/infrastructure/minio/overlays/flink-demo-rbac/certificate.yaml
+++ b/infrastructure/minio/overlays/flink-demo-rbac/certificate.yaml
@@ -1,0 +1,22 @@
+---
+# TLS certificate for the MinIO S3 API and Console HTTPS IngressRoutes.
+# flink-demo-rbac only: other clusters use different TLS models.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: minio-tls
+  namespace: storage
+  annotations:
+    argocd.argoproj.io/sync-wave: "20"
+spec:
+  dnsNames:
+    - s3.flink-demo-rbac.confluentdemo.local
+    - s3-console.flink-demo-rbac.confluentdemo.local
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: selfsigned-cluster-issuer
+  secretName: minio-tls
+  usages:
+    - digital signature
+    - key encipherment

--- a/infrastructure/minio/overlays/flink-demo-rbac/ingressroute-patch.yaml
+++ b/infrastructure/minio/overlays/flink-demo-rbac/ingressroute-patch.yaml
@@ -5,6 +5,8 @@ metadata:
   name: minio
   namespace: storage
 spec:
+  entryPoints:
+    - websecure
   routes:
     - match: Host(`s3.flink-demo-rbac.confluentdemo.local`)
       kind: Rule
@@ -12,6 +14,8 @@ spec:
         - name: minio
           port: 9000
           scheme: http
+  tls:
+    secretName: minio-tls
 ---
 apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
@@ -19,6 +23,8 @@ metadata:
   name: minio-console
   namespace: storage
 spec:
+  entryPoints:
+    - websecure
   routes:
     - match: Host(`s3-console.flink-demo-rbac.confluentdemo.local`)
       kind: Rule
@@ -26,3 +32,5 @@ spec:
         - name: minio
           port: 9001
           scheme: http
+  tls:
+    secretName: minio-tls

--- a/infrastructure/minio/overlays/flink-demo-rbac/kustomization.yaml
+++ b/infrastructure/minio/overlays/flink-demo-rbac/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 # Reference base configuration
 resources:
   - ../../base
+  - certificate.yaml  # flink-demo-rbac only: TLS cert for HTTPS s3 / s3-console routes
 
 # Cluster-specific patches
 patches:

--- a/infrastructure/minio/overlays/flink-demo/certificate.yaml
+++ b/infrastructure/minio/overlays/flink-demo/certificate.yaml
@@ -1,0 +1,22 @@
+---
+# TLS certificate for the MinIO S3 API and Console HTTPS IngressRoutes.
+# flink-demo only: other clusters use different TLS models (e.g. eks-demo ACM).
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: minio-tls
+  namespace: storage
+  annotations:
+    argocd.argoproj.io/sync-wave: "20"
+spec:
+  dnsNames:
+    - s3.flink-demo.confluentdemo.local
+    - s3-console.flink-demo.confluentdemo.local
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: selfsigned-cluster-issuer
+  secretName: minio-tls
+  usages:
+    - digital signature
+    - key encipherment

--- a/infrastructure/minio/overlays/flink-demo/ingressroute-patch.yaml
+++ b/infrastructure/minio/overlays/flink-demo/ingressroute-patch.yaml
@@ -5,6 +5,8 @@ metadata:
   name: minio
   namespace: storage
 spec:
+  entryPoints:
+    - websecure
   routes:
     - match: Host(`s3.flink-demo.confluentdemo.local`)
       kind: Rule
@@ -12,6 +14,8 @@ spec:
         - name: minio
           port: 9000
           scheme: http
+  tls:
+    secretName: minio-tls
 ---
 apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
@@ -19,6 +23,8 @@ metadata:
   name: minio-console
   namespace: storage
 spec:
+  entryPoints:
+    - websecure
   routes:
     - match: Host(`s3-console.flink-demo.confluentdemo.local`)
       kind: Rule
@@ -26,3 +32,5 @@ spec:
         - name: minio
           port: 9001
           scheme: http
+  tls:
+    secretName: minio-tls

--- a/infrastructure/minio/overlays/flink-demo/kustomization.yaml
+++ b/infrastructure/minio/overlays/flink-demo/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 # Reference base configuration
 resources:
   - ../../base
+  - certificate.yaml  # flink-demo only: TLS cert for HTTPS s3 / s3-console routes
 
 # Cluster-specific patches
 patches:

--- a/workloads/ingresses/overlays/eks-demo/cmf-certificate.yaml
+++ b/workloads/ingresses/overlays/eks-demo/cmf-certificate.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: cmf-tls
+  namespace: operator
+spec:
+  secretName: cmf-tls
+  dnsNames:
+    - cmf.eks-demo.platform.dspdemos.com
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: letsencrypt-prod

--- a/workloads/ingresses/overlays/eks-demo/cmf-ingressroute-patch.yaml
+++ b/workloads/ingresses/overlays/eks-demo/cmf-ingressroute-patch.yaml
@@ -5,6 +5,8 @@ metadata:
   name: cmf
   namespace: operator
 spec:
+  entryPoints:
+    - websecure
   routes:
     - match: Host(`cmf.eks-demo.platform.dspdemos.com`)
       kind: Rule
@@ -12,3 +14,5 @@ spec:
         - name: cmf-service
           port: 80
           scheme: http
+  tls:
+    secretName: cmf-tls

--- a/workloads/ingresses/overlays/eks-demo/kustomization.yaml
+++ b/workloads/ingresses/overlays/eks-demo/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 resources:
   - ../../base
   - schema-registry-certificate.yaml
+  - cmf-certificate.yaml
 
 patches:
   - path: cmf-ingressroute-patch.yaml

--- a/workloads/ingresses/overlays/flink-demo-rbac/cmf-certificate.yaml
+++ b/workloads/ingresses/overlays/flink-demo-rbac/cmf-certificate.yaml
@@ -1,0 +1,21 @@
+---
+# TLS certificate for the CMF HTTPS IngressRoute.
+# flink-demo-rbac only: other clusters use different TLS models.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: cmf-tls
+  namespace: operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "110"
+spec:
+  dnsNames:
+    - cmf.flink-demo-rbac.confluentdemo.local
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: selfsigned-cluster-issuer
+  secretName: cmf-tls
+  usages:
+    - digital signature
+    - key encipherment

--- a/workloads/ingresses/overlays/flink-demo-rbac/cmf-ingressroute-patch.yaml
+++ b/workloads/ingresses/overlays/flink-demo-rbac/cmf-ingressroute-patch.yaml
@@ -5,6 +5,8 @@ metadata:
   name: cmf
   namespace: operator
 spec:
+  entryPoints:
+    - websecure
   routes:
     - match: Host(`cmf.flink-demo-rbac.confluentdemo.local`)
       kind: Rule
@@ -12,3 +14,5 @@ spec:
         - name: cmf-service
           port: 80
           scheme: http
+  tls:
+    secretName: cmf-tls

--- a/workloads/ingresses/overlays/flink-demo-rbac/kustomization.yaml
+++ b/workloads/ingresses/overlays/flink-demo-rbac/kustomization.yaml
@@ -4,7 +4,9 @@ kind: Kustomization
 
 resources:
   - ../../base
-  - mds-ingressroute.yaml  # flink-demo-rbac only: MDS endpoint
+  - mds-ingressroute.yaml             # flink-demo-rbac only: MDS endpoint
+  - cmf-certificate.yaml              # flink-demo-rbac only: TLS cert for HTTPS cmf route
+  - schema-registry-certificate.yaml  # flink-demo-rbac only: TLS cert for HTTPS schema-registry route
 
 patches:
   - path: cmf-ingressroute-patch.yaml

--- a/workloads/ingresses/overlays/flink-demo-rbac/schema-registry-certificate.yaml
+++ b/workloads/ingresses/overlays/flink-demo-rbac/schema-registry-certificate.yaml
@@ -1,0 +1,21 @@
+---
+# TLS certificate for the Schema Registry HTTPS IngressRoute.
+# flink-demo-rbac only: other clusters use different TLS models.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: schema-registry-tls
+  namespace: kafka
+  annotations:
+    argocd.argoproj.io/sync-wave: "110"
+spec:
+  dnsNames:
+    - schema-registry.flink-demo-rbac.confluentdemo.local
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: selfsigned-cluster-issuer
+  secretName: schema-registry-tls
+  usages:
+    - digital signature
+    - key encipherment

--- a/workloads/ingresses/overlays/flink-demo-rbac/schema-registry-ingressroute-patch.yaml
+++ b/workloads/ingresses/overlays/flink-demo-rbac/schema-registry-ingressroute-patch.yaml
@@ -5,6 +5,8 @@ metadata:
   name: schema-registry
   namespace: kafka
 spec:
+  entryPoints:
+    - websecure
   routes:
     - kind: Rule
       match: Host(`schema-registry.flink-demo-rbac.confluentdemo.local`)
@@ -12,3 +14,5 @@ spec:
         - name: schemaregistry
           port: 8081
           scheme: http
+  tls:
+    secretName: schema-registry-tls

--- a/workloads/ingresses/overlays/flink-demo/cmf-certificate.yaml
+++ b/workloads/ingresses/overlays/flink-demo/cmf-certificate.yaml
@@ -1,0 +1,21 @@
+---
+# TLS certificate for the CMF HTTPS IngressRoute.
+# flink-demo only: other clusters use different TLS models.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: cmf-tls
+  namespace: operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "110"
+spec:
+  dnsNames:
+    - cmf.flink-demo.confluentdemo.local
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: selfsigned-cluster-issuer
+  secretName: cmf-tls
+  usages:
+    - digital signature
+    - key encipherment

--- a/workloads/ingresses/overlays/flink-demo/cmf-ingressroute-patch.yaml
+++ b/workloads/ingresses/overlays/flink-demo/cmf-ingressroute-patch.yaml
@@ -5,6 +5,8 @@ metadata:
   name: cmf
   namespace: operator
 spec:
+  entryPoints:
+    - websecure
   routes:
     - match: Host(`cmf.flink-demo.confluentdemo.local`)
       kind: Rule
@@ -12,3 +14,5 @@ spec:
         - name: cmf-service
           port: 80
           scheme: http
+  tls:
+    secretName: cmf-tls

--- a/workloads/ingresses/overlays/flink-demo/kustomization.yaml
+++ b/workloads/ingresses/overlays/flink-demo/kustomization.yaml
@@ -4,6 +4,8 @@ kind: Kustomization
 
 resources:
   - ../../base
+  - cmf-certificate.yaml              # flink-demo only: TLS cert for HTTPS cmf route
+  - schema-registry-certificate.yaml  # flink-demo only: TLS cert for HTTPS schema-registry route
 
 patches:
   - path: cmf-ingressroute-patch.yaml

--- a/workloads/ingresses/overlays/flink-demo/schema-registry-certificate.yaml
+++ b/workloads/ingresses/overlays/flink-demo/schema-registry-certificate.yaml
@@ -1,0 +1,21 @@
+---
+# TLS certificate for the Schema Registry HTTPS IngressRoute.
+# flink-demo only: other clusters use different TLS models.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: schema-registry-tls
+  namespace: kafka
+  annotations:
+    argocd.argoproj.io/sync-wave: "110"
+spec:
+  dnsNames:
+    - schema-registry.flink-demo.confluentdemo.local
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: selfsigned-cluster-issuer
+  secretName: schema-registry-tls
+  usages:
+    - digital signature
+    - key encipherment

--- a/workloads/ingresses/overlays/flink-demo/schema-registry-ingressroute-patch.yaml
+++ b/workloads/ingresses/overlays/flink-demo/schema-registry-ingressroute-patch.yaml
@@ -5,6 +5,8 @@ metadata:
   name: schema-registry
   namespace: kafka
 spec:
+  entryPoints:
+    - websecure
   routes:
     - kind: Rule
       match: Host(`schema-registry.flink-demo.confluentdemo.local`)
@@ -12,3 +14,5 @@ spec:
         - name: schemaregistry
           port: 8081
           scheme: http
+  tls:
+    secretName: schema-registry-tls


### PR DESCRIPTION
## What

Give the HTTP-only Traefik `IngressRoute`s proper HTTPS across three clusters, using each cluster's existing per-route cert pattern (cert-manager `Certificate` + `entryPoints: [websecure]` + `tls.secretName`; backends stay `scheme: http`).

- **flink-demo**: `s3`, `s3-console`, `cmf`, `schema-registry`
- **flink-demo-rbac**: `s3`, `s3-console`, `cmf`, `schema-registry` (mds left HTTP by request)
- **eks-demo**: `cmf` (was serving Traefik's default cert instead of its Let's Encrypt cert)

## Why

Closes [#309](https://github.com/osowski/confluent-platform-gitops/issues/309). These routes set neither `entryPoints` nor `tls`, so over HTTPS Traefik answered with its built-in self-signed default cert (`CN=TRAEFIK DEFAULT CERT`) — e.g. `https://s3-console.flink-demo.confluentdemo.local` was broken.

## Changes (overlays only — base untouched)

Per cluster, matching its TLS model:
- **flink-demo / flink-demo-rbac** — `selfsigned-cluster-issuer`, `*.<cluster>.confluentdemo.local`:
  - `infrastructure/minio/overlays/<cluster>/`: new `certificate.yaml` (`minio-tls`, SANs `s3.` + `s3-console.`) + `websecure`/`tls` on both routes + kustomization.
  - `workloads/ingresses/overlays/<cluster>/`: new `cmf-certificate.yaml` + `schema-registry-certificate.yaml` + `websecure`/`tls` on both patches + kustomization.
- **eks-demo** — `letsencrypt-prod`, `*.eks-demo.platform.dspdemos.com`:
  - `workloads/ingresses/overlays/eks-demo/`: new `cmf-certificate.yaml` (`cmf-tls`) + `websecure`/`tls` on the cmf patch + kustomization.

## Verification

- **flink-demo — live-verified** on a running cluster: cert-manager issued `minio-tls`/`cmf-tls`/`schema-registry-tls`; all four routes reconciled with `websecure`+`tls`; served cert per host matches the hostname SANs (no `TRAEFIK DEFAULT CERT`); MinIO console fully functional over HTTPS (`/api/v1/login` → 200, no `MINIO_BROWSER_REDIRECT_URL` needed).
- **flink-demo-rbac / eks-demo** — static validation only (those clusters aren't running locally): `kubectl kustomize` builds clean for all affected overlays; rendered IngressRoutes carry `websecure`+`tls`; Certificates resolve to the correct issuer (`selfsigned-cluster-issuer` / `letsencrypt-prod`) and host SANs.

Closes #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)