### PR TITLE
Fix Control Center SSO on flink-demo-rbac-mtls (base realm controlcenter redirect) (#316)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **flink-demo-rbac — CMF UI browser login** ([#311](https://github.com/osowski/confluent-platform-gitops/issues/311)): new `cmf-ui.flink-demo-rbac…` host fronted by oauth2-proxy provides Keycloak SSO to the CMF UI (and its artifacts upload page); the existing `cmf.*` host stays direct for CLI/API bearer access. Requires a `cmf-ui.*` `/etc/hosts` entry. (Native CMF SSO evaluated as a follow-up in [#312](https://github.com/osowski/confluent-platform-gitops/issues/312).)
 - **CMF UI endpoint on all clusters** ([#313](https://github.com/osowski/confluent-platform-gitops/issues/313)): uniform `cmf-ui.<cluster>` host — Keycloak SSO via oauth2-proxy on flink-demo-rbac-mtls and eks-demo, direct pass-through on flink-demo; oauth2-proxy/realm-sync refactored to be cluster-generic. (flink-demo-rbac-mtls `cmf.*` also brought to HTTPS.)
 
+### Fixed
+- **Control Center SSO on flink-demo-rbac-mtls** ([#316](https://github.com/osowski/confluent-platform-gitops/issues/316)): the shared base realm's `controlcenter` client now lists both the flink-demo-rbac and flink-demo-rbac-mtls redirect URIs, so a fresh mtls Keycloak import registers the mtls callback (previously only flink-demo-rbac's, causing `Invalid parameter: redirect_uri`). eks-demo (own realm) unaffected.
+
 ## [0.8.1] - 2026-07-16
 
 ### Added

--- a/workloads/keycloak/base/realm-configmap.yaml
+++ b/workloads/keycloak/base/realm-configmap.yaml
@@ -259,7 +259,8 @@ data:
           "serviceAccountsEnabled": true,
           "standardFlowEnabled": true,
           "redirectUris": [
-            "https://controlcenter.flink-demo-rbac.confluentdemo.local/api/metadata/security/1.0/oidc/authorization-code/callback"
+            "https://controlcenter.flink-demo-rbac.confluentdemo.local/api/metadata/security/1.0/oidc/authorization-code/callback",
+            "https://controlcenter.flink-demo-rbac-mtls.confluentdemo.local/api/metadata/security/1.0/oidc/authorization-code/callback"
           ],
           "webOrigins": ["*"],
           "secret": "controlcenter-secret",


### PR DESCRIPTION
## What

Add the flink-demo-rbac-mtls callback to the shared base realm's `controlcenter` client `redirectUris` (now multi-valued: flink-demo-rbac **and** flink-demo-rbac-mtls hosts).

## Why

Closes #316. flink-demo-rbac-mtls uses the shared base realm, whose `controlcenter` client hardcoded only the **flink-demo-rbac** redirect URI. On mtls, Control Center sends a `controlcenter.flink-demo-rbac-mtls…` redirect_uri that wasn't registered → Keycloak `Invalid parameter: redirect_uri`. Pre-existing latent bug (value identical at pre-#313 `cc384ad`); surfaced by a fresh mtls deploy. Same class of shared-base-realm/per-cluster-host issue #313 fixed for `cmf-ui`.

## Scope / safety

- **Base realm-configmap only.** The shared `realm-sync-job` was intentionally **not** changed: it also runs on eks-demo, whose own realm carries the correct eks controlcenter redirect — forcing the kind hosts there would break eks C3. So the fix corrects **fresh imports** on the kind clusters; eks (own realm) is untouched.
- flink-demo-rbac's own redirect is preserved (still first in the list).

## Verification

- Static: realm JSON valid; `controlcenter` client now lists both flink-demo-rbac and mtls callbacks; eks overlay realm still shows the eks host; all keycloak overlays build.
- Live: the running mtls Keycloak was hotfixed (mtls redirect added to its controlcenter client) and **Control Center login now works on mtls** (user-confirmed). This PR makes it durable for future fresh mtls deploys.

Closes #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)