### PR TITLE
Fix eks-demo node registration when an AZ is at its NAT gateway quota

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **eks-demo nodes now register when an AZ is at its NAT gateway quota** ([#333](https://github.com/osowski/confluent-platform-gitops/issues/333)): new `nat_gateway_az` variable steers the single NAT gateway to an AZ with headroom, so `CreateNatGateway` no longer fails and strands the private subnets without a default route. Added the `ec2` interface VPC endpoint that AL2023 `nodeadm` needs before kubelet starts — without it nodes boot healthy in EC2 but never join the cluster.
+
 ### Added
 - **flink-demo-rbac-mtls — Flink SQL CR chain and CMF secret encryption** ([#323](https://github.com/osowski/confluent-platform-gitops/issues/323)): the shared `flink-resources-rbac` CR chain is now verified on the mTLS cluster, with `encryption.enabled: true` and a valid 32-byte key brought over from [#321](https://github.com/osowski/confluent-platform-gitops/issues/321). Part of [#318](https://github.com/osowski/confluent-platform-gitops/issues/318).
 

--- a/terraform/clusters/eks-demo/README.md
+++ b/terraform/clusters/eks-demo/README.md
@@ -48,8 +48,8 @@ After migration, the `terraform/eks-demo/` directory can be removed from the rep
 | Resource group | Description |
 |----------------|-------------|
 | VPC | `/16` CIDR, 3 private `/20` + 3 public `/24` subnets across 3 AZs |
-| NAT Gateway | Single NAT gateway for private subnet egress |
-| VPC Interface Endpoints | SSM, SSMMessages, EC2Messages, ECR API, ECR DKR, EKS, STS, CloudWatch Logs |
+| NAT Gateway | Single NAT gateway for private subnet egress — AZ selectable via `nat_gateway_az` |
+| VPC Interface Endpoints | SSM, SSMMessages, EC2Messages, EC2, ECR API, ECR DKR, EKS, STS, CloudWatch Logs |
 | VPC Gateway Endpoint | S3 (ECR image layer pulls) |
 | EKS Control Plane | Kubernetes 1.32, private-only API endpoint |
 | Managed Node Group | `workers-v2`: t3.2xlarge, 4–6 nodes, AL2023, 100 GiB gp3 root volume |
@@ -156,6 +156,42 @@ terraform destroy
 ```
 
 The `default` security group is deleted automatically when the VPC itself is removed; don't delete it manually.
+
+### Troubleshooting: node group stuck at 0 registered nodes
+
+Symptom: the node group sits in `CREATING` with `health.issues` empty, while every instance shows `running` and healthy in the EC2 console. After roughly 25 minutes the node group fails with `NodeCreationFailure`.
+
+The usual cause is that the private subnets have no route out. AL2023 `nodeadm` calls `ec2:DescribeInstances` during init, before kubelet starts — with no egress it retries forever, so the instance boots normally but never registers.
+
+**1. Check the private route table for a default route:**
+```bash
+aws ec2 describe-route-tables --filters "Name=vpc-id,Values=<vpc-id>" \
+  --query 'RouteTables[?Tags[?Value==`eks-demo-private`]].Routes' --output table
+```
+A healthy table has `0.0.0.0/0` pointing at a NAT gateway. If it only has `local` and the S3 prefix list, the NAT gateway is missing.
+
+**2. Confirm on the instance itself** — `get-console-output` shows the retry loop directly:
+```bash
+aws ec2 get-console-output --instance-id <node-instance-id> --query Output --output text \
+  | grep -E 'nodeadm|DescribeInstances'
+```
+
+**3. Find why the NAT gateway wasn't created.** The most common reason is the per-AZ NAT gateway quota (`L-FE5A380F`, 20 by default). Terraform reports this at apply time, but the node group is created in parallel and buries it:
+```bash
+aws cloudtrail lookup-events --lookup-attributes AttributeKey=EventName,AttributeValue=CreateNatGateway \
+  --start-time <apply-start-time> --query 'Events[].CloudTrailEvent' --output text | grep -o 'errorMessage[^,]*'
+```
+
+**4. Remedy.** Count NAT gateways per AZ to find one with headroom:
+```bash
+aws ec2 describe-nat-gateways --filter Name=state,Values=available,pending \
+  --query 'NatGateways[].SubnetId' --output text | tr '\t' '\n' > /tmp/natsub.txt
+aws ec2 describe-subnets --subnet-ids $(tr '\n' ' ' < /tmp/natsub.txt) \
+  --query 'Subnets[].AvailabilityZone' --output text | tr '\t' '\n' | sort | uniq -c | sort -rn
+```
+Then set `nat_gateway_az` in `terraform.tfvars` to an AZ below quota and re-apply. Alternatively, request a quota increase for `L-FE5A380F`, or delete stale NAT gateways from abandoned demo VPCs in the crowded AZ.
+
+Note that the failed node group must be deleted before re-applying — EKS will not re-drive a node group out of `CREATING`.
 
 ## Adding a New Cluster
 

--- a/terraform/clusters/eks-demo/main.tf
+++ b/terraform/clusters/eks-demo/main.tf
@@ -38,12 +38,13 @@ provider "aws" {
 module "eks_cluster" {
   source = "../../modules/eks-cluster"
 
-  aws_region         = var.aws_region
-  cluster_name       = var.cluster_name
-  kubernetes_version = var.kubernetes_version
-  platform_zone_id   = var.platform_zone_id
-  platform_domain    = var.platform_domain
-  vpc_cidr           = var.vpc_cidr
+  aws_region            = var.aws_region
+  cluster_name          = var.cluster_name
+  kubernetes_version    = var.kubernetes_version
+  platform_zone_id      = var.platform_zone_id
+  platform_domain       = var.platform_domain
+  vpc_cidr              = var.vpc_cidr
+  nat_gateway_az        = var.nat_gateway_az
   node_instance_type    = var.node_instance_type
   node_desired_size     = var.node_desired_size
   node_min_size         = var.node_min_size

--- a/terraform/clusters/eks-demo/terraform.tfvars.example
+++ b/terraform/clusters/eks-demo/terraform.tfvars.example
@@ -4,6 +4,8 @@ kubernetes_version = "1.35"
 platform_zone_id   = "<output from dns-bootstrap: platform_zone_id>"
 platform_domain    = "platform.dspdemos.com"
 vpc_cidr           = "10.0.0.0/16"
+# Uncomment to move the NAT gateway off an AZ that is at its per-AZ quota
+# nat_gateway_az   = "us-east-1b"
 node_instance_type = "t3.2xlarge"
 node_desired_size  = 4
 node_min_size      = 4

--- a/terraform/clusters/eks-demo/variables.tf
+++ b/terraform/clusters/eks-demo/variables.tf
@@ -33,6 +33,12 @@ variable "vpc_cidr" {
   default     = "10.0.0.0/16"
 }
 
+variable "nat_gateway_az" {
+  description = "Availability zone to place the single NAT gateway in. Leave unset to use the first endpoint-capable AZ in the region; set it when that AZ is at its NAT gateway quota (L-FE5A380F, 20 per AZ)."
+  type        = string
+  default     = null
+}
+
 variable "node_instance_type" {
   description = "EC2 instance type for EKS managed node group workers"
   type        = string

--- a/terraform/modules/eks-cluster/bastion.tf
+++ b/terraform/modules/eks-cluster/bastion.tf
@@ -87,7 +87,7 @@ resource "aws_instance" "bastion" {
   # The bastion is a dumb SOCKS5 relay — operators tunnel through it via SSM
   # port-forwarding and authenticate to EKS using their local AWS credentials.
   # Do not run kubectl or AWS CLI on the bastion itself.
-  user_data_base64            = base64encode(templatefile("${path.module}/scripts/bastion-init.sh", {
+  user_data_base64 = base64encode(templatefile("${path.module}/scripts/bastion-init.sh", {
     infra_binaries_bucket = var.infra_binaries_bucket
     proxy_version         = var.proxy_version
   }))

--- a/terraform/modules/eks-cluster/eks.tf
+++ b/terraform/modules/eks-cluster/eks.tf
@@ -67,16 +67,6 @@ module "eks" {
   }
 
   tags = var.common_tags
-
-  # Do not add depends_on here to order the node group behind module.vpc or the
-  # VPC endpoints. A module-level depends_on defers this module's internal data
-  # sources to apply time, and the upstream eks-managed-node-group submodule sizes
-  # count off data.aws_partition / data.aws_caller_identity — so every plan fails
-  # with "Invalid count argument". The node group is therefore created in parallel
-  # with the VPC egress path: if the NAT gateway fails, nodes boot without a route
-  # out, nodeadm blocks on ec2:DescribeInstances, and the node group times out after
-  # ~25 minutes rather than failing fast. See the eks-demo README troubleshooting
-  # section for how to recognize and unstick that case.
 }
 
 # Allow the bastion's SOCKS5 proxy to reach the private EKS API endpoint.

--- a/terraform/modules/eks-cluster/eks.tf
+++ b/terraform/modules/eks-cluster/eks.tf
@@ -67,6 +67,16 @@ module "eks" {
   }
 
   tags = var.common_tags
+
+  # Do not add depends_on here to order the node group behind module.vpc or the
+  # VPC endpoints. A module-level depends_on defers this module's internal data
+  # sources to apply time, and the upstream eks-managed-node-group submodule sizes
+  # count off data.aws_partition / data.aws_caller_identity — so every plan fails
+  # with "Invalid count argument". The node group is therefore created in parallel
+  # with the VPC egress path: if the NAT gateway fails, nodes boot without a route
+  # out, nodeadm blocks on ec2:DescribeInstances, and the node group times out after
+  # ~25 minutes rather than failing fast. See the eks-demo README troubleshooting
+  # section for how to recognize and unstick that case.
 }
 
 # Allow the bastion's SOCKS5 proxy to reach the private EKS API endpoint.

--- a/terraform/modules/eks-cluster/main.tf
+++ b/terraform/modules/eks-cluster/main.tf
@@ -1,11 +1,33 @@
 locals {
   # Filter to AZs that support Interface VPC endpoint services.
   # In us-east-1, us-east-1e is "available" but lacks endpoint service and NAT Gateway support.
-  azs = slice(
+  candidate_azs = slice(
     [for az in data.aws_availability_zones.available.names :
     az if contains(data.aws_vpc_endpoint_service.ssm.availability_zones, az)],
     0, 3
   )
+
+  # The VPC module places the single NAT gateway in public_subnets[0], so whichever
+  # AZ sorts first here decides where the NAT lands. NAT gateways are quota-limited
+  # per AZ (L-FE5A380F, 20 by default); if that AZ is at quota, CreateNatGateway
+  # returns Client.NatGatewayLimitExceeded and the private route table is left with
+  # no default route — nodes then boot but never register. Set nat_gateway_az to
+  # steer the NAT to an AZ with headroom.
+  azs = var.nat_gateway_az == null ? local.candidate_azs : concat(
+    [var.nat_gateway_az],
+    [for az in local.candidate_azs : az if az != var.nat_gateway_az]
+  )
+}
+
+# Guard against nat_gateway_az naming an AZ outside candidate_azs, which would
+# otherwise silently widen the VPC to four AZs instead of erroring.
+resource "terraform_data" "nat_gateway_az_validation" {
+  lifecycle {
+    precondition {
+      condition     = var.nat_gateway_az == null ? true : contains(local.candidate_azs, var.nat_gateway_az)
+      error_message = "nat_gateway_az must be one of the endpoint-capable AZs selected for this VPC: ${join(", ", local.candidate_azs)}."
+    }
+  }
 }
 
 data "aws_availability_zones" "available" {

--- a/terraform/modules/eks-cluster/variables.tf
+++ b/terraform/modules/eks-cluster/variables.tf
@@ -28,6 +28,12 @@ variable "vpc_cidr" {
   type        = string
 }
 
+variable "nat_gateway_az" {
+  description = "Availability zone to place the single NAT gateway in. Defaults to the first endpoint-capable AZ in the region. Set this when that AZ is at its NAT gateway quota (L-FE5A380F, 20 per AZ) — CreateNatGateway fails there and leaves the private subnets without a default route."
+  type        = string
+  default     = null
+}
+
 variable "node_instance_type" {
   description = "EC2 instance type for EKS managed node group workers"
   type        = string

--- a/terraform/modules/eks-cluster/vpc.tf
+++ b/terraform/modules/eks-cluster/vpc.tf
@@ -5,11 +5,11 @@ module "vpc" {
   name = var.cluster_name
   cidr = var.vpc_cidr
 
-  azs             = local.azs
+  azs = local.azs
   # /20 private subnets — sized for EKS node pools (4096 addresses each)
   private_subnets = [for i, az in local.azs : cidrsubnet(var.vpc_cidr, 4, i)]
   # /24 public subnets — NAT gateway only, minimal address space needed
-  public_subnets  = [for i, az in local.azs : cidrsubnet(var.vpc_cidr, 8, i + 48)]
+  public_subnets = [for i, az in local.azs : cidrsubnet(var.vpc_cidr, 8, i + 48)]
 
   enable_nat_gateway   = true
   single_nat_gateway   = true
@@ -88,7 +88,22 @@ resource "aws_vpc_endpoint" "ec2messages" {
 }
 
 # ── EKS node endpoints — required for private-endpoint-only cluster ───────────
-# Without these, nodes cannot pull images or reach the EKS API and will never join.
+# These cover the AWS APIs a node touches during bootstrap and image pull. They do
+# not replace the NAT gateway: images hosted outside ECR (quay.io, docker.io,
+# ghcr.io) still need egress through it.
+
+# AL2023 nodeadm calls ec2:DescribeInstances during init, before kubelet starts.
+# Without a reachable EC2 API the call retries indefinitely, so the instance boots
+# and looks healthy in the EC2 console while the node never registers with EKS.
+resource "aws_vpc_endpoint" "ec2" {
+  vpc_id              = module.vpc.vpc_id
+  service_name        = "com.amazonaws.${var.aws_region}.ec2"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = module.vpc.private_subnets
+  security_group_ids  = [aws_security_group.vpc_endpoints.id]
+  private_dns_enabled = true
+  tags                = merge(var.common_tags, { Name = "${var.cluster_name}-ec2" })
+}
 
 resource "aws_vpc_endpoint" "ecr_api" {
   vpc_id              = module.vpc.vpc_id


### PR DESCRIPTION
Closes [#333](https://github.com/osowski/confluent-platform-gitops/issues/333).

## What happened

The `eks-demo` node group sat in `CREATING` with 0 registered nodes for 25+ minutes while all four EC2 instances showed `running` and healthy in the console.

`CreateNatGateway` had failed at the start of the apply:

```
2026-08-09T15:41:20-05:00  CreateNatGateway  Client.NatGatewayLimitExceeded
"Performing this operation would exceed the limit of 20 NAT gateways"
```

`single_nat_gateway = true` places the NAT in `public_subnets[0]`, which `local.azs` resolved to **us-east-1a** — the one AZ already at its per-AZ quota (`L-FE5A380F`) with 20 in use, against 9 in us-east-1b and 10 in us-east-1c. The private route table was left with only `local` and the S3 prefix list, and no `0.0.0.0/0`.

With no egress, AL2023 `nodeadm` blocks on `ec2:DescribeInstances` during init, before kubelet starts:

```
nodeadm[2715]: info init/init.go:172 Fetching instance details..
nodeadm[2715]: SDK DEBUG retrying request EC2/DescribeInstances, attempt 2
... attempts 3-9, still retrying
```

So the instance boots fine, the node never registers, and the node group hangs until the ~25 minute join timeout. IAM was fine (`AmazonEKSWorkerNodePolicy` grants `ec2:DescribeInstances`) and so were the security groups.

## What changed

**`nat_gateway_az` variable** — rotates `local.azs` so the chosen AZ sorts first, which is what decides where `single_nat_gateway` lands. Unset keeps today’s behavior exactly. A `terraform_data` precondition rejects an AZ outside the endpoint-capable set, which would otherwise silently widen the VPC to four AZs.

**`ec2` interface VPC endpoint** — the endpoint list claimed to cover everything a node needs to join but omitted the one endpoint `nodeadm` blocks on. The comment above the block is corrected too: these endpoints do *not* replace the NAT gateway, since ArgoCD, cert-manager, and Confluent images pull from quay.io/docker.io/ghcr.io.

**README troubleshooting section** — symptom, the three commands that identify it (route table, `get-console-output`, CloudTrail), and how to count NAT gateways per AZ to pick a target.

## On the `depends_on` from the issue

Ordering `module.eks` behind `module.vpc` and the endpoints was implemented and then reverted — a module-level `depends_on` defers the module’s internal data sources to apply time, and the upstream `eks-managed-node-group` submodule sizes `count` off `data.aws_partition` / `data.aws_caller_identity`, so every plan fails with `Invalid count argument`. The node group therefore still races the VPC egress path; the README troubleshooting section covers recognizing the result.

`bastion.tf` has a one-line whitespace change from `terraform fmt` — pre-existing drift, unrelated.

## Verification

Planned against an isolated empty state with real credentials:

| `nat_gateway_az` | `public_subnets[0]` AZ | Result |
|---|---|---|
| unset | us-east-1a | exit 0, matches current behavior |
| `us-east-1c` | us-east-1c | exit 0, NAT moves as intended |
| `us-east-1z` | — | exit 1, `Resource precondition failed` |

`aws_vpc_endpoint.ec2` → `com.amazonaws.us-east-1.ec2` confirmed present in the plan. `terraform validate` and `terraform fmt -check -recursive` both pass.

## Follow-up not in this PR

The stuck node group `workers-v2-93bddb64a5c56590f1cb3f7da1` must be deleted before re-applying — EKS will not re-drive a node group out of `CREATING`. The orphaned EIP `eipalloc-0d97566b5c2a845c0` is also still allocated and unassociated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
