### PR TITLE
Backport cmf-ui endpoint to all clusters (mtls/eks SSO, flink-demo direct) (#313)

### DIFF
--- a/clusters/eks-demo/workloads/kustomization.yaml
+++ b/clusters/eks-demo/workloads/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - cfk-operator.yaml
   - cmf-operator.yaml
+  - oauth2-proxy-cmf.yaml
   - confluent-resources.yaml
   - flink-kubernetes-operator.yaml
   - flink-resources-rbac.yaml

--- a/clusters/eks-demo/workloads/oauth2-proxy-cmf.yaml
+++ b/clusters/eks-demo/workloads/oauth2-proxy-cmf.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: oauth2-proxy-cmf
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "117"
+spec:
+  project: workloads
+  source:
+    repoURL: https://github.com/osowski/confluent-platform-gitops.git
+    targetRevision: HEAD
+    path: workloads/oauth2-proxy-cmf/overlays/eks-demo
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: operator
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/clusters/flink-demo-rbac-mtls/README.md
+++ b/clusters/flink-demo-rbac-mtls/README.md
@@ -174,6 +174,7 @@ Add these entries to `/etc/hosts`:
 127.0.0.1  alertmanager.flink-demo-rbac-mtls.confluentdemo.local
 127.0.0.1  argocd.flink-demo-rbac-mtls.confluentdemo.local
 127.0.0.1  cmf.flink-demo-rbac-mtls.confluentdemo.local
+127.0.0.1  cmf-ui.flink-demo-rbac-mtls.confluentdemo.local
 127.0.0.1  controlcenter.flink-demo-rbac-mtls.confluentdemo.local
 127.0.0.1  grafana.flink-demo-rbac-mtls.confluentdemo.local
 127.0.0.1  headlamp.flink-demo-rbac-mtls.confluentdemo.local
@@ -195,6 +196,7 @@ Add these entries to `/etc/hosts`:
 > ::1  alertmanager.flink-demo-rbac-mtls.confluentdemo.local
 > ::1  argocd.flink-demo-rbac-mtls.confluentdemo.local
 > ::1  cmf.flink-demo-rbac-mtls.confluentdemo.local
+> ::1  cmf-ui.flink-demo-rbac-mtls.confluentdemo.local
 > ::1  controlcenter.flink-demo-rbac-mtls.confluentdemo.local
 > ::1  grafana.flink-demo-rbac-mtls.confluentdemo.local
 > ::1  headlamp.flink-demo-rbac-mtls.confluentdemo.local
@@ -221,6 +223,19 @@ Add these entries to `/etc/hosts`:
 - **URL**: https://controlcenter.flink-demo-rbac-mtls.confluentdemo.local
 - **Username**: `admin@osow.ski` (via Keycloak SSO)
 - **Password**: `admin123`
+
+**CMF UI (Flink environments, applications, artifacts):**
+- **URL**: https://cmf-ui.flink-demo-rbac-mtls.confluentdemo.local (browser SSO via Keycloak)
+- **Username**: `admin@osow.ski` (redirected to Keycloak on first access)
+- **Password**: `admin123`
+- The browser UI is fronted by oauth2-proxy on the dedicated `cmf-ui.*` host. The direct
+  `cmf.*` host (below) stays for programmatic/CLI access with a bearer token — now served over
+  HTTPS — and is not intercepted by SSO. Artifact upload/management lives in this UI (Control
+  Center has no artifacts page).
+- **Use `cmf-ui.*` for the browser, not `cmf.*`.** `https://cmf.flink-demo-rbac-mtls.confluentdemo.local/`
+  still resolves and serves the CMF UI SPA, but **interactive login is broken there** — that host
+  has no SSO layer, so the UI cannot obtain a token and API calls return 401. Always use
+  `https://cmf-ui.flink-demo-rbac-mtls.confluentdemo.local/` for the UI.
 
 **Keycloak Admin Console:**
 - **URL**: http://keycloak.flink-demo-rbac-mtls.confluentdemo.local:30080

--- a/clusters/flink-demo-rbac-mtls/workloads/kustomization.yaml
+++ b/clusters/flink-demo-rbac-mtls/workloads/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - observability-resources.yaml
   - cmf-operator-secrets.yaml
   - cmf-operator.yaml
+  - oauth2-proxy-cmf.yaml
   - flink-resources-rbac.yaml
 
 # Workload applications are deployed in sync wave order (100-120)

--- a/clusters/flink-demo-rbac-mtls/workloads/oauth2-proxy-cmf.yaml
+++ b/clusters/flink-demo-rbac-mtls/workloads/oauth2-proxy-cmf.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: oauth2-proxy-cmf
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "117"
+spec:
+  project: workloads
+  source:
+    repoURL: https://github.com/osowski/confluent-platform-gitops.git
+    targetRevision: HEAD
+    path: workloads/oauth2-proxy-cmf/overlays/flink-demo-rbac-mtls
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: operator
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/clusters/flink-demo/README.md
+++ b/clusters/flink-demo/README.md
@@ -159,6 +159,7 @@ Add these entries to `/etc/hosts`:
 127.0.0.1  alertmanager.flink-demo.confluentdemo.local
 127.0.0.1  argocd.flink-demo.confluentdemo.local
 127.0.0.1  cmf.flink-demo.confluentdemo.local
+127.0.0.1  cmf-ui.flink-demo.confluentdemo.local
 127.0.0.1  controlcenter.flink-demo.confluentdemo.local
 127.0.0.1  grafana.flink-demo.confluentdemo.local
 127.0.0.1  headlamp.flink-demo.confluentdemo.local
@@ -176,6 +177,7 @@ Add these entries to `/etc/hosts`:
 > ::1  alertmanager.flink-demo.confluentdemo.local
 > ::1  argocd.flink-demo.confluentdemo.local
 > ::1  cmf.flink-demo.confluentdemo.local
+> ::1  cmf-ui.flink-demo.confluentdemo.local
 > ::1  controlcenter.flink-demo.confluentdemo.local
 > ::1  grafana.flink-demo.confluentdemo.local
 > ::1  headlamp.flink-demo.confluentdemo.local
@@ -218,6 +220,9 @@ Add these entries to `/etc/hosts`:
 **CMF API:**
 - **URL**: http://cmf.flink-demo.confluentdemo.local
 - **Documentation**: [CMF REST API](https://docs.confluent.io/platform/current/flink/index.html)
+- `cmf-ui.flink-demo.confluentdemo.local` is a direct alias to the same CMF UI/API — no login,
+  since flink-demo has no authentication layer. Provided for host-naming parity with clusters
+  that front CMF with SSO.
 
 **MinIO:**
 - **API URL**: http://s3.flink-demo.confluentdemo.local

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **flink-demo-rbac — CMF UI browser login** ([#311](https://github.com/osowski/confluent-platform-gitops/issues/311)): new `cmf-ui.flink-demo-rbac…` host fronted by oauth2-proxy provides Keycloak SSO to the CMF UI (and its artifacts upload page); the existing `cmf.*` host stays direct for CLI/API bearer access. Requires a `cmf-ui.*` `/etc/hosts` entry. (Native CMF SSO evaluated as a follow-up in [#312](https://github.com/osowski/confluent-platform-gitops/issues/312).)
+- **CMF UI endpoint on all clusters** ([#313](https://github.com/osowski/confluent-platform-gitops/issues/313)): uniform `cmf-ui.<cluster>` host — Keycloak SSO via oauth2-proxy on flink-demo-rbac-mtls and eks-demo, direct pass-through on flink-demo; oauth2-proxy/realm-sync refactored to be cluster-generic. (flink-demo-rbac-mtls `cmf.*` also brought to HTTPS.)
 
 ## [0.8.1] - 2026-07-16
 

--- a/workloads/ingresses/overlays/eks-demo/cmf-certificate.yaml
+++ b/workloads/ingresses/overlays/eks-demo/cmf-certificate.yaml
@@ -8,6 +8,7 @@ spec:
   secretName: cmf-tls
   dnsNames:
     - cmf.eks-demo.platform.dspdemos.com
+    - cmf-ui.eks-demo.platform.dspdemos.com
   issuerRef:
     group: cert-manager.io
     kind: ClusterIssuer

--- a/workloads/ingresses/overlays/eks-demo/cmf-ui-ingressroute.yaml
+++ b/workloads/ingresses/overlays/eks-demo/cmf-ui-ingressroute.yaml
@@ -1,0 +1,23 @@
+---
+# Browser SSO entrypoint for the CMF UI. All traffic flows through oauth2-proxy
+# (reverse-proxy mode), which runs the Keycloak login (auto-redirect) and proxies
+# authenticated requests to cmf-service with the bearer token injected. Kept on a
+# dedicated host so the direct cmf.* endpoint stays usable for CLI/API clients.
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: cmf-ui
+  namespace: operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "118"
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`cmf-ui.eks-demo.platform.dspdemos.com`)
+      kind: Rule
+      services:
+        - name: oauth2-proxy-cmf
+          port: 4180
+  tls:
+    secretName: cmf-tls

--- a/workloads/ingresses/overlays/eks-demo/kustomization.yaml
+++ b/workloads/ingresses/overlays/eks-demo/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ../../base
   - schema-registry-certificate.yaml
   - cmf-certificate.yaml
+  - cmf-ui-ingressroute.yaml
 
 patches:
   - path: cmf-ingressroute-patch.yaml

--- a/workloads/ingresses/overlays/flink-demo-rbac-mtls/cmf-certificate.yaml
+++ b/workloads/ingresses/overlays/flink-demo-rbac-mtls/cmf-certificate.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: cmf-tls
+  namespace: operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "110"
+spec:
+  dnsNames:
+    - cmf.flink-demo-rbac-mtls.confluentdemo.local
+    - cmf-ui.flink-demo-rbac-mtls.confluentdemo.local
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: selfsigned-cluster-issuer
+  secretName: cmf-tls
+  usages:
+    - digital signature
+    - key encipherment

--- a/workloads/ingresses/overlays/flink-demo-rbac-mtls/cmf-ui-ingressroute.yaml
+++ b/workloads/ingresses/overlays/flink-demo-rbac-mtls/cmf-ui-ingressroute.yaml
@@ -2,17 +2,18 @@
 apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
-  name: cmf
+  name: cmf-ui
   namespace: operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "118"
 spec:
   entryPoints:
     - websecure
   routes:
-    - match: Host(`cmf.flink-demo-rbac-mtls.confluentdemo.local`)
+    - match: Host(`cmf-ui.flink-demo-rbac-mtls.confluentdemo.local`)
       kind: Rule
       services:
-        - name: cmf-service
-          port: 80
-          scheme: http
+        - name: oauth2-proxy-cmf
+          port: 4180
   tls:
     secretName: cmf-tls

--- a/workloads/ingresses/overlays/flink-demo-rbac-mtls/kustomization.yaml
+++ b/workloads/ingresses/overlays/flink-demo-rbac-mtls/kustomization.yaml
@@ -5,6 +5,8 @@ kind: Kustomization
 resources:
   - ../../base
   - mds-ingressroute.yaml  # flink-demo-rbac-mtls only: MDS endpoint
+  - cmf-certificate.yaml       # flink-demo-rbac-mtls: TLS for cmf + cmf-ui
+  - cmf-ui-ingressroute.yaml   # flink-demo-rbac-mtls: browser SSO host
 
 patches:
   - path: cmf-ingressroute-patch.yaml

--- a/workloads/ingresses/overlays/flink-demo/cmf-certificate.yaml
+++ b/workloads/ingresses/overlays/flink-demo/cmf-certificate.yaml
@@ -11,6 +11,7 @@ metadata:
 spec:
   dnsNames:
     - cmf.flink-demo.confluentdemo.local
+    - cmf-ui.flink-demo.confluentdemo.local
   issuerRef:
     group: cert-manager.io
     kind: ClusterIssuer

--- a/workloads/ingresses/overlays/flink-demo/cmf-ui-ingressroute.yaml
+++ b/workloads/ingresses/overlays/flink-demo/cmf-ui-ingressroute.yaml
@@ -1,0 +1,22 @@
+---
+# flink-demo has no Keycloak/RBAC; cmf-ui.* is a URL-parity alias that routes
+# straight to CMF (no oauth2-proxy). Same backend as cmf.*.
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: cmf-ui
+  namespace: operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "118"
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`cmf-ui.flink-demo.confluentdemo.local`)
+      kind: Rule
+      services:
+        - name: cmf-service
+          port: 80
+          scheme: http
+  tls:
+    secretName: cmf-tls

--- a/workloads/ingresses/overlays/flink-demo/kustomization.yaml
+++ b/workloads/ingresses/overlays/flink-demo/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 resources:
   - ../../base
   - cmf-certificate.yaml              # flink-demo only: TLS cert for HTTPS cmf route
+  - cmf-ui-ingressroute.yaml          # flink-demo only: direct cmf-ui alias (no SSO)
   - schema-registry-certificate.yaml  # flink-demo only: TLS cert for HTTPS schema-registry route
 
 patches:

--- a/workloads/keycloak/base/realm-configmap.yaml
+++ b/workloads/keycloak/base/realm-configmap.yaml
@@ -318,9 +318,13 @@ data:
           "directAccessGrantsEnabled": false,
           "serviceAccountsEnabled": false,
           "redirectUris": [
-            "https://cmf-ui.flink-demo-rbac.confluentdemo.local/oauth2/callback"
+            "https://cmf-ui.flink-demo-rbac.confluentdemo.local/oauth2/callback",
+            "https://cmf-ui.flink-demo-rbac-mtls.confluentdemo.local/oauth2/callback"
           ],
-          "webOrigins": ["https://cmf-ui.flink-demo-rbac.confluentdemo.local"],
+          "webOrigins": [
+            "https://cmf-ui.flink-demo-rbac.confluentdemo.local",
+            "https://cmf-ui.flink-demo-rbac-mtls.confluentdemo.local"
+          ],
           "secret": "cmf-ui-secret",
           "protocolMappers": [
             {

--- a/workloads/keycloak/base/realm-sync-job.yaml
+++ b/workloads/keycloak/base/realm-sync-job.yaml
@@ -43,6 +43,10 @@ spec:
                 secretKeyRef:
                   name: keycloak-admin
                   key: KEYCLOAK_ADMIN_PASSWORD
+            - name: CMF_UI_REDIRECT_URI
+              value: https://cmf-ui.flink-demo-rbac.confluentdemo.local/oauth2/callback
+            - name: CMF_UI_WEB_ORIGIN
+              value: https://cmf-ui.flink-demo-rbac.confluentdemo.local
           command:
             - /bin/sh
             - -c
@@ -166,7 +170,7 @@ spec:
                 echo "Creating cmf-ui client..."
                 curl -sf -X POST "http://keycloak:8080/admin/realms/confluent/clients" \
                   -H "Authorization: Bearer $ADMIN_TOKEN" -H "Content-Type: application/json" \
-                  -d '{"clientId":"cmf-ui","enabled":true,"protocol":"openid-connect","publicClient":false,"standardFlowEnabled":true,"directAccessGrantsEnabled":false,"serviceAccountsEnabled":false,"redirectUris":["https://cmf-ui.flink-demo-rbac.confluentdemo.local/oauth2/callback"],"webOrigins":["https://cmf-ui.flink-demo-rbac.confluentdemo.local"],"secret":"cmf-ui-secret"}' \
+                  -d "{\"clientId\":\"cmf-ui\",\"enabled\":true,\"protocol\":\"openid-connect\",\"publicClient\":false,\"standardFlowEnabled\":true,\"directAccessGrantsEnabled\":false,\"serviceAccountsEnabled\":false,\"redirectUris\":[\"${CMF_UI_REDIRECT_URI}\"],\"webOrigins\":[\"${CMF_UI_WEB_ORIGIN}\"],\"secret\":\"cmf-ui-secret\"}" \
                   2>&1 | grep -v "Conflict detected" || echo "cmf-ui client created or exists"
                 CMFUI_ID=$(curl -sf -X GET "http://keycloak:8080/admin/realms/confluent/clients?clientId=cmf-ui" \
                   -H "Authorization: Bearer $ADMIN_TOKEN" | grep -o '"id":"[^"]*' | head -1 | cut -d'"' -f4)
@@ -174,7 +178,7 @@ spec:
                 echo "cmf-ui client exists: $CMFUI_ID (updating secret + redirect/web origins)"
                 curl -sf -X PUT "http://keycloak:8080/admin/realms/confluent/clients/$CMFUI_ID" \
                   -H "Authorization: Bearer $ADMIN_TOKEN" -H "Content-Type: application/json" \
-                  -d '{"secret":"cmf-ui-secret","redirectUris":["https://cmf-ui.flink-demo-rbac.confluentdemo.local/oauth2/callback"],"webOrigins":["https://cmf-ui.flink-demo-rbac.confluentdemo.local"]}'
+                  -d "{\"secret\":\"cmf-ui-secret\",\"redirectUris\":[\"${CMF_UI_REDIRECT_URI}\"],\"webOrigins\":[\"${CMF_UI_WEB_ORIGIN}\"]}"
               fi
               if [ -n "$CMFUI_ID" ]; then
                 echo "Adding client_id-from-username mapper to cmf-ui..."

--- a/workloads/keycloak/overlays/eks-demo/kustomization.yaml
+++ b/workloads/keycloak/overlays/eks-demo/kustomization.yaml
@@ -35,6 +35,11 @@ patches:
       kind: Service
       name: keycloak-external
 
+  - path: realm-sync-job-patch.yaml
+    target:
+      kind: Job
+      name: keycloak-realm-sync
+
 labels:
 - includeSelectors: false
   includeTemplates: true

--- a/workloads/keycloak/overlays/eks-demo/realm-configmap.yaml
+++ b/workloads/keycloak/overlays/eks-demo/realm-configmap.yaml
@@ -251,6 +251,34 @@ data:
           ]
         },
         {
+          "clientId": "cmf-ui",
+          "enabled": true,
+          "protocol": "openid-connect",
+          "publicClient": false,
+          "standardFlowEnabled": true,
+          "directAccessGrantsEnabled": false,
+          "serviceAccountsEnabled": false,
+          "redirectUris": ["https://cmf-ui.eks-demo.platform.dspdemos.com/oauth2/callback"],
+          "webOrigins": ["https://cmf-ui.eks-demo.platform.dspdemos.com"],
+          "secret": "cmf-ui-secret",
+          "protocolMappers": [
+            {
+              "name": "clientid-from-username",
+              "protocol": "openid-connect",
+              "protocolMapper": "oidc-usermodel-property-mapper",
+              "consentRequired": false,
+              "config": {
+                "user.attribute": "username",
+                "claim.name": "client_id",
+                "jsonType.label": "String",
+                "id.token.claim": "true",
+                "access.token.claim": "true",
+                "userinfo.token.claim": "false"
+              }
+            }
+          ]
+        },
+        {
           "clientId": "controlcenter",
           "enabled": true,
           "protocol": "openid-connect",

--- a/workloads/keycloak/overlays/eks-demo/realm-sync-job-patch.yaml
+++ b/workloads/keycloak/overlays/eks-demo/realm-sync-job-patch.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: keycloak-realm-sync
+  namespace: keycloak
+spec:
+  template:
+    spec:
+      containers:
+        - name: realm-sync
+          env:
+            - name: CMF_UI_REDIRECT_URI
+              value: https://cmf-ui.eks-demo.platform.dspdemos.com/oauth2/callback
+            - name: CMF_UI_WEB_ORIGIN
+              value: https://cmf-ui.eks-demo.platform.dspdemos.com

--- a/workloads/keycloak/overlays/flink-demo-rbac-mtls/kustomization.yaml
+++ b/workloads/keycloak/overlays/flink-demo-rbac-mtls/kustomization.yaml
@@ -21,6 +21,11 @@ patches:
       kind: IngressRoute
       name: keycloak
 
+  - path: realm-sync-job-patch.yaml
+    target:
+      kind: Job
+      name: keycloak-realm-sync
+
 # Cluster-specific labels
 labels:
 - includeSelectors: false

--- a/workloads/keycloak/overlays/flink-demo-rbac-mtls/realm-sync-job-patch.yaml
+++ b/workloads/keycloak/overlays/flink-demo-rbac-mtls/realm-sync-job-patch.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: keycloak-realm-sync
+  namespace: keycloak
+spec:
+  template:
+    spec:
+      containers:
+        - name: realm-sync
+          env:
+            - name: CMF_UI_REDIRECT_URI
+              value: https://cmf-ui.flink-demo-rbac-mtls.confluentdemo.local/oauth2/callback
+            - name: CMF_UI_WEB_ORIGIN
+              value: https://cmf-ui.flink-demo-rbac-mtls.confluentdemo.local

--- a/workloads/oauth2-proxy-cmf/base/deployment.yaml
+++ b/workloads/oauth2-proxy-cmf/base/deployment.yaml
@@ -24,12 +24,9 @@ spec:
           args:
             - --provider=oidc
             - --skip-oidc-discovery=true
-            - --oidc-issuer-url=https://keycloak.flink-demo-rbac.confluentdemo.local/realms/confluent
-            - --login-url=https://keycloak.flink-demo-rbac.confluentdemo.local/realms/confluent/protocol/openid-connect/auth
             - --redeem-url=http://keycloak.keycloak.svc.cluster.local:8080/realms/confluent/protocol/openid-connect/token
             - --oidc-jwks-url=http://keycloak.keycloak.svc.cluster.local:8080/realms/confluent/protocol/openid-connect/certs
             - --client-id=cmf-ui
-            - --redirect-url=https://cmf-ui.flink-demo-rbac.confluentdemo.local/oauth2/callback
             - --email-domain=*
             # Demo Keycloak users have unverified emails; skip the email_verified check
             - --insecure-oidc-allow-unverified-email=true
@@ -42,9 +39,10 @@ spec:
             - --upstream=http://cmf-service.operator.svc.cluster.local:80
             - --http-address=0.0.0.0:4180
             - --cookie-secure=true
-            - --cookie-domain=.flink-demo-rbac.confluentdemo.local
-            - --whitelist-domain=.flink-demo-rbac.confluentdemo.local
             - --skip-provider-button=true
+          envFrom:
+            - configMapRef:
+                name: oauth2-proxy-cmf-cluster
           env:
             - name: OAUTH2_PROXY_CLIENT_SECRET
               valueFrom:

--- a/workloads/oauth2-proxy-cmf/overlays/eks-demo/cluster-config.yaml
+++ b/workloads/oauth2-proxy-cmf/overlays/eks-demo/cluster-config.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: oauth2-proxy-cmf-cluster
+  namespace: operator
+data:
+  OAUTH2_PROXY_OIDC_ISSUER_URL: https://keycloak.eks-demo.platform.dspdemos.com/realms/confluent
+  OAUTH2_PROXY_LOGIN_URL: https://keycloak.eks-demo.platform.dspdemos.com/realms/confluent/protocol/openid-connect/auth
+  OAUTH2_PROXY_REDIRECT_URL: https://cmf-ui.eks-demo.platform.dspdemos.com/oauth2/callback
+  OAUTH2_PROXY_COOKIE_DOMAINS: .eks-demo.platform.dspdemos.com
+  OAUTH2_PROXY_WHITELIST_DOMAINS: .eks-demo.platform.dspdemos.com

--- a/workloads/oauth2-proxy-cmf/overlays/eks-demo/kustomization.yaml
+++ b/workloads/oauth2-proxy-cmf/overlays/eks-demo/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+  - cluster-config.yaml
+labels:
+  - includeSelectors: false
+    includeTemplates: true
+    pairs:
+      cluster: eks-demo

--- a/workloads/oauth2-proxy-cmf/overlays/flink-demo-rbac-mtls/cluster-config.yaml
+++ b/workloads/oauth2-proxy-cmf/overlays/flink-demo-rbac-mtls/cluster-config.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: oauth2-proxy-cmf-cluster
+  namespace: operator
+data:
+  OAUTH2_PROXY_OIDC_ISSUER_URL: https://keycloak.flink-demo-rbac-mtls.confluentdemo.local/realms/confluent
+  OAUTH2_PROXY_LOGIN_URL: https://keycloak.flink-demo-rbac-mtls.confluentdemo.local/realms/confluent/protocol/openid-connect/auth
+  OAUTH2_PROXY_REDIRECT_URL: https://cmf-ui.flink-demo-rbac-mtls.confluentdemo.local/oauth2/callback
+  OAUTH2_PROXY_COOKIE_DOMAINS: .flink-demo-rbac-mtls.confluentdemo.local
+  OAUTH2_PROXY_WHITELIST_DOMAINS: .flink-demo-rbac-mtls.confluentdemo.local

--- a/workloads/oauth2-proxy-cmf/overlays/flink-demo-rbac-mtls/kustomization.yaml
+++ b/workloads/oauth2-proxy-cmf/overlays/flink-demo-rbac-mtls/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+  - cluster-config.yaml
+labels:
+  - includeSelectors: false
+    includeTemplates: true
+    pairs:
+      cluster: flink-demo-rbac-mtls

--- a/workloads/oauth2-proxy-cmf/overlays/flink-demo-rbac/cluster-config.yaml
+++ b/workloads/oauth2-proxy-cmf/overlays/flink-demo-rbac/cluster-config.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: oauth2-proxy-cmf-cluster
+  namespace: operator
+data:
+  OAUTH2_PROXY_OIDC_ISSUER_URL: https://keycloak.flink-demo-rbac.confluentdemo.local/realms/confluent
+  OAUTH2_PROXY_LOGIN_URL: https://keycloak.flink-demo-rbac.confluentdemo.local/realms/confluent/protocol/openid-connect/auth
+  OAUTH2_PROXY_REDIRECT_URL: https://cmf-ui.flink-demo-rbac.confluentdemo.local/oauth2/callback
+  OAUTH2_PROXY_COOKIE_DOMAINS: .flink-demo-rbac.confluentdemo.local
+  OAUTH2_PROXY_WHITELIST_DOMAINS: .flink-demo-rbac.confluentdemo.local

--- a/workloads/oauth2-proxy-cmf/overlays/flink-demo-rbac/kustomization.yaml
+++ b/workloads/oauth2-proxy-cmf/overlays/flink-demo-rbac/kustomization.yaml
@@ -3,6 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+  - cluster-config.yaml
 labels:
   - includeSelectors: false
     includeTemplates: true


### PR DESCRIPTION
> ✅ **Ready to merge.** The throwaway repoint commit has been dropped (rebased out); the branch no longer changes any `targetRevision` (`clusters/flink-demo-rbac-mtls` untouched vs main). Final whole-branch review (opus) passed.

## What

Backports the uniform **`cmf-ui.<cluster>`** CMF UI endpoint (from #311) to the remaining clusters:
- **flink-demo-rbac-mtls** & **eks-demo**: browser SSO via oauth2-proxy (Keycloak), plus mtls `cmf.*` brought to HTTPS.
- **flink-demo** (no Keycloak/RBAC): `cmf-ui.*` is a **direct** alias to cmf-service (URL parity, no login).

`cmf.*` stays the direct CLI/API endpoint on every cluster.

## Why

Closes #313 — uniform CMF UI URLs fleet-wide. (Native CMF SSO evaluated as a follow-up in #312; if adopted it would supersede oauth2-proxy.)

## Changes

- **Refactor (behavior-preserving):** oauth2-proxy base now sources the 5 cluster-specific settings from a per-cluster `oauth2-proxy-cmf-cluster` ConfigMap (`envFrom`); realm-sync-job's `cmf-ui` redirect is parameterized via `CMF_UI_REDIRECT_URI`/`CMF_UI_WEB_ORIGIN` env. flink-demo-rbac refactored to match (values byte-for-byte identical).
- **mtls / eks:** oauth2-proxy overlay + ArgoCD app; `cmf-ui` IngressRoute → oauth2-proxy; Keycloak `cmf-ui` client (base realm gains mtls redirect; eks gets a client in its own overlay realm) + sync-job env; cert SANs. mtls also HTTPS-parity for `cmf.*`.
- **flink-demo:** `cmf-ui` IngressRoute → cmf-service direct + cert SAN.
- **Docs:** `/etc/hosts` + CMF UI notes (mtls, flink-demo) + changelog.

## Verification

- **flink-demo-rbac-mtls — LIVE:** `cmf-ui.*` 302→Keycloak → scripted login → 200 authenticated CMF UI; `cmf.*` 200 direct + API 401; `cmf-ui` Keycloak client carries the mtls redirect.
- **eks-demo — static** (cloud cluster): overlays build, `cmf-ui` client in eks realm, cert SAN, app registered.
- **flink-demo — static:** `cmf-ui` → cmf-service direct route + SAN.
- Refactor regression: flink-demo-rbac ConfigMap == old args (byte-for-byte); mtls (same refactored base) works live. Final whole-branch review (opus) clean.

## Follow-ups
- #312 — native CMF UI SSO (potential oauth2-proxy replacement).

Closes #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)