### PR TITLE
Quote whole-CPU-multiple cpu values across all clusters' confluent-resources overlays

### DIFF
--- a/workloads/confluent-resources/overlays/flink-demo-rbac-mtls/connect-patch.yaml
+++ b/workloads/confluent-resources/overlays/flink-demo-rbac-mtls/connect-patch.yaml
@@ -9,8 +9,8 @@ spec:
   podTemplate:
     resources:
       requests:
-        cpu: 1000m
+        cpu: "1"
         memory: 1Gi
       limits:
-        cpu: 2000m
+        cpu: "2"
         memory: 2Gi

--- a/workloads/confluent-resources/overlays/flink-demo-rbac-mtls/ksqldb-patch.yaml
+++ b/workloads/confluent-resources/overlays/flink-demo-rbac-mtls/ksqldb-patch.yaml
@@ -13,7 +13,7 @@ spec:
         cpu: 500m
         memory: 1Gi
       limits:
-        cpu: 1000m
+        cpu: "1"
         memory: 2Gi
 
   # JVM heap tuning to prevent excessive memory consumption

--- a/workloads/confluent-resources/overlays/flink-demo-rbac/connect-patch.yaml
+++ b/workloads/confluent-resources/overlays/flink-demo-rbac/connect-patch.yaml
@@ -9,8 +9,8 @@ spec:
   podTemplate:
     resources:
       requests:
-        cpu: 1000m
+        cpu: "1"
         memory: 1Gi
       limits:
-        cpu: 2000m
+        cpu: "2"
         memory: 2Gi

--- a/workloads/confluent-resources/overlays/flink-demo-rbac/ksqldb-patch.yaml
+++ b/workloads/confluent-resources/overlays/flink-demo-rbac/ksqldb-patch.yaml
@@ -13,7 +13,7 @@ spec:
         cpu: 500m
         memory: 1Gi
       limits:
-        cpu: 1000m
+        cpu: "1"
         memory: 2Gi
 
   # JVM heap tuning to prevent excessive memory consumption


### PR DESCRIPTION
## What

Quotes the exact-multiple-of-1000m `cpu` values as their canonical decimal-core string (`"1"`, `"2"`) in:

- `workloads/confluent-resources/overlays/flink-demo-rbac/connect-patch.yaml`
- `workloads/confluent-resources/overlays/flink-demo-rbac/ksqldb-patch.yaml`
- `workloads/confluent-resources/overlays/flink-demo-rbac-mtls/connect-patch.yaml`
- `workloads/confluent-resources/overlays/flink-demo-rbac-mtls/ksqldb-patch.yaml`

`eks-demo` is not affected (its values aren't exact multiples of 1000m). Already fixed on `flink-demo` in #351.

## Why

Closes #352. Kubernetes canonicalizes a `resource.Quantity` that's an exact multiple of `1000m` to its decimal-core form when the API server echoes it back, so an unquoted millicpu value in git never matches the live object's string — ArgoCD reports the resource permanently `OutOfSync` for a cosmetic reason, which makes the `OutOfSync` signal noisy and hides genuine drift.

## Validation

Repo-wide grep for `cpu: [0-9]*000m` after this change turns up only `workloads/ollama` and `workloads/keycloak` base charts — out of scope for this issue (not `confluent-resources` overlays), left untouched.

Once merged, verify each cluster:
```bash
kubectl get application confluent-resources -n argocd -o jsonpath='{range .status.resources[*]}{.kind}/{.name}:{.status}{"\n"}{end}'
```
Connect/KsqlDB should show `Synced`, not `OutOfSync`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)