### PR TITLE
Pin eks-demo producers to the Avro-capable amd64 image (#338)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **eks-demo producers now emit Avro, unblocking the Flink SQL statements** ([#338](https://github.com/osowski/confluent-platform-gitops/issues/338)): the pinned amd64 producer image was built without the Avro serializer and wrote plain JSON, so every statement restart-looped on `Unknown magic byte!` while the JAR pipeline (which does its own parsing) looked healthy. Now pins `v0.2.1-avro-amd64`; verified end-to-end on eks-demo with 8k+ records and zero deserialization errors.
+
+### Fixed
 - **eks-demo nodes now register when an AZ is at its NAT gateway quota** ([#333](https://github.com/osowski/confluent-platform-gitops/issues/333)): new `nat_gateway_az` variable steers the single NAT gateway to an AZ with headroom, so `CreateNatGateway` no longer fails and strands the private subnets without a default route. Added the `ec2` interface VPC endpoint that AL2023 `nodeadm` needs before kubelet starts — without it nodes boot healthy in EC2 but never join the cluster.
 
 ### Added

--- a/workloads/flink-resources-rbac/README.md
+++ b/workloads/flink-resources-rbac/README.md
@@ -141,6 +141,14 @@ kubectl -n kafka exec -it <kafka-pod> -- kafka-avro-console-consumer \
   --topic shapes-sql-output --from-beginning --max-messages 5 ...
 ```
 
+> **Producer wire format:** the inferred input tables are `value.format = 'avro-registry'` with
+> `scan.startup.mode = 'earliest-offset'`, so the statement re-reads from offset 0 on every
+> (re)start and a single record lacking the Confluent wire prefix (magic byte `0x00` + 4-byte
+> schema ID) fails the job permanently — not just for the bad record. The producer image tag must
+> therefore be an Avro build, and if a non-Avro producer has ever written to an input topic, purge
+> the topic (delete and re-create the `KafkaTopic` CR) **before** scaling a producer back up.
+> Confirm with the producer's own log line: `first 15 bytes: [0, 0, 0, 0, 1, ...]`.
+
 > **Versions:** requires CMF chart **2.3.1+** (2.3.0 ships incorrectly built SQL jars). The
 > Flink SQL compute-pool image tracks the latest `confluentinc/cp-flink-sql` tag independently
 > (`1.19-cp8` at time of writing — verify with `skopeo list-tags docker://confluentinc/cp-flink-sql`).

--- a/workloads/flink-resources-rbac/overlays/eks-demo/producer-image-patch.yaml
+++ b/workloads/flink-resources-rbac/overlays/eks-demo/producer-image-patch.yaml
@@ -1,6 +1,13 @@
 # Override producer image for eks-demo (amd64 EKS nodes)
 # Base image is arm64-only; this patch pins the amd64-specific build until
 # multi-arch CI/CD is set up in flink-sandbox (osowski/flink-sandbox#6)
+#
+# The tag must be an Avro build: the catalog-inferred input tables use
+# value.format = 'avro-registry', so a producer writing anything without the
+# Confluent wire prefix wedges every Flink SQL statement on "Unknown magic byte!".
+# Verify before bumping:
+#   docker run --rm --platform linux/amd64 --entrypoint sh <image> \
+#     -c 'ls schemas/ && pip list | grep -i fastavro'
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -12,7 +19,7 @@ spec:
     spec:
       containers:
         - name: producer
-          image: quay.io/osowski/kafka-producer:v0.2.0-avro-amd64
+          image: quay.io/osowski/kafka-producer:v0.2.1-avro-amd64
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -24,4 +31,4 @@ spec:
     spec:
       containers:
         - name: producer
-          image: quay.io/osowski/kafka-producer:v0.2.0-avro-amd64
+          image: quay.io/osowski/kafka-producer:v0.2.1-avro-amd64


### PR DESCRIPTION
Fixes [#338](https://github.com/osowski/confluent-platform-gitops/issues/338).

## What

Bump both producer pins in `workloads/flink-resources-rbac/overlays/eks-demo/producer-image-patch.yaml` from `v0.2.0-avro-amd64` to `v0.2.1-avro-amd64`, and document the wire-format constraint that makes the pin load-bearing.

## Why

The `-avro-amd64` tag was a misnomer. It was hand-built from a source tree that never contained the Avro serializer — that code lives on an unmerged branch upstream — so both eks-demo producers wrote plain JSON. Since the catalog-inferred input tables are `value.format = 'avro-registry'`, every Flink SQL statement failed on `Unknown magic byte!`, while the JAR `FlinkApplication` reading the same topic parses records itself and kept reporting healthy. That asymmetry is what made the issue look cluster-specific rather than producer-specific.

The image contents were confirmed directly, not inferred:

| Check | `v0.2.0-avro-amd64` (old) | `v0.2.1-avro-amd64` (new) |
|---|---|---|
| `/app/schemas/*.avsc` | absent | present |
| `fastavro` | not installed | `1.12.2` |
| `AvroSerializer` in `producer.py` | 0 references | 4 references |
| `json.dumps` serialization | lines 187, 217 | none |

## Verified on eks-demo

- Producer logs its own wire prefix: `first 15 bytes: [0, 0, 0, 0, 1, ...]` — magic byte `0x00` + schema ID 1.
- `shapes-input` consumed independently from offset 0 of all three partitions: first-byte histogram `{0: 60}`, schema-id histogram `{1: 60}`, Avro decode 60/60, zero JSON records.
- `shapes-sql-enrich` job `RUNNING`, **25 checkpoints** completed, **0** restarts, **0** occurrences of `magic byte`/`SerializationException`/`malformed`.
- Throughput parity, measured back-to-back: input 8,096 → output 8,141, lag ≈ 0.
- Output enrichment correct: `encoded = aHVtaWRpdHktc2Vuc29yLUM=` decodes to `humidity-sensor-C`, matching `TO_BASE64(ENCODE(CONCAT(type, '-', location)))`.
- Schema Registry unchanged by the producer's auto-register: `shapes-input-value` still `versions=[1] id=1`, so the declarative `Schema` CR remains authoritative.

## Operational note for whoever syncs this

Because the inferred tables use `scan.startup.mode = 'earliest-offset'`, a statement re-reads from offset 0 on every restart — so a single non-Avro record wedges the job permanently, not just that record. Any input topic a JSON producer has written to must be purged (delete and re-create the `KafkaTopic` CR) **before** a producer is scaled back up. `shapes-input` and `colors-input` were both re-created during this investigation and `colors-input` is currently empty, so the colors path will come up clean.

This also unblocks syncing `Deployment/shapes-producer`, which was `OutOfSync` on both image and replica count; before this change, syncing it would have rolled the live producer back to the JSON build.

## Checklist

- [x] Reviewed [Code Review Checklist](https://github.com/osowski/confluent-platform-gitops/blob/main/docs/code_review_checklist.md)
- [x] `kubectl kustomize` clean for all three `flink-resources-rbac` overlays; rendered output confirms both producers on the new tag
- [x] Pinned tag exists on quay (`sha256:23f8566…`, `amd64/linux`)
- [x] No residual `v0.2.0-avro-amd64` references in the repo
- [x] `docs/changelog.md` updated; no secrets added or modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)