### PR TITLE
Fix stale ingress Application names/waves in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,16 +120,16 @@ confluent-platform-gitops/
 ├── infrastructure/                 # Platform infrastructure components
 │   ├── argocd/                     # Argo CD self-management (Helm)
 │   ├── argocd-config/              # Argo CD ConfigMap patches (custom health checks)
-│   ├── argocd-ingress/             # Traefik IngressRoute for Argo CD UI
 │   ├── cert-manager/               # TLS certificate management (Helm)
 │   ├── cert-manager-resources/     # ClusterIssuer and Certificate resources
+│   ├── headlamp/                   # Kubernetes dashboard (Helm)
+│   ├── ingresses/                  # Traefik IngressRoutes for ArgoCD, Vault, Headlamp UIs
 │   ├── kube-prometheus-stack/      # Monitoring stack (Helm)
 │   ├── kube-prometheus-stack-crds/ # Prometheus Operator CRDs (Helm)
 │   ├── traefik/                    # Ingress controller (Helm)
 │   ├── trust-manager/              # cert-manager trust distribution (Helm)
 │   ├── vault/                      # HashiCorp Vault secrets management (Helm)
-│   ├── vault-config/               # Vault transit engine configuration
-│   └── vault-ingress/              # Traefik IngressRoute for Vault UI
+│   └── vault-config/               # Vault transit engine configuration
 ├── workloads/                      # User-facing applications and services
 │   ├── cfk-operator/               # Confluent for Kubernetes operator (Helm)
 │   ├── cmf-operator/               # Confluent Manager for Apache Flink (Helm)
@@ -210,16 +210,16 @@ confluent-platform-gitops/
 - **trust-manager** (wave 30) - cert-manager trust distribution for CA bundles
 - **external-secrets** (wave 30) - External Secrets Operator for syncing secrets from external providers
 - **vault** (wave 40) - HashiCorp Vault secrets management (dev mode)
-- **vault-ingress** (wave 45) - Traefik IngressRoute for Vault UI
 - **vault-config** (wave 50) - Vault transit engine configuration
+- **headlamp** (wave 50) - Kubernetes dashboard for cluster visibility
 - **cert-manager-resources** (wave 75) - Self-signed ClusterIssuer and certificates
-- **argocd-ingress** (wave 80) - Traefik IngressRoute for Argo CD UI
+- **infra-ingresses** (wave 80) - Traefik IngressRoutes for ArgoCD, Vault, and Headlamp UIs
 - **argocd-config** (wave 85) - Argo CD ConfigMap patches for custom health checks
 
 ### Workloads (Automated Sync)
 - **namespaces** (wave 100) - Namespace definitions (kafka, flink, operator)
 - **cfk-operator** (wave 105) - Confluent for Kubernetes (CFK) operator
-- **controlcenter-ingress** (wave 115) - Traefik IngressRoute for Confluent Control Center UI
+- **workload-ingresses** (wave 110) - Traefik IngressRoutes (CMF, Control Center, Schema Registry)
 - **flink-kubernetes-operator** (wave 116) - Flink Kubernetes Operator for stream processing
 - **observability-resources** (wave 117) - PodMonitors and Grafana dashboards
 - **cmf-operator** (wave 118) - Confluent Manager for Apache Flink (CMF)

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ confluent-platform-gitops/
 ### Workloads (Automated Sync)
 - **namespaces** (wave 100) - Namespace definitions (kafka, flink, operator)
 - **cfk-operator** (wave 105) - Confluent for Kubernetes (CFK) operator
-- **workload-ingresses** (wave 110) - Traefik IngressRoutes (CMF, Control Center, Schema Registry)
+- **workload-ingresses** (wave 110) - Traefik IngressRoutes for workload UIs
 - **flink-kubernetes-operator** (wave 116) - Flink Kubernetes Operator for stream processing
 - **observability-resources** (wave 117) - PodMonitors and Grafana dashboards
 - **cmf-operator** (wave 118) - Confluent Manager for Apache Flink (CMF)

--- a/clusters/eks-demo/README.md
+++ b/clusters/eks-demo/README.md
@@ -273,8 +273,9 @@ Defined in `clusters/eks-demo/infrastructure/kustomization.yaml`:
 - **trust-manager** (wave 30) - CA certificate distribution
 - **external-secrets** (wave 30) - External Secrets Operator for syncing secrets from external providers
 - **reflector** (wave 40) - Secret/ConfigMap replication across namespaces
+- **headlamp** (wave 50) - Kubernetes dashboard
 - **cert-manager-resources** (wave 75) - ClusterIssuers for Let's Encrypt staging and production
-- **infra-ingresses** (wave 80) - Traefik IngressRoute for ArgoCD UI
+- **infra-ingresses** (wave 80) - Traefik IngressRoutes for ArgoCD and Headlamp UIs
 - **minio** (wave 85) - Object storage for Flink checkpoints and savepoints
 - **argocd-config** (wave 85) - ArgoCD ConfigMap patches for custom health checks
 

--- a/clusters/flink-demo-rbac-mtls/README.md
+++ b/clusters/flink-demo-rbac-mtls/README.md
@@ -164,7 +164,7 @@ Workload applications are defined in `workloads/kustomization.yaml`:
 - **cfk-operator** (wave 105) - Confluent for Kubernetes operator
 - **mds-keygen** (wave 106) - MDS token keypair generation
 - **confluent-resources** (wave 110) - Confluent Platform (KRaft, Kafka, Schema Registry, MDS, etc.) — **manual sync**
-- **workload-ingresses** (wave 110) - Traefik IngressRoutes for CMF, Control Center, Schema Registry, and MDS UIs
+- **workload-ingresses** (wave 110) - Traefik IngressRoutes for workload UIs
 - **flink-kubernetes-operator** (wave 116) - Flink Kubernetes Operator
 - **observability-resources** (wave 117) - PodMonitors and Grafana dashboards
 - **cmf-operator-secrets** (wave 117) - CMF operator secret configuration

--- a/clusters/flink-demo-rbac-mtls/README.md
+++ b/clusters/flink-demo-rbac-mtls/README.md
@@ -149,8 +149,9 @@ Infrastructure applications are defined in `infrastructure/kustomization.yaml`:
 - **kube-prometheus-stack** (wave 20) - Monitoring stack (Prometheus, Grafana, Alertmanager)
 - **trust-manager** (wave 30) - CA certificate distribution
 - **reflector** (wave 40) - Secret/ConfigMap replication across namespaces
+- **headlamp** (wave 50) - Kubernetes dashboard
 - **cert-manager-resources** (wave 75) - ClusterIssuer and certificates
-- **argocd-ingress** (wave 80) - Traefik IngressRoute for ArgoCD UI
+- **infra-ingresses** (wave 80) - Traefik IngressRoutes for ArgoCD and Headlamp UIs
 - **argocd-config** (wave 85) - ArgoCD ConfigMap patches for custom health checks
 - **minio** (wave 85) - S3-compatible object storage (namespace: storage)
 
@@ -163,7 +164,7 @@ Workload applications are defined in `workloads/kustomization.yaml`:
 - **cfk-operator** (wave 105) - Confluent for Kubernetes operator
 - **mds-keygen** (wave 106) - MDS token keypair generation
 - **confluent-resources** (wave 110) - Confluent Platform (KRaft, Kafka, Schema Registry, MDS, etc.) — **manual sync**
-- **ingresses** (wave 110) - Traefik IngressRoutes for all services
+- **workload-ingresses** (wave 110) - Traefik IngressRoutes for CMF, Control Center, Schema Registry, and MDS UIs
 - **flink-kubernetes-operator** (wave 116) - Flink Kubernetes Operator
 - **observability-resources** (wave 117) - PodMonitors and Grafana dashboards
 - **cmf-operator-secrets** (wave 117) - CMF operator secret configuration

--- a/clusters/flink-demo-rbac/README.md
+++ b/clusters/flink-demo-rbac/README.md
@@ -116,8 +116,9 @@ Infrastructure applications are defined in `infrastructure/kustomization.yaml`:
 - **kube-prometheus-stack** (wave 20) - Monitoring stack (Prometheus, Grafana, Alertmanager)
 - **trust-manager** (wave 30) - CA certificate distribution
 - **reflector** (wave 40) - Secret/ConfigMap replication across namespaces
+- **headlamp** (wave 50) - Kubernetes dashboard
 - **cert-manager-resources** (wave 75) - ClusterIssuer and certificates
-- **argocd-ingress** (wave 80) - Traefik IngressRoute for ArgoCD UI
+- **infra-ingresses** (wave 80) - Traefik IngressRoutes for ArgoCD and Headlamp UIs
 - **argocd-config** (wave 85) - ArgoCD ConfigMap patches for custom health checks
 - **minio** (wave 85) - S3-compatible object storage (namespace: storage)
 
@@ -130,7 +131,7 @@ Workload applications are defined in `workloads/kustomization.yaml`:
 - **cfk-operator** (wave 105) - Confluent for Kubernetes operator
 - **mds-keygen** (wave 106) - MDS token keypair generation
 - **confluent-resources** (wave 110) - Confluent Platform (KRaft, Kafka, Schema Registry, MDS, etc.) — **manual sync**
-- **ingresses** (wave 110) - Traefik IngressRoutes for all services
+- **workload-ingresses** (wave 110) - Traefik IngressRoutes for CMF, Control Center, Schema Registry, and MDS UIs
 - **flink-kubernetes-operator** (wave 116) - Flink Kubernetes Operator
 - **observability-resources** (wave 117) - PodMonitors and Grafana dashboards
 - **cmf-operator-secrets** (wave 117) - CMF operator secret configuration

--- a/clusters/flink-demo-rbac/README.md
+++ b/clusters/flink-demo-rbac/README.md
@@ -131,7 +131,7 @@ Workload applications are defined in `workloads/kustomization.yaml`:
 - **cfk-operator** (wave 105) - Confluent for Kubernetes operator
 - **mds-keygen** (wave 106) - MDS token keypair generation
 - **confluent-resources** (wave 110) - Confluent Platform (KRaft, Kafka, Schema Registry, MDS, etc.) — **manual sync**
-- **workload-ingresses** (wave 110) - Traefik IngressRoutes for CMF, Control Center, Schema Registry, and MDS UIs
+- **workload-ingresses** (wave 110) - Traefik IngressRoutes for workload UIs
 - **flink-kubernetes-operator** (wave 116) - Flink Kubernetes Operator
 - **observability-resources** (wave 117) - PodMonitors and Grafana dashboards
 - **cmf-operator-secrets** (wave 117) - CMF operator secret configuration

--- a/clusters/flink-demo/README.md
+++ b/clusters/flink-demo/README.md
@@ -124,10 +124,10 @@ Infrastructure applications are defined in `infrastructure/kustomization.yaml`:
 - **trust-manager** (wave 30) - CA certificate distribution
 - **reflector** (wave 40) - Cross-namespace secret replication for minio-credentials
 - **vault** (wave 40) - HashiCorp Vault (dev mode)
-- **vault-ingress** (wave 45) - Traefik IngressRoute for Vault UI
 - **vault-config** (wave 50) - Vault transit engine configuration
+- **headlamp** (wave 50) - Kubernetes dashboard
 - **cert-manager-resources** (wave 75) - ClusterIssuer and certificates
-- **argocd-ingress** (wave 80) - Traefik IngressRoute for ArgoCD UI
+- **infra-ingresses** (wave 80) - Traefik IngressRoutes for ArgoCD, Vault, and Headlamp UIs
 - **minio** (wave 85) - S3-compatible object storage for Flink checkpoints and savepoints
 - **argocd-config** (wave 85) - ArgoCD ConfigMap patches for custom health checks
 - **registry** (wave 85) - In-cluster image registry at pinned ClusterIP `10.96.0.50:5000`

--- a/clusters/flink-demo/README.md
+++ b/clusters/flink-demo/README.md
@@ -139,7 +139,7 @@ Workload applications are defined in `workloads/kustomization.yaml`:
 
 - **namespaces** (wave 100) - Namespace definitions (kafka, flink, operator)
 - **cfk-operator** (wave 105) - Confluent for Kubernetes operator
-- **workload-ingresses** (wave 110) - Traefik IngressRoutes (CMF, Control Center, Schema Registry)
+- **workload-ingresses** (wave 110) - Traefik IngressRoutes for workload UIs
 - **confluent-resources** (wave 110) - Confluent Platform (KRaft, Kafka, Schema Registry, etc.) — **manual sync**
 - **flink-kubernetes-operator** (wave 116) - Flink Kubernetes Operator
 - **observability-resources** (wave 117) - PodMonitors and Grafana dashboards

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -67,7 +67,7 @@ Platform infrastructure components deployed before workloads.
 **Deployed workloads:**
 - **cfk-operator** (wave 105) - Confluent for Kubernetes (CFK) operator for managing Confluent Platform
 - **confluent-resources** (wave 110) - Confluent Platform resources (KRaft, Kafka, Schema Registry, Control Center)
-- **workload-ingresses** (wave 110) - Traefik IngressRoutes for CMF, Confluent Control Center, and Schema Registry UI access
+- **workload-ingresses** (wave 110) - Traefik IngressRoutes for workload UIs
 - **flink-kubernetes-operator** (wave 116) - Flink Kubernetes Operator for managing Flink deployments
 - **cmf-operator** (wave 118) - Confluent Manager for Apache Flink (CMF) for central Flink management
 - **flink-resources** (see [Sync Waves](#sync-waves) for the exact per-cluster wave) - Flink integration resources (CMFRestClass, single `default` FlinkEnvironment, generic Flink SQL demo) for Kafka integration, deployed on all four clusters
@@ -135,7 +135,6 @@ Bootstrap Application (sync-wave 0)
 │   │   └── Watches: clusters/<cluster>/infrastructure/
 │   │       ├── kube-prometheus-stack-crds (sync-wave 2)
 │   │       ├── traefik (sync-wave 10)
-│   │       ├── longhorn (sync-wave 15)
 │   │       ├── kube-prometheus-stack (sync-wave 20)
 │   │       ├── cert-manager (sync-wave 20)
 │   │       ├── trust-manager (sync-wave 30)
@@ -154,7 +153,6 @@ Bootstrap Application (sync-wave 0)
 │           ├── cmf-operator (sync-wave 118)
 │           ├── flink-resources (sync-wave — see Sync Waves table)
 │           ├── colors-and-shapes (sync-wave — see Sync Waves table)
-│           ├── http-echo (sync-wave 105)
 │           └── (future workload applications)
 ```
 
@@ -295,7 +293,6 @@ Applications deploy in waves using `argocd.argoproj.io/sync-wave` annotations:
 | 1 | infrastructure (parent) | Infrastructure App of Apps |
 | 2 | kube-prometheus-stack-crds | Prometheus Operator CRDs for early availability |
 | 10 | traefik | Ingress controller for external access |
-| 15 | longhorn | Distributed block storage for persistent volumes |
 | 20 | kube-prometheus-stack | Monitoring stack (Prometheus, Grafana, Alertmanager) |
 | 20 | cert-manager | TLS certificate management |
 | 30 | trust-manager | Automatic distribution of CA certificate trust bundles |
@@ -310,7 +307,7 @@ Applications deploy in waves using `argocd.argoproj.io/sync-wave` annotations:
 | 100 | workloads (parent) | Workloads App of Apps |
 | 105 | cfk-operator | Confluent for Kubernetes operator (CRDs and webhooks) |
 | 110 | confluent-resources | Confluent Platform resources (KRaft, Kafka, Schema Registry, Control Center, Schema Registry IngressRoute) |
-| 110 | workload-ingresses | Traefik IngressRoutes for CMF, Confluent Control Center, and Schema Registry UI access |
+| 110 | workload-ingresses | Traefik IngressRoutes for workload UIs |
 | 116 | flink-kubernetes-operator | Flink Kubernetes Operator (manages Flink deployments and jobs) |
 | 118 | cmf-operator | Confluent Manager for Apache Flink (central management interface) |
 | 119/120 | flink-resources | Flink integration resources (CMFRestClass, single `default` FlinkEnvironment, generic Flink SQL demo) for Kafka integration; deployed on all four clusters — wave 119 on the three RBAC clusters (ahead of colors-and-shapes), wave 120 on flink-demo |
@@ -466,12 +463,12 @@ Examples:
 
 - Use lowercase hyphenated names
 - Match the directory name in `workloads/` or `infrastructure/`
-- Example: `http-echo`, `kube-prometheus-stack`
+- Example: `confluent-resources`, `kube-prometheus-stack`
 
 ### Namespace Names
 
 - Generally match the application name
-- Infrastructure components may use standard names (e.g., `longhorn-system`, `monitoring`)
+- Infrastructure components may use standard names (e.g., `monitoring`, `reflector-system`)
 
 ## Tool Choices
 
@@ -480,7 +477,7 @@ Examples:
 Used for:
 - Simple applications with minimal customization
 - Applications without upstream Helm charts
-- Example: http-echo
+- Example: `confluent-resources`, `flink-resources`
 
 **Pros**: Simple, no templating, GitOps-friendly
 **Cons**: Limited logic, verbose for complex apps

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -58,18 +58,16 @@ Platform infrastructure components deployed before workloads.
 - **cert-manager** (wave 20) - TLS certificate management
 - **trust-manager** (wave 30) - Automatic distribution of CA certificate trust bundles across namespaces
 - **vault** (wave 40) - HashiCorp Vault for secrets management and encryption services
-- **vault-ingress** (wave 45) - Traefik IngressRoute for Vault UI access
 - **vault-config** (wave 50) - Post-deployment Job to configure transit encryption engine
 - **headlamp** (wave 50) - Kubernetes dashboard (chart `0.43.0`), namespace `headlamp`, cluster-admin SA; token-based login on all clusters
-- **headlamp-ingress** (wave 80) - Traefik IngressRoute + cert-manager Certificate for Headlamp UI access
 - **cert-manager-resources** (wave 75) - Self-signed ClusterIssuer and certificate resources
-- **argocd-ingress** (wave 80) - Traefik IngressRoute for ArgoCD UI access
+- **infra-ingresses** (wave 80) - Traefik IngressRoutes + cert-manager Certificates for ArgoCD, Vault, and Headlamp UI access
 - **argocd-config** (wave 85) - ArgoCD ConfigMap patches for custom health checks and configuration
 
 **Deployed workloads:**
 - **cfk-operator** (wave 105) - Confluent for Kubernetes (CFK) operator for managing Confluent Platform
 - **confluent-resources** (wave 110) - Confluent Platform resources (KRaft, Kafka, Schema Registry, Control Center)
-- **controlcenter-ingress** (wave 115) - Traefik IngressRoute for Confluent Control Center UI access
+- **workload-ingresses** (wave 110) - Traefik IngressRoutes for CMF, Confluent Control Center, and Schema Registry UI access
 - **flink-kubernetes-operator** (wave 116) - Flink Kubernetes Operator for managing Flink deployments
 - **cmf-operator** (wave 118) - Confluent Manager for Apache Flink (CMF) for central Flink management
 - **flink-resources** (see [Sync Waves](#sync-waves) for the exact per-cluster wave) - Flink integration resources (CMFRestClass, single `default` FlinkEnvironment, generic Flink SQL demo) for Kafka integration, deployed on all four clusters
@@ -142,16 +140,16 @@ Bootstrap Application (sync-wave 0)
 │   │       ├── cert-manager (sync-wave 20)
 │   │       ├── trust-manager (sync-wave 30)
 │   │       ├── vault (sync-wave 40)
-│   │       ├── vault-ingress (sync-wave 45)
 │   │       ├── vault-config (sync-wave 50)
+│   │       ├── headlamp (sync-wave 50)
 │   │       ├── cert-manager-resources (sync-wave 75)
-│   │       ├── argocd-ingress (sync-wave 80)
+│   │       ├── infra-ingresses (sync-wave 80)
 │   │       └── argocd-config (sync-wave 85)
 │   └── workloads (Parent Application, sync-wave 100)
 │       └── Watches: clusters/<cluster>/workloads/
 │           ├── cfk-operator (sync-wave 105)
 │           ├── confluent-resources (sync-wave 110)
-│           ├── controlcenter-ingress (sync-wave 115)
+│           ├── workload-ingresses (sync-wave 110)
 │           ├── flink-kubernetes-operator (sync-wave 116)
 │           ├── cmf-operator (sync-wave 118)
 │           ├── flink-resources (sync-wave — see Sync Waves table)
@@ -302,19 +300,17 @@ Applications deploy in waves using `argocd.argoproj.io/sync-wave` annotations:
 | 20 | cert-manager | TLS certificate management |
 | 30 | trust-manager | Automatic distribution of CA certificate trust bundles |
 | 40 | vault | HashiCorp Vault for secrets management and encryption |
-| 45 | vault-ingress | Traefik IngressRoute for Vault UI access |
 | 50 | vault-config | Post-deployment Job to configure transit encryption engine |
 | 50 | headlamp | Kubernetes dashboard (Helm chart 0.43.0), cluster-admin SA, namespace `headlamp` |
 | 75 | cert-manager-resources | Self-signed ClusterIssuer and certificate resources |
-| 80 | argocd-ingress | Traefik IngressRoute for ArgoCD UI access |
-| 80 | headlamp-ingress | Traefik IngressRoute + cert-manager Certificate for Headlamp UI |
+| 80 | infra-ingresses | Traefik IngressRoutes + cert-manager Certificates for ArgoCD, Vault, and Headlamp UI access |
 | 85 | argocd-config | ArgoCD ConfigMap patches for custom health checks |
 | 85 | registry | In-cluster OCI image registry at a pinned ClusterIP (kind clusters) |
 | 86 | registry-hosts | PostSync Job writing per-node containerd `hosts.toml` for the in-cluster registry |
 | 100 | workloads (parent) | Workloads App of Apps |
 | 105 | cfk-operator | Confluent for Kubernetes operator (CRDs and webhooks) |
 | 110 | confluent-resources | Confluent Platform resources (KRaft, Kafka, Schema Registry, Control Center, Schema Registry IngressRoute) |
-| 115 | controlcenter-ingress | Traefik IngressRoute for Confluent Control Center UI access |
+| 110 | workload-ingresses | Traefik IngressRoutes for CMF, Confluent Control Center, and Schema Registry UI access |
 | 116 | flink-kubernetes-operator | Flink Kubernetes Operator (manages Flink deployments and jobs) |
 | 118 | cmf-operator | Confluent Manager for Apache Flink (central management interface) |
 | 119/120 | flink-resources | Flink integration resources (CMFRestClass, single `default` FlinkEnvironment, generic Flink SQL demo) for Kafka integration; deployed on all four clusters — wave 119 on the three RBAC clusters (ahead of colors-and-shapes), wave 120 on flink-demo |
@@ -644,7 +640,7 @@ kubectl logs -n argocd -l app.kubernetes.io/name=argocd-application-controller
 - Audit trail for all changes
 
 **Current Access:**
-- ArgoCD UI accessible via argocd-ingress Application (Traefik IngressRoute)
+- ArgoCD UI accessible via the infra-ingresses Application (Traefik IngressRoute)
 - Hostname pattern: `argocd.<cluster>.<domain>` (e.g., argocd.flink-demo.confluentdemo.local)
 - TLS certificates managed by cert-manager
 


### PR DESCRIPTION
## What

Root `README.md`, `docs/architecture.md`, and all four cluster READMEs described several per-service Traefik ingress Applications that don't exist as separate manifests: `controlcenter-ingress` (wave 115), `vault-ingress` (45), `argocd-ingress` (80), `headlamp-ingress` (80).

## Ground truth (verified against every cluster's manifests)

Two consolidated Applications actually exist, on all four clusters:

- **`infra-ingresses`** (wave 80) — ArgoCD + Vault + Headlamp Traefik IngressRoutes/Certificates (`infrastructure/ingresses/overlays/<cluster>/`). Vault only applies on `flink-demo` (the only cluster that runs Vault).
- **`workload-ingresses`** (wave 110) — CMF + Control Center + Schema Registry (+ MDS on the three RBAC clusters) IngressRoutes/Certificates (`workloads/ingresses/overlays/<cluster>/`).

`flink-demo-rbac` and `flink-demo-rbac-mtls` additionally had the workload-side app named plain `ingresses` in their own READMEs instead of its real name `workload-ingresses`.

## Also fixed

- Added the `headlamp` Application itself (wave 50 — the dashboard workload) to every cluster README's Infrastructure Applications list. It's deployed on all four clusters but was missing from every one of these lists, even though `architecture.md` already documented it correctly.
- **Normalized `workload-ingresses`'s description to one generic phrase everywhere** ("Traefik IngressRoutes for workload UIs", matching `eks-demo`'s existing wording) instead of enumerating the specific UIs it fronts. The enumerated form needed an edit in every doc every time a new workload UI's ingress was added to that app; the generic phrasing doesn't.
- **Removed all remaining mentions of `longhorn` and `http-echo`** from `docs/architecture.md` (Application Hierarchy tree, Sync Waves table, and the Naming Conventions/Tool Choices illustrative examples) — neither exists in any cluster's actual manifests. Replaced the illustrative examples with real Kustomize-based apps (`confluent-resources`, `flink-resources`) and a real standard-named namespace (`reflector-system`) so the convention is still demonstrated with something actually deployed.

## Verified clean

```
grep -rln "controlcenter-ingress\|vault-ingress\|argocd-ingress\|headlamp-ingress\|longhorn\|http-echo" --include=*.md .
```
returns nothing anywhere in the repo after this change.

Closes #372

🤖 Generated with [Claude Code](https://claude.com/claude-code)