### PR TITLE
Document Flink SQL CR constraints and record the preview-adoption ADR

### DIFF
--- a/adrs/0010-adopt-cfk-preview-flink-sql-crds.md
+++ b/adrs/0010-adopt-cfk-preview-flink-sql-crds.md
@@ -1,0 +1,57 @@
+# 10. Adopt CFK 3.3 Flink SQL CRDs While They Are a Preview Feature
+
+Date: 2026-08-07
+
+## Status
+
+Accepted
+
+## Context
+
+CMF's Flink SQL object model — secrets, secret mappings, catalogs, databases, compute pools and statements — had no declarative Kubernetes representation before CFK 3.3.0. This repository drove it through the CMF REST API from ArgoCD hook Jobs: two `sql-init` Jobs on `flink-resources-rbac` running seven `curl` steps each, plus two more on `cp-flink-sql-sandbox`. Roughly 1,400 lines of shell and JSON-in-ConfigMap.
+
+That approach had costs beyond its size:
+
+- **Invisible to ArgoCD.** The Jobs were fire-and-forget. ArgoCD could not diff, prune, or report the state of anything they created, so the CMF-side objects were untracked drift by construction.
+- **No upsert.** The CMF API has none, so every step carried a create-then-update fallback, with a `409` treated as success and `PUT` failures swallowed as warnings.
+- **A token refresh loop.** CMF 2.2's embedded Schema Registry client rejected `OAUTHBEARER` as a `bearer.auth.credentials.source`. The Jobs worked around this by minting a Keycloak access token at runtime and embedding it in each catalog as a `STATIC_TOKEN`. That token expires, which is the reason the Jobs had to re-run on every sync — the imperative machinery existed largely to service its own workaround.
+
+CFK 3.3.0 (chart `0.1718.10`) introduced six CRDs covering the whole model: `FlinkSecret`, `FlinkEnvironmentSecretMapping`, `FlinkKafkaCatalog`, `FlinkKafkaDatabase`, `FlinkComputePool` and `FlinkStatement`. Separately, CMF 2.3.1 added `OAUTHBEARER` support for Schema Registry catalog authentication with automatic token refresh, removing the reason the `STATIC_TOKEN` workaround existed. This repository runs CMF 2.4.0.
+
+The complication: Confluent documents Flink SQL support in CFK 3.3.0 as a **preview feature**, with the explicit guidance *"Do not use preview features in production."* The CRDs are also gated behind two Helm flags (`enableCMFDay2Ops`, `enableFlinkSQL`), the second of which defaults to `false`.
+
+## Decision
+
+Adopt the CFK 3.3 Flink SQL CRDs across this repository's clusters, and delete the hook Jobs they replace.
+
+The preview designation is accepted rather than worked around. This repository exists to demonstrate and exercise Confluent Platform on Kubernetes; every cluster in it is a demo or reference environment, none carries production traffic or an availability commitment, and exercising new operator capability ahead of GA is part of its purpose. Weighed against that, the imperative Jobs were the larger practical risk: untracked, unpruneable, and dependent on a credential-refresh loop.
+
+Supporting decisions taken alongside it:
+
+- **Enable both feature gates** (`enableCMFDay2Ops`, `enableFlinkSQL`) in the CFK operator base values, and whitelist the six kinds in the `workloads` ArgoCD `AppProject`.
+- **Gate the chain on health.** Add Lua health checks in `argocd-cm` for every CMF-backed Flink kind. Without them ArgoCD treats an unknown custom resource as Healthy the instant it is created, which both hides failures and makes the dependency-chain sync waves decorative.
+- **Enable CMF secret encryption**, which `FlinkSecret` requires.
+- **Keep the credential split** the previous ConfigMaps documented: Kafka connections use the `cmf` service account, Schema Registry uses the per-group `sa-<group>-flink` account.
+
+## Consequences
+
+**Positive.** ~1,400 lines of shell and JSON become ~24 custom resources. CMF-side objects are visible, diffable and prunable in ArgoCD. Credentials are declarative and rotate by editing a Kubernetes Secret, with CFK tracking its `resourceVersion`. The `STATIC_TOKEN` refresh loop and its expiry failure mode are gone. Sync waves genuinely order the dependency chain now that health is evaluated.
+
+**Negative — preview risk.** The API may change incompatibly before GA, and CFK upgrades must be treated as potentially breaking for these kinds. Rollback means reinstating the hook Jobs from git history; they are removed from the tree but not from history, and the CMF REST API they used is unchanged.
+
+**Negative — undocumented behaviour is discovered by running it.** Several constraints are not in the CFK documentation and were found only against a live cluster. They are recorded in [architecture.md](../docs/architecture.md); the load-bearing ones:
+
+- The `FlinkSecret`, its `FlinkEnvironmentSecretMapping`, and the `connectionSecretId` that references them must all share one identical name. The docs state only the mapping half of the rule.
+- CFK does not refresh `FlinkStatement.status.phase` once a statement starts running — a healthy statement reads `PENDING` indefinitely — so health checks must not gate on `RUNNING`.
+- `FlinkComputePool.status.phase` carries the pool *type*, not a lifecycle state.
+- `FlinkKafkaCatalog.status.environmentsWithAccess` is unset on correctly configured catalogs and cannot be used as a health signal.
+- Renaming a `FlinkSecret` on a live cluster deadlocks against its own secret mapping.
+
+**Neutral — version floor.** This commits the repository to CFK 3.3.0+ and CMF 2.3.0+ (2.4.0 in practice), and to a `cp-flink-sql` image matching the CMF version. Downgrading below those floors is no longer possible without reverting the whole approach.
+
+## References
+
+- Epic [#318](https://github.com/osowski/confluent-platform-gitops/issues/318) and its children [#319](https://github.com/osowski/confluent-platform-gitops/issues/319)–[#326](https://github.com/osowski/confluent-platform-gitops/issues/326)
+- [Manage Apache Flink SQL Statements Using Confluent for Kubernetes](https://docs.confluent.io/operator/current/co-manage-flink-sql.html)
+- [Manage Global Apache Flink Resources Using Confluent for Kubernetes](https://docs.confluent.io/operator/current/co-flink-global-resources.html)
+- [ADR-0008](0008-flink-sql-statement-config-placement-rbac.md) — which configuration layer owns a given Flink SQL setting

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -185,13 +185,23 @@ See [ADR-0002](../adrs/0002-cfk-component-sync-wave-ordering.md) for the full de
 
 ### Intra-Application Sync Waves: Flink SQL Resources
 
-CFK 3.3.0 introduced declarative CRDs for the CMF Flink SQL object model, replacing the ArgoCD hook Jobs that previously drove the CMF REST API. These resources form a strict dependency chain:
+The CMF Flink SQL object model is expressed as CFK custom resources (CFK 3.3.0+). They form a strict dependency chain, with the `FlinkEnvironment` ahead of it and `FlinkApplication` behind it:
 
 ```
-FlinkSecret → FlinkEnvironmentSecretMapping → FlinkKafkaCatalog → FlinkKafkaDatabase → FlinkComputePool → FlinkStatement
+FlinkEnvironment
+  → FlinkSecret → FlinkEnvironmentSecretMapping → FlinkKafkaCatalog
+    → FlinkKafkaDatabase → FlinkComputePool → FlinkStatement
+                                                → FlinkApplication
 ```
 
-Apply in that order and delete in reverse, so each CMF-side resource is removed before the resource it depends on. Sync-wave annotations express both directions, since ArgoCD deletes in reverse wave order. `cp-flink-sql-sandbox` uses waves 40/45/50 for catalog/database/pool, following its topics (30) and schemas (35).
+Apply in that order and delete in reverse, so each CMF-side resource is removed before the resource it depends on. Sync-wave annotations express both directions, since ArgoCD deletes in reverse wave order.
+
+| App | Wave scheme |
+|---|---|
+| `flink-resources-rbac` | environment 5; Secret 10; FlinkSecret 20; mapping 30; catalog 40; database 50; pool 60; statement 70; application 80 |
+| `cp-flink-sql-sandbox` | topics 30; schemas 35; catalog 40; database 45; pool 50 |
+
+`FlinkApplication` must come after `FlinkEnvironment` rather than sharing its wave. Unwaved they race, and CFK reports `FlinkEnvironment "<env>" not found` on the application. Without a health check that failure is invisible — ArgoCD marks the application Healthy on creation and CFK retries in the background — but once health is evaluated it fails the sync outright.
 
 The following constraints are enforced by CEL rules on the CRDs or by CMF runtime behaviour, and are easy to trip over:
 
@@ -201,7 +211,7 @@ The following constraints are enforced by CEL rules on the CRDs or by CMF runtim
 | `FlinkComputePool.spec.type` is immutable | Switching DEDICATED↔SHARED requires a new CR |
 | `FlinkComputePool.spec.state` valid only on `SHARED` pools | CEL rejects `state` on a DEDICATED pool |
 | `FlinkKafkaCatalog.spec.flinkEnvironment` is required and immutable | Sharing a catalog across environments needs one CR per environment, even though CMF catalogs are global |
-| `FlinkEnvironmentSecretMapping` name must equal the `connectionSecretId` referenced by the catalog/database | **Not validated by CFK.** CMF silently ignores an unmapped catalog rather than erroring |
+| The `FlinkSecret`, its `FlinkEnvironmentSecretMapping`, and the `connectionSecretId`/`connectionSecretRef` that references them must all share **one identical name** | Two mechanisms enforce it: CMF keys an environment's secrets by mapping name and silently ignores an unmapped catalog rather than erroring; and CFK resolves `connectionSecretId` to a `FlinkSecret` resource, failing with `flinksecret "<id>" not found in namespace` on a mismatch |
 | DDL (`CREATE TABLE`) runs only in environments listed in the database's `ddlEnvironments` | DDL is rejected everywhere else |
 | `clusterSpec.image` must match the deployed CMF version | JobManager fails to load the statement plan |
 | `FlinkSecret` requires CMF secret encryption (`encryption.enabled=true`) | Secrets cannot be stored encrypted at rest, so the sync fails |
@@ -218,6 +228,21 @@ The following constraints are enforced by CEL rules on the CRDs or by CMF runtim
 - `argocd.argoproj.io/sync-options: Force=true,Replace=true` forces a delete-and-recreate that passes validation, but silently discards job state.
 
 Versioning the name is preferred: it is explicit, auditable, and leaves the previous statement's history intact.
+
+These CRDs are a **preview feature** in CFK 3.3.0. The decision to adopt them anyway, and the rollback path if the API changes before GA, is recorded in [ADR-0010](../adrs/0010-adopt-cfk-preview-flink-sql-crds.md).
+
+#### Renaming a FlinkSecret deadlocks a live cluster
+
+CMF refuses to delete a secret that an environment still maps:
+
+```
+Secret 'sr-oauth-secret-shapes' is still mapped to environments [shapes-env].
+Remove those mappings first.
+```
+
+Because the `FlinkSecret` sits at wave 20 and its mapping at wave 30, a rename makes the two waves deadlock: wave 20 cannot prune the old secret while the mapping that references it still exists, and the wave that would update that mapping never runs. The old resources sit `ERROR` with the CFK finalizer held, and the sync hangs.
+
+To rename in place, delete the `FlinkEnvironmentSecretMapping` resources first so the old secrets can finalize, then sync. A cluster built from scratch never hits this — it only bites when renaming an existing deployment, and it is a concrete instance of the reverse-order teardown rule above.
 
 #### Health assessment
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+- **Flink SQL CR constraints and preview-adoption ADR** ([#326](https://github.com/osowski/confluent-platform-gitops/issues/326)): `architecture.md` is now the canonical reference for the Flink SQL dependency chain, its sync-wave scheme, and the constraints that are not validated by CFK — notably the three-way secret naming rule and the status fields that cannot be used as health signals; [ADR-0010](../adrs/0010-adopt-cfk-preview-flink-sql-crds.md) records the decision to adopt preview CRDs. Part of [#318](https://github.com/osowski/confluent-platform-gitops/issues/318).
+
 ### Changed
 - **flink-resources-rbac — Flink SQL resources now declarative** ([#322](https://github.com/osowski/confluent-platform-gitops/issues/322)): the two 744-line `sql-init` PostSync hook Jobs and their JSON ConfigMaps are replaced by 20 CFK 3.3 custom resources, so catalogs, databases, compute pools, and statements are visible, diffable, and prunable in ArgoCD. Schema Registry now authenticates with `OAUTHBEARER` and CMF-managed token refresh, retiring the `STATIC_TOKEN` that had to be re-minted on every sync. Part of [#318](https://github.com/osowski/confluent-platform-gitops/issues/318).
 

--- a/workloads/flink-resources-rbac/README.md
+++ b/workloads/flink-resources-rbac/README.md
@@ -120,8 +120,9 @@ demonstrating JAR/SQL parity. It does **not** write to the JAR output topics (`s
 1. The statement is a declarative `FlinkStatement` CR in `base/flink-statements.yaml`, reconciled
    into CMF by CFK. Its SQL is **immutable once running** — a CEL rule on the CRD rejects any
    update that changes `spec.statement`, so editing it in Git fails the sync permanently. Add a
-   versioned CR (`shapes-sql-enrich-v2`) instead; see the file header for why
-   `Force=true,Replace=true` is the worse option.
+   versioned CR (`shapes-sql-enrich-v2`) instead. See
+   [architecture.md](../../docs/architecture.md#changing-the-sql-of-a-running-flinkstatement)
+   for that rule and the rest of the Flink SQL CR constraints.
 2. The statement reads the inferred `shapes-input` table, adds an `encoded` column (mirroring the
    JAR enrichment), and writes `ProcessedSensorEvent` records to `shapes-sql-output`. The Kafka
    tables are auto-inferred from the registered SR schemas; an explicit `INSERT` column list


### PR DESCRIPTION
Closes [#326](https://github.com/osowski/confluent-platform-gitops/issues/326) · Part of [#318](https://github.com/osowski/confluent-platform-gitops/issues/318)

Documentation only — no manifest or cluster changes. Consolidates what #319–#322 turned up into the canonical location, and records the adoption decision.

## Constraints added to `architecture.md`

Several of these are absent from the CFK documentation and were found only by running the chain against a live cluster:

- **The three-way naming rule.** The `FlinkSecret`, its `FlinkEnvironmentSecretMapping`, and the `connectionSecretId`/`connectionSecretRef` referencing them must share **one identical name**. Two independent mechanisms enforce it: CMF keys an environment's secrets by mapping name and silently ignores an unmapped catalog; CFK separately resolves `connectionSecretId` to a `FlinkSecret` resource and fails with `flinksecret "<id>" not found in namespace`. The docs state only the first half — the previous table row in this file did too, and was wrong.
- **`FlinkApplication` must be waved after `FlinkEnvironment`.** Unwaved they race and CFK reports `FlinkEnvironment "<env>" not found`. Harmless before health checks existed, a hard sync failure after.
- **Renaming a `FlinkSecret` on a live cluster deadlocks.** CMF refuses to delete a secret an environment still maps; the mapping that would release it is in a later wave that never runs. Fresh clusters never hit it.
- **The full sync-wave scheme** for both `flink-resources-rbac` (5 / 10–70 / 80) and `cp-flink-sql-sandbox` (30–50), in one table.
- **Status fields that cannot serve as health signals** — already added in #322, now sitting alongside the rest rather than alone.

I also dropped a temporal opener ("replacing the ArgoCD hook Jobs that previously drove...") — this is a long-lived doc describing current state.

## ADR-0010

Records adopting CRDs that Confluent documents as **preview** ("Do not use preview features in production"). The reasoning: every cluster here is a demo or reference environment with no production traffic or availability commitment, and against that the imperative Jobs were the larger practical risk — untracked, unpruneable, and existing largely to service their own `STATIC_TOKEN` refresh loop.

Also covers the rollback path (Jobs are gone from the tree, not from history; the CMF REST API they used is unchanged) and the version floor this commits to (CFK 3.3.0+, CMF 2.3.0+, a matching `cp-flink-sql` image).

## Cross-references, not duplication

Per the repo's documentation principles, `architecture.md` is canonical. The `flink-resources-rbac` README now points there for statement immutability rather than at a manifest header; `cp-flink-sql-sandbox`'s README already did. ADR-0010 is linked from the Flink SQL section, matching how 0002/0008/0009 are referenced.

Verified all internal anchors and relative ADR links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
