### PR TITLE
Simplify live-test docs: retarget on the feature branch itself, no separate chore branch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,8 +89,8 @@ Only load task-specific docs when needed. This file is intentionally concise —
    - Follow guidance and formatting from https://adr.github.io/ for structure of ADRs.
 - **Live-testing an unmerged branch on a cluster MUST follow [Live-Testing an Unmerged Branch on a Cluster](./docs/bootstrap-procedure.md#live-testing-an-unmerged-branch-on-a-cluster).**
    - Always retarget via `./scripts/update-target-revision.sh` — never hand-edit a `targetRevision` field.
-   - Every `targetRevision` change, including reverting a live-test pin back to `HEAD`, goes through a feature branch and PR like any other change. There is no direct-to-`main` exception.
-   - Never `kubectl edit`/`kubectl patch` a live resource, or manually force an ArgoCD sync, to "test a change faster." Automated sync already triggers on a targetRevision change; manual drift gets silently reverted on the next reconciliation pass.
+   - Run it once, directly on the feature branch under test, and push it there — `bootstrap.yaml` is applied locally, not reconciled from `main`, so there is no separate branch/PR needed just to point a cluster at a feature branch. Revert the same way, on the same branch, before merging.
+   - Some Applications are deliberately manual-sync (no `automated` policy) — triggering their sync via `kubectl patch application ... sync` is the sanctioned way those apps ever sync. For everything else, don't fight ArgoCD's automated sync with a manual `kubectl edit`/`kubectl patch`/force-sync — a targetRevision change already triggers it; manual drift gets silently reverted on the next reconciliation pass.
 
 ### Security - MUST FOLLOW
 

--- a/docs/bootstrap-procedure.md
+++ b/docs/bootstrap-procedure.md
@@ -374,24 +374,33 @@ For the full version pinning workflow, see [Release Process](release-process.md)
 To validate an unmerged feature branch against a real cluster before merging its PR:
 
 1. **Push the feature branch first.** ArgoCD reads from the remote, not your local checkout.
-2. **Always use `./scripts/update-target-revision.sh <cluster> <branch> --yes`** — never hand-edit a `targetRevision` field. The script updates every Application manifest under `clusters/<cluster>/` uniformly and verifies the result; a manual edit is easy to get inconsistent across the ~25 files a cluster has, and misses new files (see the script's own new-file warning).
-3. **Commit the result on a small branch of its own** (e.g. `chore-<issue-id>/point-<cluster>-at-<branch>`) **and open a PR into `main` like any other change.** There is no direct-to-`main` exception for `targetRevision` pinning, even though it's temporary and reverted before merge (step 7) — merge that PR, then continue.
-4. **Re-apply `bootstrap.yaml` to the live cluster twice**, since its ArgoCD Application object was `kubectl apply`'d once at cluster creation and does not self-heal from git:
+2. **Retarget the cluster on the feature branch itself** — `bootstrap.yaml`'s live Application object is `kubectl apply`'d locally, not reconciled from `main`, so nothing needs to be merged into `main` just to point a cluster at a feature branch:
+   ```bash
+   ./scripts/update-target-revision.sh <cluster> <branch> --yes
+   git commit -am "chore: point <cluster> Applications at this branch for live testing"
+   git push
+   ```
+   Run this **once**, directly on the branch under test, and push it there (this is fine — it's already a feature branch, not `main`). The script updates every Application manifest under `clusters/<cluster>/` uniformly, including `bootstrap.yaml` itself; a manual edit is easy to get inconsistent across the ~25 files a cluster has, and misses new files (see the script's own new-file warning). Because `bootstrap.yaml`'s own retarget is part of this same commit, there's no separate "which parent-app tree does ArgoCD read from" gotcha to chase — the whole cluster reads from this one branch from here on.
+3. **Apply that branch's `bootstrap.yaml` to the live cluster twice**, since its ArgoCD Application object was `kubectl apply`'d once at cluster creation and does not self-heal from git:
    ```bash
    kubectl apply -f clusters/<cluster>/bootstrap.yaml
    kubectl apply -f clusters/<cluster>/bootstrap.yaml   # first apply can silently no-op; confirm the second reports "configured"
    ```
-5. **Critical gotcha:** once `bootstrap.yaml` itself points at the feature branch, the `workloads`/`infrastructure` parent Applications start rendering their *child* Application manifest list **from that branch**, not from `main`. Any Application file the branch touches (or that `bootstrap` must read fresh from it, like a brand-new Application) needs the **same** `update-target-revision.sh <cluster> <branch> --yes` run again — this time from a checkout of the feature branch itself, committed and pushed directly to it (this is fine — it's already a feature branch, not `main`). Skipping this makes the `main`-branch retarget invisible: the feature branch's own un-retargeted copy (still `targetRevision: HEAD`) is what actually gets applied. Run `git diff main --stat` on the branch to see which Application files need this.
-6. **Let ArgoCD's automated sync do the work — do not fight it.** Every workload Application here has `syncPolicy.automated` set (even where `selfHeal: false`), and a `targetRevision` change is exactly the condition that triggers automated sync on its own. Do **not** `kubectl edit`/`kubectl patch` a live resource (ConfigMap, Deployment, etc.) to "test faster," and do not manually `kubectl patch application ... sync` to force a sync — manual drift gets silently reverted on the next reconciliation pass (typically within a few minutes), wasting time and producing confusing "my change disappeared" symptoms. Just poll status instead:
+4. **Some Applications are deliberately manual-sync** (no `syncPolicy.automated` at all — e.g. `confluent-resources` and `flink-resources` on the RBAC clusters, to avoid an in-place mTLS/auth transition wedging the KRaft quorum). These need an explicit sync trigger; this is the sanctioned way those apps ever sync, not "fighting" anything:
+   ```bash
+   kubectl patch application <app> -n argocd --type merge -p '{"operation":{"sync":{"syncStrategy":{"hook":{}}}}}'
+   ```
+5. **For everything else, let ArgoCD's automated sync do the work — do not fight it.** Those Applications have `syncPolicy.automated` set (even where `selfHeal: false`), and a `targetRevision` change is exactly the condition that triggers automated sync on its own. Do **not** `kubectl edit`/`kubectl patch` a live resource (ConfigMap, Deployment, etc.) to "test faster," and do not manually force-sync an app that already has automated sync — manual drift gets silently reverted on the next reconciliation pass (typically within a few minutes), wasting time and producing confusing "my change disappeared" symptoms. Just poll status instead:
    ```bash
    kubectl get application <app> -n argocd -o jsonpath='sync={.status.sync.status} health={.status.health.status} rev={.spec.sources[1].targetRevision}{"\n"}'
    ```
-7. **Revert everything to `HEAD` once validation is done** — both the `main`-side retarget from step 3 and any feature-branch commits from step 5 — again through the script and its own branch + PR, never a direct push:
+6. **Revert to `HEAD` once validation is done, on the same feature branch, before merging its PR:**
    ```bash
-   ./scripts/update-target-revision.sh <cluster> HEAD --yes   # on a branch off main, reverting step 3
-   ./scripts/update-target-revision.sh <cluster> HEAD --yes   # on the feature branch itself, if step 5 applied
+   ./scripts/update-target-revision.sh <cluster> HEAD --yes
+   git commit -am "chore: revert <cluster> targetRevision to HEAD before merge"
+   git push
    ```
-   Then re-apply `bootstrap.yaml` live (twice) to point the cluster back at `main`.
+   Re-apply `bootstrap.yaml` from `main` (twice) to point the cluster back. The feature branch's PR now merges normally — its own `targetRevision` fields are already back to `HEAD` by the time it lands.
 
 ## Upgrading Bootstrap
 


### PR DESCRIPTION
## What

Replaces the two-branch live-test flow from #361 (a chore branch off `main`, merged via its own PR, plus a self-pointing commit on the feature branch) with the simpler flow actually used live during #357: run `update-target-revision.sh` once, directly on the feature branch under test, push it there, and `kubectl apply` that branch's `bootstrap.yaml` locally.

Also clarifies that some Applications (`confluent-resources`, `flink-resources` on the RBAC clusters) are deliberately manual-sync by design — triggering their sync is the sanctioned way those apps ever sync, not an exception to "don't fight ArgoCD's reconciliation loop."

## Why

Closes #365. `bootstrap.yaml`'s live Application object is `kubectl apply`'d locally and isn't reconciled from `main`, so nothing ever needs to land on `main` just to point a cluster at a feature branch — the earlier docs had this backwards, adding a merge step that was never actually required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)